### PR TITLE
Support highlighting file numbers

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormSearchResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormSearchResponseMapper.java
@@ -1,7 +1,5 @@
 package de.bund.digitalservice.ris.search.mapper;
 
-import static java.util.Map.entry;
-
 import de.bund.digitalservice.ris.search.config.ApiConfig;
 import de.bund.digitalservice.ris.search.models.opensearch.Article;
 import de.bund.digitalservice.ris.search.models.opensearch.Norm;
@@ -14,6 +12,7 @@ import de.bund.digitalservice.ris.search.schema.PublicationIssueSchema;
 import de.bund.digitalservice.ris.search.schema.SearchMemberSchema;
 import de.bund.digitalservice.ris.search.schema.TextMatchSchema;
 import de.bund.digitalservice.ris.search.utils.DateUtils;
+import de.bund.digitalservice.ris.search.utils.PageUtils;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -96,10 +95,9 @@ public class NormSearchResponseMapper {
   }
 
   private static String getTextMatchName(String key) {
-    Map<String, String> normHighlightFieldNameTranslations =
-        Map.ofEntries(entry("officialTitle", "name"));
-
-    return Optional.ofNullable(normHighlightFieldNameTranslations.get(key)).orElse(key);
+    String converted = PageUtils.snakeCaseToCamelCase(key);
+    if (converted.equals("officialTitle")) return "name";
+    return converted;
   }
 
   private static LegislationWorkSearchSchema fromDomain(Norm norm) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/CaseLawDocumentationUnit.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/CaseLawDocumentationUnit.java
