### PR TITLE
RISDEV-7621 add different searches to browser history

### DIFF
--- a/frontend/src/components/Search/SimpleSearch/SimpleSearchInput.unit.spec.ts
+++ b/frontend/src/components/Search/SimpleSearch/SimpleSearchInput.unit.spec.ts
@@ -49,6 +49,12 @@ describe("SearchComponent", () => {
     expect(wrapper.vm.model).toBeFalsy();
   });
 
+  it("updates input on model change", async () => {
+    await wrapper.setProps({ modelValue: "updated model" });
+    const input = wrapper.findComponent("input") as VueWrapper;
+    expect(input.attributes("modelvalue")).toBe("updated model");
+  });
+
   it("submits search on Enter key press", async () => {
     const input = wrapper.findComponent("input") as VueWrapper;
     input.vm.$emit("update:modelValue", "test query");

--- a/frontend/src/components/Search/SimpleSearch/SimpleSearchInput.vue
+++ b/frontend/src/components/Search/SimpleSearch/SimpleSearchInput.vue
@@ -14,7 +14,14 @@ const props = defineProps<{ fullWidth?: boolean }>();
 const postHogStore = usePostHogStore();
 const router = useRouter();
 
+// currentText is decoupled from the model, we want to update
+// the model only when the user performs a search
 const currentText = ref<string | undefined>(model.value);
+
+// propagate model updates back to the input
+watch(model, (newValue) => {
+  currentText.value = newValue;
+});
 const emit = defineEmits(["emptySearch"]);
 const performSearch = () => {
   // If the user is coming from another page, we want to track the search

--- a/frontend/src/stores/searchParams/dateParams.ts
+++ b/frontend/src/stores/searchParams/dateParams.ts
@@ -72,11 +72,11 @@ export function useDateParams(initialState: QueryParams) {
     },
   });
 
-  function $reset() {
-    date.value = initialState.date;
-    dateAfter.value = initialState.dateAfter;
-    dateBefore.value = initialState.dateBefore;
-    dateSearchMode.value = initialState.dateSearchMode;
+  function reset(state: QueryParams) {
+    date.value = state.date;
+    dateAfter.value = state.dateAfter;
+    dateBefore.value = state.dateBefore;
+    dateSearchMode.value = state.dateSearchMode;
   }
-  return { date, dateAfter, dateBefore, dateSearchMode, $reset };
+  return { date, dateAfter, dateBefore, dateSearchMode, reset };
 }

--- a/frontend/src/stores/searchParams/dateParams.unit.spec.ts
+++ b/frontend/src/stores/searchParams/dateParams.unit.spec.ts
@@ -130,7 +130,7 @@ describe("useDateParams", () => {
     result.dateSearchMode.effect(DateSearchMode.Equal);
     result.date.value = "2024-01-01";
 
-    result.$reset();
+    result.reset(initialState);
 
     expect(result.date.value).toBe("2023-01-01");
     expect(result.dateAfter.value).toBe("2023-02-01");

--- a/frontend/src/stores/searchParams/getInitialState.ts
+++ b/frontend/src/stores/searchParams/getInitialState.ts
@@ -17,7 +17,7 @@ export const defaultParams: QueryParams = {
   dateSearchMode: DateSearchMode.None,
 };
 
-export const omitDefaults = (newValue: LocationQueryRaw) => {
+export const omitDefaults = (newValue: LocationQueryRaw): LocationQueryRaw => {
   return _.pickBy(newValue, (value, key) => {
     return (defaultParams as unknown as Record<string, string>)[key] !== value;
   });

--- a/frontend/src/stores/searchParams/getInitialState.ts
+++ b/frontend/src/stores/searchParams/getInitialState.ts
@@ -1,6 +1,10 @@
 import _ from "lodash";
 import { DocumentKind } from "@/types";
-import type { LocationQueryRaw, LocationQueryValue, Router } from "#vue-router";
+import type {
+  LocationQuery,
+  LocationQueryRaw,
+  LocationQueryValue,
+} from "#vue-router";
 import { dateSearchFromQuery, DateSearchMode } from "./dateParams";
 import type { QueryParams } from "@/stores/searchParams/index";
 
@@ -13,7 +17,7 @@ export const defaultParams: QueryParams = {
   dateSearchMode: DateSearchMode.None,
 };
 
-const omitDefaults = (newValue: LocationQueryRaw) => {
+export const omitDefaults = (newValue: LocationQueryRaw) => {
   return _.pickBy(newValue, (value, key) => {
     return (defaultParams as unknown as Record<string, string>)[key] !== value;
   });
@@ -41,8 +45,7 @@ function getFirstValue(
 ): string | undefined {
   return (Array.isArray(value) ? value[0] : value) ?? undefined;
 }
-export const getInitialState = (router: Router): QueryParams => {
-  const routerQuery = router.currentRoute.value.query;
+export const getInitialState = (routerQuery: LocationQuery): QueryParams => {
   return {
     query: getFirstValue(routerQuery.query) ?? defaultParams.query,
     category: getFirstValue(routerQuery.category) ?? defaultParams.category,
@@ -53,14 +56,4 @@ export const getInitialState = (router: Router): QueryParams => {
     ...dateSearchFromQuery(routerQuery),
     court: getFirstValue(routerQuery.court),
   };
-};
-export const setRouterQuery = (router: Router, params: LocationQueryRaw) => {
-  const postHogStore = usePostHogStore();
-  const newParams = params as unknown as QueryParams;
-  const previousParams = addDefaults(router.currentRoute.value.query);
-  postHogStore.searchPerformed("simple", newParams, previousParams);
-  return router.replace({
-    ...router.currentRoute.value,
-    query: omitDefaults(params),
-  });
 };

--- a/frontend/src/stores/searchParams/getInitialState.unit.spec.ts
+++ b/frontend/src/stores/searchParams/getInitialState.unit.spec.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import type { LocationQueryRaw, Router } from "vue-router";
+import type { LocationQueryRaw } from "vue-router";
 import { DateSearchMode } from "@/stores/searchParams/index";
 import { dateSearchFromQuery } from "@/stores/searchParams/dateParams";
 import {
@@ -12,11 +12,6 @@ import { describe, expect } from "vitest";
 vi.mock("./dateParams.ts");
 
 describe("getInitialState", () => {
-  const buildMockRouter = (query: LocationQueryRaw) =>
-    ({
-      currentRoute: { value: { query } },
-    }) as Router;
-
   beforeAll(() => {
     vi.mocked(dateSearchFromQuery).mockImplementation(() => ({
       dateSearchMode: DateSearchMode.None,
@@ -24,44 +19,44 @@ describe("getInitialState", () => {
   });
 
   it("returns the correct query", () => {
-    expect(
-      getInitialState(buildMockRouter({ query: "this query" })),
-    ).toMatchObject({ query: "this query" });
+    expect(getInitialState({ query: "this query" })).toMatchObject({
+      query: "this query",
+    });
   });
 
   it("returns the default values", () => {
-    expect(getInitialState(buildMockRouter({}))).toEqual(defaultParams);
+    expect(getInitialState({})).toEqual(defaultParams);
   });
 
   it("parses the category", () => {
-    expect(
-      getInitialState(buildMockRouter({ category: "R.urteil" })),
-    ).toMatchObject({ category: "R.urteil" });
+    expect(getInitialState({ category: "R.urteil" })).toMatchObject({
+      category: "R.urteil",
+    });
   });
 
   it("parses int page params", () => {
     expect(
-      getInitialState(buildMockRouter({ itemsPerPage: "55", pageNumber: "7" })),
+      getInitialState({ itemsPerPage: "55", pageNumber: "7" }),
     ).toMatchObject({ itemsPerPage: 55, pageNumber: 7 });
   });
 
   it("parses sort", () => {
-    expect(getInitialState(buildMockRouter({ sort: "-date" }))).toMatchObject({
+    expect(getInitialState({ sort: "-date" })).toMatchObject({
       sort: "-date",
     });
   });
 
   it("parses court", () => {
-    expect(
-      getInitialState(buildMockRouter({ court: "OLVerfG Kiel" })),
-    ).toMatchObject({ court: "OLVerfG Kiel" });
-    expect(
-      getInitialState(buildMockRouter({ court: ["in array"] })),
-    ).toMatchObject({ court: "in array" });
+    expect(getInitialState({ court: "OLVerfG Kiel" })).toMatchObject({
+      court: "OLVerfG Kiel",
+    });
+    expect(getInitialState({ court: ["in array"] })).toMatchObject({
+      court: "in array",
+    });
   });
 
   it("delegates date parsing to ./dateParams", () => {
-    getInitialState(buildMockRouter({ date: "some date" }));
+    getInitialState({ date: "some date" });
     expect(dateSearchFromQuery).toHaveBeenCalledWith({ date: "some date" });
   });
 

--- a/frontend/src/stores/searchParams/index.spec.ts
+++ b/frontend/src/stores/searchParams/index.spec.ts
@@ -176,10 +176,20 @@ describe("useSimpleSearchParamsStore", () => {
     expect(mockPostHog.searchPerformed).toHaveBeenCalledExactlyOnceWith(
       "simple",
       {
+        category: "A",
+        dateSearchMode: "",
+        itemsPerPage: 10,
+        pageNumber: 0,
         query: "second",
+        sort: "default",
       },
       {
+        category: "A",
+        dateSearchMode: "",
+        itemsPerPage: 10,
+        pageNumber: 0,
         query: "first",
+        sort: "default",
       },
     );
   });

--- a/frontend/src/stores/searchParams/index.spec.ts
+++ b/frontend/src/stores/searchParams/index.spec.ts
@@ -149,7 +149,7 @@ describe("useSimpleSearchParamsStore", () => {
     await nextTick();
     expect(mockPush).toHaveBeenLastCalledWith({
       path: "/search",
-      query: { category: DocumentKind.CaseLaw, pageNumber: 1 },
+      query: { category: DocumentKind.CaseLaw, pageNumber: "1" },
     });
 
     store.category = DocumentKind.All;

--- a/frontend/src/stores/searchParams/index.spec.ts
+++ b/frontend/src/stores/searchParams/index.spec.ts
@@ -1,28 +1,56 @@
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
-import { useSimpleSearchParamsStore } from "@/stores/searchParams/index";
+import {
+  type QueryParams,
+  useSimpleSearchParamsStore,
+} from "@/stores/searchParams/index";
 import { DocumentKind } from "@/types";
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
 import { defaultParams } from "@/stores/searchParams/getInitialState";
 import { sortMode } from "@/components/types";
+import type { RouteLocationNormalized } from "#vue-router";
 
-const routerEmptyState = { currentRoute: { value: { query: {} } } };
+type MockRoute = Pick<RouteLocationNormalized, "path" | "query">;
+const mockRouteInitialState = {
+  path: "/search",
+  query: {},
+};
+const mockRoute = ref<MockRoute>(mockRouteInitialState);
+const routerEmptyState = {
+  push: (newValue: MockRoute) => {
+    mockRoute.value = newValue;
+  },
+};
+
+const mockPostHog = {
+  searchPerformed: vi.fn(),
+};
 
 // refer to https://nuxt.com/docs/getting-started/testing#unit-testing
-const { useRouterMock } = vi.hoisted(() => {
+const { useRouteMock, useRouterMock, usePostHogStoreMock } = vi.hoisted(() => {
   return {
+    useRouteMock: vi.fn().mockImplementation(() => mockRoute.value),
     useRouterMock: vi.fn().mockImplementation(() => routerEmptyState),
+    usePostHogStoreMock: () => mockPostHog,
   };
 });
 
+mockNuxtImport("useRoute", () => {
+  return useRouteMock;
+});
 mockNuxtImport("useRouter", () => {
   return useRouterMock;
+});
+mockNuxtImport("usePostHogStore", () => {
+  return usePostHogStoreMock;
 });
 
 describe("useSimpleSearchParamsStore", () => {
   beforeEach(async () => {
     setActivePinia(createPinia());
+    mockRoute.value = mockRouteInitialState;
+    mockPostHog.searchPerformed.mockRestore();
   });
 
   it("returns default parameters if the URL is empty", async () => {
@@ -40,9 +68,7 @@ describe("useSimpleSearchParamsStore", () => {
   });
 
   it("returns the correct category if one is set", async () => {
-    useRouterMock.mockReturnValueOnce({
-      currentRoute: { value: { query: { category: "R" } } },
-    });
+    useRouteMock.mockReturnValueOnce({ query: { category: "R" } });
 
     const store = useSimpleSearchParamsStore();
 
@@ -51,8 +77,8 @@ describe("useSimpleSearchParamsStore", () => {
 
   for (const category of ["A", "R", "N", "R.urteil"])
     it(`returns the correct category for ${category}`, async () => {
-      useRouterMock.mockReturnValueOnce({
-        currentRoute: { value: { query: { category } } },
+      useRouteMock.mockReturnValueOnce({
+        query: { category },
       });
 
       const store = useSimpleSearchParamsStore();
@@ -61,18 +87,17 @@ describe("useSimpleSearchParamsStore", () => {
     });
 
   it("discards caseLaw-specific options if the DocumentKind is updated", async () => {
-    const mockReplace = vi.fn();
-    useRouterMock.mockReturnValue({
-      currentRoute: {
-        value: {
-          query: {
-            category: DocumentKind.CaseLaw,
-            sort: sortMode.courtName,
-            court: "Example court",
-          },
-        },
+    const mockPush = vi.fn();
+
+    useRouteMock.mockReturnValueOnce({
+      query: {
+        category: DocumentKind.CaseLaw,
+        sort: sortMode.courtName,
+        court: "Example court",
       },
-      replace: mockReplace,
+    });
+    useRouterMock.mockReturnValue({
+      push: mockPush,
     });
 
     const store = useSimpleSearchParamsStore();
@@ -88,17 +113,15 @@ describe("useSimpleSearchParamsStore", () => {
   });
 
   it("resets the page index if the category is updated", async () => {
-    const mockReplace = vi.fn();
-    useRouterMock.mockReturnValue({
-      currentRoute: {
-        value: {
-          query: {
-            category: DocumentKind.CaseLaw,
-            pageNumber: 1,
-          },
-        },
+    const mockPush = vi.fn();
+    useRouterMock.mockReturnValueOnce({
+      push: mockPush,
+    });
+    useRouteMock.mockReturnValueOnce({
+      query: {
+        category: DocumentKind.CaseLaw,
+        pageNumber: 1,
       },
-      replace: mockReplace,
     });
 
     const store = useSimpleSearchParamsStore();
@@ -111,24 +134,74 @@ describe("useSimpleSearchParamsStore", () => {
   });
 
   it("updates the URL", async () => {
-    const mockReplace = vi.fn();
+    const mockPush = vi
+      .fn()
+      .mockImplementation((newValue) => Object.assign(mockRoute, newValue));
+
     useRouterMock.mockReturnValue({
-      ...routerEmptyState,
-      replace: mockReplace,
+      push: mockPush,
     });
 
     const store = useSimpleSearchParamsStore();
 
     store.category = DocumentKind.CaseLaw;
+    store.pageNumber = 1;
     await nextTick();
-    expect(mockReplace).toHaveBeenLastCalledWith({
-      query: { category: DocumentKind.CaseLaw },
+    expect(mockPush).toHaveBeenLastCalledWith({
+      path: "/search",
+      query: { category: DocumentKind.CaseLaw, pageNumber: 1 },
     });
 
     store.category = DocumentKind.All;
     await nextTick();
-    expect(mockReplace).toHaveBeenLastCalledWith({
-      query: {},
+    expect(mockPush).toHaveBeenLastCalledWith({
+      path: "/search",
+      query: {}, // pageNumber is reset through category change
     });
+  });
+
+  it("updates if the URL changes, and reports an event", async () => {
+    const mockRoute = reactive({
+      query: { query: "first" },
+    });
+    useRouteMock.mockReturnValue(mockRoute);
+    const store = useSimpleSearchParamsStore();
+    expect(store.query).toBe("first");
+
+    mockRoute.query = { query: "second" };
+    await nextTick();
+
+    expect(store.query).toBe("second");
+
+    expect(mockPostHog.searchPerformed).toHaveBeenCalledExactlyOnceWith(
+      "simple",
+      {
+        query: "second",
+      },
+      {
+        query: "first",
+      },
+    );
+  });
+
+  it("does not create a reactive cycle", async () => {
+    const mockRoute = reactive<{ query: Partial<QueryParams> }>({
+      query: { query: "testQuery" },
+    });
+    useRouteMock.mockReturnValue(mockRoute);
+    const mockPush = vi
+      .fn()
+      .mockImplementation((newValue) => Object.assign(mockRoute, newValue));
+    useRouterMock.mockReturnValue({
+      push: mockPush,
+    });
+
+    const store = useSimpleSearchParamsStore();
+    store.sort = "newSort";
+    await nextTick();
+    expect(mockPush).toHaveBeenCalledExactlyOnceWith({
+      query: { query: "testQuery", sort: "newSort" },
+    });
+    expect(mockRoute.query.sort).toBe("newSort");
   });
 });

--- a/frontend/src/stores/searchParams/index.ts
+++ b/frontend/src/stores/searchParams/index.ts
@@ -141,10 +141,12 @@ export const useSimpleSearchParamsStore = defineStore(
       () => route.query,
       async (newQuery) => {
         // check whether the store already has the values, in order to prevent loops
-        const updatedQueryWasSetByStore = _.isEqualWith(
-          toRaw(routerQuerySetByStore.value),
+        const updatedQueryWasSetByStore = _.isEqual(
+          _.mapValues(
+            toRaw(routerQuerySetByStore.value),
+            (value) => value?.toString(), // numbers in query are represented as strings
+          ),
           newQuery,
-          (a, b) => a.toString() == b, // numbers in query are represented as strings
         );
 
         if (!updatedQueryWasSetByStore) {

--- a/frontend/src/stores/searchParams/index.ts
+++ b/frontend/src/stores/searchParams/index.ts
@@ -102,13 +102,14 @@ export const useSimpleSearchParamsStore = defineStore(
     function reinitializeFromQuery(routerQuery: LocationQuery) {
       const initialState = getInitialState(routerQuery);
 
+      console.log("initial state", initialState);
       query.value = initialState.query;
       pageNumber.value = initialState.pageNumber;
       category.value = initialState.category;
       itemsPerPage.value = initialState.itemsPerPage;
       sort.value = initialState.sort;
       court.value = initialState.court;
-      dateParams.$reset();
+      dateParams.reset(initialState);
     }
 
     /*
@@ -151,6 +152,7 @@ export const useSimpleSearchParamsStore = defineStore(
 
         if (!updatedQueryWasSetByStore) {
           reinitializeFromQuery(newQuery);
+          console.log(newQuery);
         }
       },
     );

--- a/frontend/src/stores/searchParams/index.ts
+++ b/frontend/src/stores/searchParams/index.ts
@@ -3,6 +3,7 @@ import { DocumentKind } from "@/types";
 import type { DateSearchMode } from "@/stores/searchParams/dateParams";
 import { useDateParams } from "@/stores/searchParams/dateParams";
 import {
+  addDefaults,
   defaultParams,
   getInitialState,
   omitDefaults,
@@ -102,7 +103,6 @@ export const useSimpleSearchParamsStore = defineStore(
     function reinitializeFromQuery(routerQuery: LocationQuery) {
       const initialState = getInitialState(routerQuery);
 
-      console.log("initial state", initialState);
       query.value = initialState.query;
       pageNumber.value = initialState.pageNumber;
       category.value = initialState.category;
@@ -127,8 +127,12 @@ export const useSimpleSearchParamsStore = defineStore(
     const postHogStore = usePostHogStore();
     const updateRouterQuery = (router: Router, params: LocationQueryRaw) => {
       const query = omitDefaults(params);
-      const oldQuery = routerQuerySetByStore.value;
-      postHogStore.searchPerformed("simple", query, oldQuery);
+      const previousQuery = routerQuerySetByStore.value;
+      postHogStore.searchPerformed(
+        "simple",
+        addDefaults(query),
+        addDefaults(previousQuery),
+      );
       routerQuerySetByStore.value = query;
       return router.push({
         ...route,

--- a/frontend/src/stores/usePostHogStore.ts
+++ b/frontend/src/stores/usePostHogStore.ts
@@ -97,8 +97,8 @@ export const usePostHogStore = defineStore("postHog", () => {
   }
   function searchPerformed(
     type: "simple" | "advanced",
-    newParams?: QueryParams,
-    previousParams?: QueryParams,
+    newParams?: Partial<QueryParams>,
+    previousParams?: Partial<QueryParams>,
   ) {
     if (postHog.value && userConsent.value === true) {
       postHog.value.capture("search_performed", {


### PR DESCRIPTION
This PR changes `router.replace` to `router.push` when propagating Pinia state changes to the browser History API, and adds logic to enable the store to update according to the URL.

In order to prevent cycles where the store updates the route and the route change triggers a store update, logic is added to ensure that the store ignores route changes triggered by it.

Test cases have been added, including for PostHog reporting.