### PR TITLE
Change ObjectStorage method naming, exceptions

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/CaseLawController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/CaseLawController.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.search.controller.api;
 
 import de.bund.digitalservice.ris.search.config.ApiConfig;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.mapper.CaseLawSchemaMapper;
 import de.bund.digitalservice.ris.search.models.opensearch.CaseLawDocumentationUnit;
 import de.bund.digitalservice.ris.search.repository.objectstorage.CaseLawBucket;
@@ -71,7 +72,8 @@ public class CaseLawController {
   @ApiResponse(responseCode = "200")
   @ApiResponse(responseCode = "404", content = @Content)
   public ResponseEntity<String> getCaseLawDocumentationUnitAsHtml(
-      @Parameter(example = "STRE201770751") @PathVariable String documentNumber) {
+      @Parameter(example = "STRE201770751") @PathVariable String documentNumber)
+      throws ObjectStoreServiceException {
     Optional<byte[]> bytes = caseLawBucket.get(String.format("%s.xml", documentNumber));
 
     if (bytes.isPresent()) {
@@ -92,7 +94,8 @@ public class CaseLawController {
   @ApiResponse(responseCode = "200")
   @ApiResponse(responseCode = "404", content = @Content(schema = @Schema()))
   public ResponseEntity<byte[]> getCaseLawDocumentationUnitAsXml(
-      @Parameter(example = "STRE201770751") @PathVariable String documentNumber) {
+      @Parameter(example = "STRE201770751") @PathVariable String documentNumber)
+      throws ObjectStoreServiceException {
 
     Optional<byte[]> bytes = caseLawBucket.get(String.format("%s.xml", documentNumber));
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ImporterController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ImporterController.java
@@ -2,7 +2,7 @@ package de.bund.digitalservice.ris.search.controller.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
 import de.bund.digitalservice.ris.search.service.ImportService;
 import de.bund.digitalservice.ris.search.service.IndexNormsService;
@@ -36,7 +36,7 @@ public class ImporterController {
       Changelog cl = new ObjectMapper().readValue(changelog, Changelog.class);
       normsImporter.importChangelogContent("apiRequest", cl, normsIndexer, Instant.now());
       return ResponseEntity.noContent().build();
-    } catch (JsonProcessingException | RetryableObjectStoreException e) {
+    } catch (JsonProcessingException | ObjectStoreServiceException e) {
       return ResponseEntity.badRequest().body(e.getMessage());
     }
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/NormsController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/NormsController.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 
 import de.bund.digitalservice.ris.search.config.ApiConfig;
 import de.bund.digitalservice.ris.search.exception.CustomValidationException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.mapper.MappingDefinitions;
 import de.bund.digitalservice.ris.search.mapper.NormResponseMapper;
 import de.bund.digitalservice.ris.search.mapper.NormSearchResponseMapper;
@@ -209,7 +210,8 @@ public class NormsController {
       @PathVariable @Schema(example = "2") Integer version,
       @PathVariable @Schema(example = "deu") String language,
       @PathVariable @Schema(example = "2020-06-19") LocalDate pointInTimeManifestation,
-      @Schema(example = "regelungstext-1") @PathVariable String subtype) {
+      @Schema(example = "regelungstext-1") @PathVariable String subtype)
+      throws ObjectStoreServiceException {
     var eli =
         new ManifestationEli(
             jurisdiction,
@@ -277,7 +279,8 @@ public class NormsController {
       @PathVariable @Schema(example = "2") Integer version,
       @PathVariable @Schema(example = "deu") String language,
       @PathVariable @Schema(example = "2020-06-19") LocalDate pointInTimeManifestation,
-      @Schema(example = "regelungstext-1") @PathVariable String subtype) {
+      @Schema(example = "regelungstext-1") @PathVariable String subtype)
+      throws ObjectStoreServiceException {
     var eli =
         new ManifestationEli(
             jurisdiction,
@@ -408,7 +411,8 @@ public class NormsController {
               example = "hauptteil-1_art-1")
           @PathVariable
           String articleEid,
-      @PathVariable @Schema(allowableValues = "html") String format) {
+      @PathVariable @Schema(allowableValues = "html") String format)
+      throws ObjectStoreServiceException {
     if (!Objects.equals(format, "html")) {
       return ResponseEntity.badRequest().body("only html is supported for format");
     }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/exception/NoSuchKeyException.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/exception/NoSuchKeyException.java
@@ -1,6 +1,6 @@
 package de.bund.digitalservice.ris.search.exception;
 
-public class NoSuchKeyException extends ObjectStoreServiceException {
+public class NoSuchKeyException extends Exception {
   public NoSuchKeyException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/exception/NoSuchKeyException.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/exception/NoSuchKeyException.java
@@ -1,0 +1,7 @@
+package de.bund.digitalservice.ris.search.exception;
+
+public class NoSuchKeyException extends ObjectStoreServiceException {
+  public NoSuchKeyException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/exception/ObjectStoreServiceException.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/exception/ObjectStoreServiceException.java
@@ -1,0 +1,8 @@
+package de.bund.digitalservice.ris.search.exception;
+
+public class ObjectStoreServiceException extends Exception {
+
+  public ObjectStoreServiceException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/exception/RetryableObjectStoreException.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/exception/RetryableObjectStoreException.java
@@ -1,8 +1,0 @@
-package de.bund.digitalservice.ris.search.exception;
-
-public class RetryableObjectStoreException extends Exception {
-
-  public RetryableObjectStoreException(String message, Throwable cause) {
-    super(message, cause);
-  }
-}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/importer/e2e/EndToEndImporter.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/importer/e2e/EndToEndImporter.java
@@ -1,6 +1,6 @@
 package de.bund.digitalservice.ris.search.importer.e2e;
 
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.service.IndexCaselawService;
 import de.bund.digitalservice.ris.search.service.IndexNormsService;
 import java.time.Instant;
@@ -34,7 +34,7 @@ public class EndToEndImporter {
 
   @Async
   @EventListener(value = ApplicationReadyEvent.class)
-  public void endToEndTrigger() throws RetryableObjectStoreException {
+  public void endToEndTrigger() throws ObjectStoreServiceException {
     logger.info("Import E2E caselaw data: started");
     indexCaselawService.reindexAll(Instant.now().toString());
     logger.info("Import E2E caselaw data: done");

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/LocalFilesystemObjectStorageClient.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/LocalFilesystemObjectStorageClient.java
@@ -1,5 +1,6 @@
 package de.bund.digitalservice.ris.search.repository.objectstorage;
 
+import de.bund.digitalservice.ris.search.exception.NoSuchKeyException;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -48,7 +49,7 @@ public class LocalFilesystemObjectStorageClient implements ObjectStorageClient {
   }
 
   @Override
-  public List<String> getAllFilenamesByPath(String prefix) {
+  public List<String> listKeysByPrefix(String prefix) {
     if (!prefix.isEmpty() && !prefix.endsWith("/")) {
       LOGGER.warn("Filtering by non-directory prefix is not supported, {}", prefix);
     }
@@ -66,9 +67,13 @@ public class LocalFilesystemObjectStorageClient implements ObjectStorageClient {
   }
 
   @Override
-  public FilterInputStream getStream(String objectKey) throws FileNotFoundException {
+  public FilterInputStream getStream(String objectKey) throws NoSuchKeyException {
     File file = localStorageDirectory.resolve(bucket).resolve(objectKey).toFile();
-    return new DataInputStream(new FileInputStream(file));
+    try {
+      return new DataInputStream(new FileInputStream(file));
+    } catch (FileNotFoundException e) {
+      throw new NoSuchKeyException(objectKey + " not found", e);
+    }
   }
 
   @Override

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectStorageClient.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectStorageClient.java
@@ -1,15 +1,15 @@
 package de.bund.digitalservice.ris.search.repository.objectstorage;
 
-import java.io.FileNotFoundException;
+import de.bund.digitalservice.ris.search.exception.NoSuchKeyException;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
 public interface ObjectStorageClient {
-  public List<String> getAllFilenamesByPath(String path);
+  public List<String> listKeysByPrefix(String path);
 
-  public FilterInputStream getStream(String objectKey) throws FileNotFoundException;
+  public FilterInputStream getStream(String objectKey) throws NoSuchKeyException;
 
   public void save(String fileName, String fileContent);
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/S3ObjectStorageClient.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/S3ObjectStorageClient.java
@@ -1,6 +1,6 @@
 package de.bund.digitalservice.ris.search.repository.objectstorage;
 
-import java.io.FileNotFoundException;
+import de.bund.digitalservice.ris.search.exception.NoSuchKeyException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -19,7 +19,6 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
-import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
@@ -36,7 +35,7 @@ public class S3ObjectStorageClient implements ObjectStorageClient {
   }
 
   @Override
-  public List<String> getAllFilenamesByPath(String path) {
+  public List<String> listKeysByPrefix(String path) {
     List<String> keys = new ArrayList<>();
     ListObjectsV2Response response;
     ListObjectsV2Request request =
@@ -58,12 +57,12 @@ public class S3ObjectStorageClient implements ObjectStorageClient {
 
   @Override
   public ResponseInputStream<GetObjectResponse> getStream(String objectKey)
-      throws FileNotFoundException {
+      throws NoSuchKeyException {
     GetObjectRequest request = GetObjectRequest.builder().bucket(bucketName).key(objectKey).build();
     try {
       return s3Client.getObject(request);
-    } catch (NoSuchKeyException e) {
-      throw new FileNotFoundException(e.getMessage());
+    } catch (software.amazon.awssdk.services.s3.model.NoSuchKeyException e) {
+      throw new NoSuchKeyException(e.getMessage(), e);
     }
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/ChangelogService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/ChangelogService.java
@@ -2,7 +2,7 @@ package de.bund.digitalservice.ris.search.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
 import de.bund.digitalservice.ris.search.repository.objectstorage.ObjectStorage;
 import java.time.Instant;
@@ -23,10 +23,10 @@ public class ChangelogService {
 
   public List<String> getNewChangelogsSinceInstant(
       ObjectStorage changelogBucket, Instant threshold) {
-    List<String> allChangelogFiles = changelogBucket.getAllFilenamesByPath(CHANGELOG);
+    List<String> allChangelogFiles = changelogBucket.getAllKeysByPrefix(CHANGELOG);
 
     List<String> result = new ArrayList<>();
-    // we need to foreach here to be able to throw the RetryableObjectStoreException
+    // we need a loop here to be able to throw the ObjectStoreServiceException
     for (String filename : allChangelogFiles) {
       if (!CHANGELOG.equals(filename) && changelogIsNewerThanThreshold(filename, threshold)) {
         result.add(filename);
@@ -37,7 +37,7 @@ public class ChangelogService {
   }
 
   public Changelog parseOneChangelog(ObjectStorage changelogBucket, String filename)
-      throws RetryableObjectStoreException {
+      throws ObjectStoreServiceException {
     Optional<String> changelogContent = changelogBucket.getFileAsString(filename);
     if (changelogContent.isEmpty()) {
       logger.error("Changelog file {} could not be fetched during import.", filename);

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/ImportService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/ImportService.java
@@ -1,6 +1,6 @@
 package de.bund.digitalservice.ris.search.service;
 
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
 import de.bund.digitalservice.ris.search.repository.objectstorage.ObjectStorage;
 import java.time.Instant;
@@ -59,7 +59,7 @@ public class ImportService {
           importChangelogs(indexService, changelogBucket, lastSuccess, lastSuccessFilename);
         }
         indexStatusService.unlockIndex(lockfile);
-      } catch (RetryableObjectStoreException e) {
+      } catch (ObjectStoreServiceException e) {
         logger.error("Import process failed due to a retryable error. Removing lock", e);
         indexStatusService.unlockIndex(lockfile);
       }
@@ -71,7 +71,7 @@ public class ImportService {
       ObjectStorage changelogBucket,
       Instant lastSuccess,
       String lastSuccessFilename)
-      throws RetryableObjectStoreException {
+      throws ObjectStoreServiceException {
     List<String> unprocessedChangelogs =
         changelogService.getNewChangelogsSinceInstant(changelogBucket, lastSuccess);
 
@@ -95,7 +95,7 @@ public class ImportService {
 
   public void importChangelogContent(
       String changelogKey, Changelog changelog, IndexService service, Instant startTime)
-      throws RetryableObjectStoreException {
+      throws ObjectStoreServiceException {
     if (changelog.isChangeAll()) {
       logger.info("Reindexing all");
       service.reindexAll(startTime.toString());
@@ -128,7 +128,7 @@ public class ImportService {
               numberOfIndexedDocuments);
         }
       }
-    } catch (RetryableObjectStoreException e) {
+    } catch (ObjectStoreServiceException e) {
       logger.error("Import process failed due to a retryable error.", e);
     }
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexCaselawService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexCaselawService.java
@@ -1,7 +1,7 @@
 package de.bund.digitalservice.ris.search.service;
 
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.exception.OpenSearchMapperException;
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
 import de.bund.digitalservice.ris.search.mapper.CaseLawLdmlToOpenSearchMapper;
 import de.bund.digitalservice.ris.search.models.opensearch.CaseLawDocumentationUnit;
@@ -35,14 +35,14 @@ public class IndexCaselawService implements IndexService {
   }
 
   @Override
-  public void reindexAll(String startingTimestamp) throws RetryableObjectStoreException {
+  public void reindexAll(String startingTimestamp) throws ObjectStoreServiceException {
     List<String> ldmlFiles = getAllCaseLawFilenames();
     indexFileList(ldmlFiles);
     repository.deleteByIndexedAtBefore(startingTimestamp);
   }
 
   @Override
-  public void indexChangelog(String key, Changelog changelog) throws RetryableObjectStoreException {
+  public void indexChangelog(String key, Changelog changelog) throws ObjectStoreServiceException {
     if (changelog.isChangeAll()) {
       reindexAll(Instant.now().toString());
     } else {
@@ -59,7 +59,7 @@ public class IndexCaselawService implements IndexService {
     return filename.substring(0, filename.lastIndexOf('.'));
   }
 
-  public void indexFileList(List<String> filenames) throws RetryableObjectStoreException {
+  public void indexFileList(List<String> filenames) throws ObjectStoreServiceException {
     List<List<String>> fileBatches = ListUtils.partition(filenames, IMPORT_BATCH_SIZE);
     logger.info("Import caselaw process will have {} batches", fileBatches.size());
     for (int i = 0; i < fileBatches.size(); i++) {
@@ -68,7 +68,7 @@ public class IndexCaselawService implements IndexService {
     }
   }
 
-  public void indexOneBatch(List<String> filenames) throws RetryableObjectStoreException {
+  public void indexOneBatch(List<String> filenames) throws ObjectStoreServiceException {
     for (String filename : filenames) {
       Optional<String> content = bucket.getFileAsString(filename);
       if (content.isPresent()) {
@@ -97,7 +97,7 @@ public class IndexCaselawService implements IndexService {
   }
 
   private List<String> getAllCaseLawFilenames() {
-    return bucket.getAllFilenames().stream()
+    return bucket.getAllKeys().stream()
         .filter(s -> !s.contains(ChangelogService.CHANGELOG))
         .toList();
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
@@ -1,6 +1,6 @@
 package de.bund.digitalservice.ris.search.service;
 
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
 import de.bund.digitalservice.ris.search.mapper.NormLdmlToOpenSearchMapper;
 import de.bund.digitalservice.ris.search.models.opensearch.Norm;
@@ -39,9 +39,9 @@ public class IndexNormsService implements IndexService {
     this.normsSynthesizedRepository = normsSynthesizedRepository;
   }
 
-  public void reindexAll(String startingTimestamp) throws RetryableObjectStoreException {
+  public void reindexAll(String startingTimestamp) throws ObjectStoreServiceException {
     List<ManifestationEli> manifestations =
-        normsBucket.getAllFilenamesByPath("eli/").stream()
+        normsBucket.getAllKeysByPrefix("eli/").stream()
             .map(ManifestationEli::fromString)
             .flatMap(Optional::stream)
             .toList();
@@ -61,7 +61,7 @@ public class IndexNormsService implements IndexService {
 
   @Override
   public void indexChangelog(String changelogKey, Changelog changelog)
-      throws RetryableObjectStoreException {
+      throws ObjectStoreServiceException {
     try {
       List<ManifestationEli> changedFiles =
           getValidManifestations(changelogKey, changelog.getChanged().stream().toList());
@@ -95,7 +95,7 @@ public class IndexNormsService implements IndexService {
   }
 
   private void indexOneNormBatch(List<ExpressionEli> expressionElis)
-      throws RetryableObjectStoreException {
+      throws ObjectStoreServiceException {
     List<Norm> norms = new ArrayList<>();
     for (ExpressionEli eli : expressionElis) {
       if (eli.subtype().startsWith("regelungstext-")) {
@@ -121,11 +121,11 @@ public class IndexNormsService implements IndexService {
     return result;
   }
 
-  private Norm getNormFromS3(ExpressionEli expressionEli) throws RetryableObjectStoreException {
+  private Norm getNormFromS3(ExpressionEli expressionEli) throws ObjectStoreServiceException {
     String today = DateUtils.toDateString(LocalDate.now());
     // get the currently active manifestation or if none are active the most recently active
     final List<String> keysMatchingExpressionEli =
-        normsBucket.getAllFilenamesByPath(expressionEli.getUriPrefix());
+        normsBucket.getAllKeysByPrefix(expressionEli.getUriPrefix());
 
     Optional<String> newestFileName =
         // get all files with the given norm manifestation prefix
@@ -186,7 +186,7 @@ public class IndexNormsService implements IndexService {
 
   public int getNumberOfFilesInBucket() {
     List<ManifestationEli> norms =
-        normsBucket.getAllFilenamesByPath("eli/").stream()
+        normsBucket.getAllKeysByPrefix("eli/").stream()
             .map(ManifestationEli::fromString)
             .flatMap(Optional::stream)
             .filter(e -> e.subtype().startsWith("regelungstext-"))

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexService.java
@@ -1,12 +1,12 @@
 package de.bund.digitalservice.ris.search.service;
 
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
 
 public interface IndexService {
-  void reindexAll(String startingTimestamp) throws RetryableObjectStoreException;
+  void reindexAll(String startingTimestamp) throws ObjectStoreServiceException;
 
-  void indexChangelog(String key, Changelog changelog) throws RetryableObjectStoreException;
+  void indexChangelog(String key, Changelog changelog) throws ObjectStoreServiceException;
 
   int getNumberOfIndexedDocuments();
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexStatusService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexStatusService.java
@@ -1,6 +1,6 @@
 package de.bund.digitalservice.ris.search.service;
 
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.repository.objectstorage.PortalBucket;
 import java.time.Duration;
 import java.time.Instant;
@@ -38,7 +38,7 @@ public class IndexStatusService {
       } else {
         return false;
       }
-    } catch (RetryableObjectStoreException e) {
+    } catch (ObjectStoreServiceException e) {
       logger.error("AWS S3 encountered an issue.", e);
       return false;
     }
@@ -68,7 +68,7 @@ public class IndexStatusService {
     portalBucket.delete(lockFileName);
   }
 
-  public Instant getLastSuccess(String fileName) throws RetryableObjectStoreException {
+  public Instant getLastSuccess(String fileName) throws ObjectStoreServiceException {
     String lastSuccess = portalBucket.getFileAsString(fileName).orElse(null);
     if (lastSuccess == null) {
       logger.error("Status file missing.");

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormsService.java
@@ -2,6 +2,8 @@ package de.bund.digitalservice.ris.search.service;
 
 import static org.opensearch.index.query.QueryBuilders.queryStringQuery;
 
+import de.bund.digitalservice.ris.search.exception.NoSuchKeyException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.models.api.parameters.NormsSearchParams;
 import de.bund.digitalservice.ris.search.models.api.parameters.UniversalSearchParams;
 import de.bund.digitalservice.ris.search.models.opensearch.Norm;
@@ -124,7 +126,8 @@ public class NormsService {
     return Optional.ofNullable(result);
   }
 
-  public Optional<byte[]> getNormFileByEli(ManifestationEli eli) {
+  public Optional<byte[]> getNormFileByEli(ManifestationEli eli)
+      throws ObjectStoreServiceException {
     return normsBucket.get(eli.toString());
   }
 
@@ -149,12 +152,12 @@ public class NormsService {
       while ((length = objectInputStream.read(bytes)) >= 0) {
         zipOut.write(bytes, 0, length);
       }
-    } catch (IOException e) {
+    } catch (IOException | NoSuchKeyException e) {
       throw new IOException("error adding item with key %s".formatted(key), e);
     }
   }
 
   public List<String> getAllFilenamesByPath(String prefix) {
-    return normsBucket.getAllFilenamesByPath(prefix);
+    return normsBucket.getAllKeysByPrefix(prefix);
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/XsltTransformerService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/XsltTransformerService.java
@@ -1,11 +1,11 @@
 package de.bund.digitalservice.ris.search.service;
 
 import de.bund.digitalservice.ris.search.exception.FileTransformationException;
+import de.bund.digitalservice.ris.search.exception.NoSuchKeyException;
 import de.bund.digitalservice.ris.search.repository.objectstorage.NormsBucket;
 import de.bund.digitalservice.ris.search.service.exception.XMLElementNotFoundException;
 import de.bund.digitalservice.ris.search.utils.eli.ManifestationEli;
 import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -81,7 +81,7 @@ public class XsltTransformerService {
     try {
       var response = this.normsBucket.getStream(eli.toString());
       return new StreamSource(response);
-    } catch (FileNotFoundException | NullPointerException e) {
+    } catch (NoSuchKeyException | NullPointerException e) {
       throw new TransformerException("Failed to resolve: " + eli, e);
     }
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/importer/caselaw/CaseLawImportStatusTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/importer/caselaw/CaseLawImportStatusTest.java
@@ -1,6 +1,6 @@
 package de.bund.digitalservice.ris.search.integration.importer.caselaw;
 
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.integration.config.ContainersIntegrationBase;
 import de.bund.digitalservice.ris.search.repository.objectstorage.CaseLawBucket;
 import de.bund.digitalservice.ris.search.repository.objectstorage.PortalBucket;
@@ -48,7 +48,7 @@ class CaseLawImportStatusTest extends ContainersIntegrationBase {
   }
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     for (int i = 0; i < 5; i++) {
       try {
         caseLawBucket.save(
@@ -62,22 +62,22 @@ class CaseLawImportStatusTest extends ContainersIntegrationBase {
   }
 
   @Test
-  void createsLastSuccessFileProperly() throws RetryableObjectStoreException {
-    Assertions.assertEquals(5, caseLawBucket.getAllFilenames().size());
+  void createsLastSuccessFileProperly() throws ObjectStoreServiceException {
+    Assertions.assertEquals(5, caseLawBucket.getAllKeys().size());
     importService.importChangelogs(
         indexCaselawService,
         caseLawBucket,
         Instant.now(),
         ImportService.CASELAW_LAST_SUCCESS_FILENAME);
-    Assertions.assertEquals(5, caseLawBucket.getAllFilenames().size());
+    Assertions.assertEquals(5, caseLawBucket.getAllKeys().size());
     Assertions.assertTrue(
-        portalBucket.getAllFilenames().contains(ImportService.CASELAW_LAST_SUCCESS_FILENAME));
+        portalBucket.getAllKeys().contains(ImportService.CASELAW_LAST_SUCCESS_FILENAME));
     String lastSuccess = readValueFromFile(ImportService.CASELAW_LAST_SUCCESS_FILENAME);
     Assertions.assertTrue(isUTCDate(lastSuccess));
   }
 
   @Test
-  void testLocking() throws RetryableObjectStoreException {
+  void testLocking() throws ObjectStoreServiceException {
     Instant currentTime = Instant.now();
     boolean locked = indexStatusService.lockIndex(ImportService.CASELAW_LOCK_FILENAME, currentTime);
     Assertions.assertTrue(locked);
@@ -96,7 +96,7 @@ class CaseLawImportStatusTest extends ContainersIntegrationBase {
     }
   }
 
-  private String readValueFromFile(String fileName) throws RetryableObjectStoreException {
+  private String readValueFromFile(String fileName) throws ObjectStoreServiceException {
     return portalBucket.getFileAsString(fileName).orElse(null);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/importer/norm/NormsImporterTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/importer/norm/NormsImporterTest.java
@@ -2,7 +2,7 @@ package de.bund.digitalservice.ris.search.integration.importer.norm;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.integration.config.ContainersIntegrationBase;
 import de.bund.digitalservice.ris.search.models.opensearch.Norm;
 import de.bund.digitalservice.ris.search.repository.objectstorage.NormsBucket;
@@ -41,10 +41,10 @@ class NormsImporterTest extends ContainersIntegrationBase {
             s.contains("changelog")
                 || s.equals(ImportService.NORM_LOCK_FILENAME)
                 || s.equals(ImportService.NORM_LAST_SUCCESS_FILENAME);
-    portalBucket.getAllFilenames().stream()
+    portalBucket.getAllKeys().stream()
         .filter(isChangelogOrStatus)
         .forEach(filename -> portalBucket.delete(filename));
-    normsBucket.getAllFilenames().stream()
+    normsBucket.getAllKeys().stream()
         .filter(isChangelogOrStatus)
         .forEach(filename -> normsBucket.delete(filename));
     normIndex.deleteAll();
@@ -52,7 +52,7 @@ class NormsImporterTest extends ContainersIntegrationBase {
 
   @Test
   @DisplayName("Only unprocessed changelogs are considered")
-  void testProcessedChangelogIsIgnored() throws RetryableObjectStoreException {
+  void testProcessedChangelogIsIgnored() throws ObjectStoreServiceException {
     final String ignoredManifestationEli =
         "eli/bund/bgbl-1/1991/s101/1991-01-01/1/deu/1991-01-01/regelungstext-1.xml";
     final String nonIgnoredManifestationEli =
@@ -84,7 +84,7 @@ class NormsImporterTest extends ContainersIntegrationBase {
 
   @Test
   @DisplayName("Updating the manifestation for an expression ELI only keeps the new manifestation")
-  void testDeleteAndUpdate() throws RetryableObjectStoreException {
+  void testDeleteAndUpdate() throws ObjectStoreServiceException {
     final String expressionEli = "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/regelungstext-1";
 
     final String expressionEliUriPart = "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu";
@@ -113,7 +113,7 @@ class NormsImporterTest extends ContainersIntegrationBase {
 
   @Test
   @DisplayName("Delete removes the norm")
-  void testDelete() throws RetryableObjectStoreException {
+  void testDelete() throws ObjectStoreServiceException {
     final String expressionEliToDelete =
         "eli/bund/bgbl-1/1993/s101/1993-01-01/1/deu/regelungstext-1";
     final String expressionEliToKeep = "eli/bund/bgbl-1/1994/s101/1994-01-01/1/deu/regelungstext-1";

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/repository/LocalFilesystemObjectStorageClientTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/repository/LocalFilesystemObjectStorageClientTest.java
@@ -2,11 +2,10 @@ package de.bund.digitalservice.ris.search.integration.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.bund.digitalservice.ris.search.exception.NoSuchKeyException;
 import de.bund.digitalservice.ris.search.repository.objectstorage.LocalFilesystemObjectStorageClient;
 import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
 import java.io.FilterInputStream;
-import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,20 +25,20 @@ class LocalFilesystemObjectStorageClientTest {
 
   @AfterEach
   void afterEach() {
-    for (String key : this.client.getAllFilenamesByPath("")) {
+    for (String key : this.client.listKeysByPrefix("")) {
       this.client.delete(key);
     }
   }
 
   @Test
-  void itStoresListsAndDeletesGivenFilesByPath() throws IOException {
+  void itStoresListsAndDeletesGivenFilesByPath() throws NoSuchKeyException {
     String path1 = "path/to/file1";
     String path2 = "path/to/file2";
 
     client.save(path1, "content1");
     client.save(path2, "content2");
 
-    List<String> filenames = client.getAllFilenamesByPath("path/to/");
+    List<String> filenames = client.listKeysByPrefix("path/to/");
 
     assertThat(filenames).containsExactlyInAnyOrder(path1, path2);
 
@@ -49,22 +48,22 @@ class LocalFilesystemObjectStorageClientTest {
     client.delete("path/to/file1");
     client.delete("path/to/file2");
 
-    assertThat(client.getAllFilenamesByPath("")).isEmpty();
+    assertThat(client.listKeysByPrefix("")).isEmpty();
   }
 
   @Test
   void itSupportEmptyPrefixes() {
     client.save("path/to/file", "content");
-    assertThat(client.getAllFilenamesByPath("")).containsExactly("path/to/file");
+    assertThat(client.listKeysByPrefix("")).containsExactly("path/to/file");
   }
 
   @Test
   void ItReturnsAnEmptyListOnInvalidPaths() {
-    assertThat(client.getAllFilenamesByPath("another/")).isEmpty();
+    assertThat(client.listKeysByPrefix("another/")).isEmpty();
   }
 
   @Test
-  void itWritesStreamToFile() throws FileNotFoundException {
+  void itWritesStreamToFile() throws NoSuchKeyException {
     ByteArrayInputStream inputStream = new ByteArrayInputStream("content".getBytes());
     client.putStream("stream", inputStream);
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/importer/caselaw/CaseLawImporterTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/importer/caselaw/CaseLawImporterTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
 import de.bund.digitalservice.ris.search.models.opensearch.CaseLawDocumentationUnit;
 import de.bund.digitalservice.ris.search.repository.objectstorage.CaseLawBucket;
@@ -41,12 +41,12 @@ class CaseLawImporterTest {
 
   @Test
   @DisplayName("Import one caselaw ldml")
-  void canImportLdml() throws RetryableObjectStoreException {
+  void canImportLdml() throws ObjectStoreServiceException {
     IndexCaselawService indexCaselawService =
         new IndexCaselawService(caseLawBucket, caseLawSynthesizedRepositoryMock);
     Changelog mockChangelog = new Changelog();
     mockChangelog.setChangeAll(true);
-    when(caseLawBucket.getAllFilenames()).thenReturn(List.of("mockFile.xml"));
+    when(caseLawBucket.getAllKeys()).thenReturn(List.of("mockFile.xml"));
     when(caseLawBucket.getFileAsString("mockFile.xml")).thenReturn(Optional.of(testCaseLawLdml));
     indexCaselawService.indexChangelog("mockChangelogFileName", mockChangelog);
     verify(caseLawSynthesizedRepositoryMock, atLeastOnce()).save(any());

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/ChangelogServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/ChangelogServiceTest.java
@@ -3,7 +3,7 @@ package de.bund.digitalservice.ris.search.unit.service;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
 import de.bund.digitalservice.ris.search.repository.objectstorage.ObjectStorage;
 import de.bund.digitalservice.ris.search.service.ChangelogService;
@@ -31,7 +31,7 @@ class ChangelogServiceTest {
   }
 
   @Test
-  void itSkipsInvalidChangelogContent() throws RetryableObjectStoreException {
+  void itSkipsInvalidChangelogContent() throws ObjectStoreServiceException {
 
     when(bucket.getFileAsString(any())).thenReturn(Optional.of("you shall not parse"));
     Changelog changelog = changelogService.parseOneChangelog(bucket, "mockFileName");
@@ -39,7 +39,7 @@ class ChangelogServiceTest {
   }
 
   @Test
-  void itSkipsEmptyChangelogFiles() throws RetryableObjectStoreException {
+  void itSkipsEmptyChangelogFiles() throws ObjectStoreServiceException {
 
     when(bucket.getFileAsString(any())).thenReturn(Optional.empty());
 
@@ -55,7 +55,7 @@ class ChangelogServiceTest {
     String changelogFile2 =
         ChangelogService.CHANGELOG + lastSuccess.plus(2, ChronoUnit.HOURS) + "-changelog.json";
 
-    when(bucket.getAllFilenamesByPath(ChangelogService.CHANGELOG))
+    when(bucket.getAllKeysByPrefix(ChangelogService.CHANGELOG))
         .thenReturn(List.of(changelogFile2, changelogFile1));
 
     List<String> changelogs = changelogService.getNewChangelogsSinceInstant(bucket, lastSuccess);

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/ImportServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/ImportServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
 import de.bund.digitalservice.ris.search.repository.objectstorage.NormsBucket;
 import de.bund.digitalservice.ris.search.service.ChangelogService;
@@ -44,7 +44,7 @@ class ImportServiceTest {
   }
 
   @Test
-  void lockIsAcquiredAndReleasedOnSuccesfulProcess() throws RetryableObjectStoreException {
+  void lockIsAcquiredAndReleasedOnSuccessfulProcess() throws ObjectStoreServiceException {
     when(indexStatusService.lockIndex(eq("norm_lock.txt"), any())).thenReturn(true);
 
     Changelog changelog = new Changelog();
@@ -69,7 +69,7 @@ class ImportServiceTest {
   }
 
   @Test
-  void lockIsAcquiredAndReleasedOnRetryableException() throws RetryableObjectStoreException {
+  void lockIsAcquiredAndReleasedOnRetryableException() throws ObjectStoreServiceException {
 
     Instant lastSuccess = Instant.now().minus(1, ChronoUnit.HOURS);
 
@@ -79,7 +79,7 @@ class ImportServiceTest {
     when(changelogService.getNewChangelogsSinceInstant(any(), any()))
         .thenReturn(List.of("changelogs/" + Instant.now() + "-changelog.json"));
     when(changelogService.parseOneChangelog(any(), any()))
-        .thenThrow(RetryableObjectStoreException.class);
+        .thenThrow(ObjectStoreServiceException.class);
 
     service.lockAndImportChangelogs(
         indexNormsService,
@@ -93,7 +93,7 @@ class ImportServiceTest {
   }
 
   @Test
-  void itTriggersReindexAll() throws RetryableObjectStoreException {
+  void itTriggersReindexAll() throws ObjectStoreServiceException {
     Changelog changelog = new Changelog();
     changelog.setChangeAll(true);
     Instant startTime = Instant.now();

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexCaseLawServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexCaseLawServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
 import de.bund.digitalservice.ris.search.repository.objectstorage.CaseLawBucket;
 import de.bund.digitalservice.ris.search.repository.opensearch.CaseLawSynthesizedRepository;
@@ -180,10 +180,10 @@ class IndexCaseLawServiceTest {
   }
 
   @Test
-  void reindexAllIgnoreseInvalidFiles() throws RetryableObjectStoreException {
+  void reindexAllIgnoresInvalidFiles() throws ObjectStoreServiceException {
     String testContent = caseLawContent;
 
-    when(this.bucket.getAllFilenames()).thenReturn(List.of("file1", "file2"));
+    when(this.bucket.getAllKeys()).thenReturn(List.of("file1", "file2"));
     when(this.bucket.getFileAsString("file1")).thenReturn(Optional.of(testContent));
     when(this.bucket.getFileAsString("file2")).thenReturn(Optional.of("this will not parse"));
 
@@ -202,7 +202,7 @@ class IndexCaseLawServiceTest {
   }
 
   @Test
-  void itCanReindexFromeOneSpecificChangelog() throws RetryableObjectStoreException {
+  void itCanReindexFromOneSpecificChangelog() throws ObjectStoreServiceException {
     String testContent = caseLawContent;
 
     when(this.bucket.getFileAsString("TEST080020093.xml")).thenReturn(Optional.of(testContent));
@@ -221,7 +221,7 @@ class IndexCaseLawServiceTest {
   }
 
   @Test
-  void itCanDeleteFromOneSpecificChangelog() throws RetryableObjectStoreException {
+  void itCanDeleteFromOneSpecificChangelog() throws ObjectStoreServiceException {
     Changelog changelog = new Changelog();
     changelog.setDeleted(Sets.newHashSet(Set.of("TEST080020093.xml")));
     service.indexChangelog("changelog1", changelog);
@@ -231,7 +231,7 @@ class IndexCaseLawServiceTest {
 
   @Test
   void itReturnsRightNumberOfFiles() {
-    when(this.bucket.getAllFilenames())
+    when(this.bucket.getAllKeys())
         .thenReturn(
             List.of(
                 "TEST080020093",

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexNormsServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexNormsServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import de.bund.digitalservice.ris.search.exception.RetryableObjectStoreException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.mapper.NormLdmlToOpenSearchMapper;
 import de.bund.digitalservice.ris.search.models.opensearch.Norm;
 import de.bund.digitalservice.ris.search.repository.objectstorage.NormsBucket;
@@ -127,14 +127,14 @@ class IndexNormsServiceTest {
           """;
 
   @Test
-  void reindexAllIgnoreseInvalidFiles() throws RetryableObjectStoreException {
+  void reindexAllIgnoresInvalidFiles() throws ObjectStoreServiceException {
 
-    when(this.bucket.getAllFilenamesByPath("eli/"))
+    when(this.bucket.getAllKeysByPrefix("eli/"))
         .thenReturn(
             List.of(
                 "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-1.xml",
                 "not an eli"));
-    when(this.bucket.getAllFilenamesByPath("eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu"))
+    when(this.bucket.getAllKeysByPrefix("eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu"))
         .thenReturn(
             List.of("eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-1.xml"));
     when(this.bucket.getFileAsString(
@@ -160,7 +160,7 @@ class IndexNormsServiceTest {
 
   @Test
   void itReturnsRightNumberOfFiles() {
-    when(this.bucket.getAllFilenamesByPath("eli/"))
+    when(this.bucket.getAllKeysByPrefix("eli/"))
         .thenReturn(
             List.of(
                 "eli/bund/bgbl-1/2013/s323/2018-07-02/2/deu/2025-03-08/regelungstext-1.xml",

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/XsltTransformerServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/XsltTransformerServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.testcontainers.shaded.org.apache.commons.lang3.StringUtils.deleteWhitespace;
 
 import de.bund.digitalservice.ris.search.exception.FileTransformationException;
+import de.bund.digitalservice.ris.search.exception.NoSuchKeyException;
 import de.bund.digitalservice.ris.search.repository.objectstorage.NormsBucket;
 import de.bund.digitalservice.ris.search.service.XsltTransformerService;
 import de.bund.digitalservice.ris.search.utils.CaseLawLdmlTemplateUtils;
@@ -71,7 +72,7 @@ class XsltTransformerServiceTest {
   }
 
   @Test
-  void testTransformNormWithAttachments() throws IOException {
+  void testTransformNormWithAttachments() throws IOException, NoSuchKeyException {
     byte[] bytes = Files.readAllBytes(Path.of(resourcesPath, "attachments.xml"));
 
     final Function<String, ResponseInputStream<GetObjectResponse>> makeInputStream =


### PR DESCRIPTION
This PR changes the naming of ObjectStorage methods to be more in line with standard object storage terms, like using "object" instead of "file" and "key" instead of "path".
It also changes the RetryableObjectStoreException to a more generic ObjectStoreServiceException, with a custom NoSuchKeyException to differentiate such cases.

The `get` method is removed to enforce more specific exception handling. Up to this point, any kind of exception thrown in this method would cause clients to get a `404` error code.