@@ -79,6 +79,7 @@ public record CaseLawDocumentationUnit(
     public static final String TENOR = "tenor";
     public static final String DECISION_DATE = "decision_date";
     public static final String FILE_NUMBERS = "file_numbers";
+    public static final String FILE_NUMBERS_TEXT = "file_numbers.text";
 
     /** Field holding the type of court, e.g., FG, BVerwG */
     public static final String COURT_TYPE = "court_type";

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/PageUtils.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/PageUtils.java
@@ -5,9 +5,7 @@ import de.bund.digitalservice.ris.search.models.opensearch.AbstractSearchEntity;
 import de.bund.digitalservice.ris.search.models.opensearch.CaseLawDocumentationUnit;
 import de.bund.digitalservice.ris.search.models.opensearch.Norm;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.SearchHit;
@@ -79,7 +77,7 @@ public class PageUtils {
         // For mixed search hits, the keys of the highlightFields Map must be converted manually.
         // If a single index is queried, the names are converted automatically by {@link
         // ElasticsearchOperations}.
-        convertSnakeCaseKeysToCamelCase(searchHit.getHighlightFields()),
+        searchHit.getHighlightFields(),
         searchHit.getInnerHits(),
         searchHit.getNestedMetaData(),
         searchHit.getExplanation(),
@@ -89,14 +87,8 @@ public class PageUtils {
 
   public static final Pattern SNAKE_CASE_PATTERN = Pattern.compile("_([a-z])");
 
-  private static String snakeCaseToCamelCase(String str) {
+  public static String snakeCaseToCamelCase(String str) {
+    if (!str.contains("_")) return str;
     return SNAKE_CASE_PATTERN.matcher(str).replaceAll(m -> m.group(1).toUpperCase());
-  }
-
-  public static <T> Map<String, T> convertSnakeCaseKeysToCamelCase(Map<String, T> map) {
-    // Convert the key from snake_case to camelCase
-    // Add a new entry with the converted key and original value to the newMap
-    return map.entrySet().stream()
-        .collect(Collectors.toMap(e -> snakeCaseToCamelCase(e.getKey()), Map.Entry::getValue));
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/RisHighlightBuilder.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/RisHighlightBuilder.java
@@ -66,6 +66,12 @@ public final class RisHighlightBuilder {
   private static HighlightBuilder addCaseLawFields(HighlightBuilder builder) {
     CASE_LAW_HIGHLIGHT_CONTENT_FIELDS.forEach(builder::field);
     builder.field(getFieldBasic(CaseLawDocumentationUnit.Fields.ECLI));
+    /*
+     * Note that this uses the .text variant of file_numbers
+     * */
+    builder.field(
+        getFieldBasic(CaseLawDocumentationUnit.Fields.FILE_NUMBERS_TEXT)
+            .numOfFragments(5) /* Support highlighting multiple (partial) file numbers */);
     return builder;
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/AllDocumentsSearchControllerAPITest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/AllDocumentsSearchControllerAPITest.java
@@ -1,9 +1,12 @@
 package de.bund.digitalservice.ris.search.integration.controller.api;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -69,13 +72,47 @@ class AllDocumentsSearchControllerAPITest extends ContainersIntegrationBase {
   }
 
   @Test
-  @DisplayName("Should return correct result for term search")
+  @DisplayName("Should return correct result for term search, with textMatches")
   void shouldReturnCorrectResultForFilterSearch() throws Exception {
     String query = "?searchTerm=Test";
 
     mockMvc
         .perform(get(ApiConfig.Paths.DOCUMENT + query).contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.member", hasSize(4)));
+        .andExpectAll(
+            status().isOk(),
+            jsonPath("$.member", hasSize(4)),
+            jsonPath(
+                "$.member[*].textMatches[*].name",
+                everyItem(
+                    either(
+                            oneOf(
+                                "name",
+                                "headnote",
+                                "otherHeadnote",
+                                "caseFacts",
+                                "headline",
+                                "outline",
+                                "longText",
+                                "otherLongText",
+                                "dissentingOpinion",
+                                "decisionGrounds",
+                                "fileNumbers"))
+                        .or(matchesRegex("§ \\d .+")))));
+  }
+
+  @Test
+  @DisplayName("Should correctly highlight case law file numbers")
+  void shouldReturnTextMatchForFileNumber() throws Exception {
+    String fileNumber = CaseLawTestData.allDocuments.getFirst().fileNumbers().getFirst();
+    String query = "?searchTerm=" + fileNumber;
+
+    mockMvc
+        .perform(get(ApiConfig.Paths.DOCUMENT + query).contentType(MediaType.APPLICATION_JSON))
+        .andExpectAll(
+            status().isOk(),
+            jsonPath(
+                "$.member[0].textMatches[?(@.name == 'fileNumbers')].text",
+                contains("<mark>IX</mark> <mark>ZR</mark> <mark>100</mark>/<mark>10</mark>")));
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/utils/PageUtilsTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/utils/PageUtilsTest.java
@@ -1,6 +1,6 @@
 package de.bund.digitalservice.ris.search.unit.utils;
 
-import static de.bund.digitalservice.ris.search.utils.PageUtils.convertSnakeCaseKeysToCamelCase;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -17,10 +17,12 @@ class PageUtilsTest {
 
   @Test
   void testConvertSnakeCaseKeysToCamelCase() {
-    var input = Map.of("UPPERCASE", "uc", "camelCase", "cc", "snake_case", "sc");
-    var expectedOutput = Map.of("UPPERCASE", "uc", "camelCase", "cc", "snakeCase", "sc");
+    var expectations =
+        Map.of("UPPERCASE", "UPPERCASE", "camelCase", "camelCase", "snake_case", "snakeCase");
 
-    assertEquals(expectedOutput, convertSnakeCaseKeysToCamelCase(input));
+    for (var entry : expectations.entrySet()) {
+      assertThat(PageUtils.snakeCaseToCamelCase(entry.getKey())).isEqualTo(entry.getValue());
+    }
   }
 
   @Test

--- a/frontend/src/components/Search/Result/Caselaw/CaseLawSearchResult.unit.spec.ts
+++ b/frontend/src/components/Search/Result/Caselaw/CaseLawSearchResult.unit.spec.ts
@@ -24,7 +24,7 @@ const searchResult: SearchResult<CaseLaw> = {
     decisionGrounds: "Decision Grounds",
     courtName: "Test Court",
     decisionDate: "2023-01-01",
-    fileNumbers: ["123", "456"],
+    fileNumbers: ["123", "testing highlighted file number is here"],
     decisionName: ["Decision Name"],
     documentType: "Document Type",
   },
@@ -40,6 +40,54 @@ describe("CaselawSearchResult.vue", () => {
       },
     });
     expect(wrapper.get("a").text()).toBe("Decision Name — Test Headline");
+  });
+
+  it(`displays highlighted headline`, async () => {
+    const textMatch: TextMatch = {
+      "@type": "SearchResultMatch",
+      name: "headline",
+      text: `testing <mark>highlighted headline</mark> is here`,
+      location: null,
+    };
+    const caseLawSearchResult: SearchResult<CaseLaw> = {
+      item: searchResult.item,
+      textMatches: [textMatch],
+    };
+    const wrapper = await mountSuspended(CaselawRecord, {
+      props: { searchResult: caseLawSearchResult, order: 0 },
+      stubs: {
+        RouterLink: RouterLinkStub,
+      },
+    });
+    const highlightedElements = wrapper.findAll("mark");
+    expect(highlightedElements).length(1);
+    expect(highlightedElements[0].text()).toBe(`highlighted headline`);
+  });
+
+  it("displays highlighted file numbers", async () => {
+    const textMatch: TextMatch = {
+      "@type": "SearchResultMatch",
+      name: "fileNumbers",
+      text: `testing <mark>highlighted file number</mark> is here`,
+      location: null,
+    };
+    const caseLawSearchResult: SearchResult<CaseLaw> = {
+      item: searchResult.item,
+      textMatches: [textMatch],
+    };
+    const wrapper = await mountSuspended(CaselawRecord, {
+      props: { searchResult: caseLawSearchResult, order: 0 },
+      stubs: {
+        RouterLink: RouterLinkStub,
+      },
+    });
+    const highlightedElements = wrapper.findAll("mark");
+    expect(highlightedElements).length(1);
+    expect(highlightedElements[0].text()).toBe(`highlighted file number`);
+
+    expect(wrapper.get("[aria-label='Aktenzeichen']").html()).toBe(
+      `<span aria-label="Aktenzeichen">123, testing <mark>highlighted file number</mark> is here</span>`,
+    );
   });
 
   it("displays highlighted text with correct class", async () => {

--- a/frontend/src/components/Search/Result/Caselaw/CaselawSearchResult.vue
+++ b/frontend/src/components/Search/Result/Caselaw/CaselawSearchResult.vue
@@ -27,6 +27,12 @@ function getMatch(match: string, matches: TextMatch[]) {
   return matches.find((highlight) => highlight.name === match)?.text;
 }
 
+function getMatches(match: string, matches: TextMatch[]) {
+  return matches
+    .filter((highlight) => highlight.name === match)
+    .map((highlight) => highlight.text);
+}
+
 type Key =
   | "guidingPrinciple"
   | "headnote"
@@ -63,6 +69,22 @@ const fields: Map<Key, FieldDisplayProperties> = new Map([
   ],
 ]);
 
+function getFileNumbers(item: CaseLaw) {
+  const matches = getMatches("fileNumbers", props.searchResult.textMatches);
+  if (matches.length) {
+    const replaced = [...item.fileNumbers];
+    matches.forEach((match) => {
+      const stripped = sanitizeSearchResult(match, []);
+      const index = item.fileNumbers.indexOf(stripped);
+      if (index !== -1) {
+        replaced[index] = match;
+      }
+    });
+    return replaced.join(", ");
+  }
+  return item.fileNumbers?.join(", ");
+}
+
 const metadata = computed(() => {
   const item = props.searchResult.item;
   return {
@@ -73,7 +95,7 @@ const metadata = computed(() => {
     url: `/case-law/${props.searchResult.item.documentNumber}`,
     courtName: item.courtName,
     decisionDate: formattedDate(item.decisionDate),
-    fileNumbers: item.fileNumbers?.join(", "),
+    fileNumbers: getFileNumbers(item),
     decisionName: item.decisionName?.at(0),
     documentType: item.documentType || "Entscheidung",
   } as CaseLawMetadata;
@@ -132,7 +154,7 @@ function openResult(url: string) {
         ><span class="sr-only">Entscheidungsdatum </span
         >{{ metadata.decisionDate }}</span
       >
-      <span aria-label="Aktenzeichen">{{ metadata.fileNumbers }}</span>
+      <span aria-label="Aktenzeichen" v-html="metadata.fileNumbers" />
     </div>
     <NuxtLink
       :to="metadata.url"

--- a/frontend/src/utils/sanitize.ts
+++ b/frontend/src/utils/sanitize.ts
@@ -2,7 +2,10 @@ import DOMPurify from "dompurify";
 
 let purify: typeof DOMPurify;
 
-export function sanitizeSearchResult(html: string) {
+export function sanitizeSearchResult(
+  html: string,
+  allowedTags: string[] | undefined = ["b", "i", "mark"],
+) {
   if (!purify) {
     if (import.meta.server) {
       const { JSDOM } = require("jsdom");
@@ -13,5 +16,5 @@ export function sanitizeSearchResult(html: string) {
       purify = DOMPurify;
     }
   }
-  return purify.sanitize(html, { ALLOWED_TAGS: ["b", "i", "mark"] });
+  return purify.sanitize(html, { ALLOWED_TAGS: allowedTags });
 }


### PR DESCRIPTION
This PR adds support for highlighting of file numbers in case law search results.

In order to simplify the logic, the textMatch key conversion (from snake_case to camelCase, dropping `.text` suffix where used) is now done in all cases, not just in the AllDocumentsSearchController.

Test cases have been added. In the edge case that a file number is input without any whitespace or special characters, the highlighting is not expected.