### PR TITLE
Only check for bucket count after import

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexSyncJob.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexSyncJob.java
@@ -51,7 +51,6 @@ public class IndexSyncJob {
     }
 
     fetchAndProcessChanges(state);
-    alertOnNumberMismatch(state);
     indexStatusService.unlockIndex(statusFileName);
   }
 
@@ -70,12 +69,17 @@ public class IndexSyncJob {
       // if status file or last success missing do a full reset
       indexService.reindexAll(state.startTime());
       indexStatusService.updateLastProcessedChangelog(statusFileName, state.startTime());
+      alertOnNumberMismatch(state);
     } else {
       List<String> unprocessedChangelogs =
           getNewChangelogs(changelogBucket, state.lastProcessedChangelogFile()).stream()
               .sorted()
               .toList();
       processChangelogs(state, unprocessedChangelogs);
+      boolean didRun = !unprocessedChangelogs.isEmpty();
+      if (didRun) {
+        alertOnNumberMismatch(state);
+      }
     }
   }
 


### PR DESCRIPTION
Currently, the bucket file numbers are checked whenever the import job runs. This PR changes the logic to only perform this check operation if a changelog file has been processed.