### PR TITLE
Clarify API endpoint documentation

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/CaseLawController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/CaseLawController.java
@@ -47,7 +47,7 @@ public class CaseLawController {
       path = ApiConfig.Paths.CASELAW + "/{documentNumber}",
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(
-      summary = "Get a single decision by document number",
+      summary = "Decision metadata",
       description = "The endpoint returns a single decision from our database.")
   @ApiResponse(responseCode = "200")
   @ApiResponse(responseCode = "404", content = @Content)
@@ -67,7 +67,7 @@ public class CaseLawController {
       path = ApiConfig.Paths.CASELAW + "/{documentNumber}.html",
       produces = MediaType.TEXT_HTML_VALUE)
   @Operation(
-      summary = "Get a case law decision as HTML",
+      summary = "Decision HTML",
       description = "Renders and returns a case law decision as HTML.")
   @ApiResponse(responseCode = "200")
   @ApiResponse(responseCode = "404", content = @Content)
@@ -88,7 +88,7 @@ public class CaseLawController {
       path = ApiConfig.Paths.CASELAW + "/{documentNumber}.xml",
       produces = MediaType.APPLICATION_XML_VALUE)
   @Operation(
-      summary = "Get a case law decision as XML",
+      summary = "Decision XML",
       description =
           "Returns a case law decision as XML. This content is used as a source for the HTML endpoint.")
   @ApiResponse(responseCode = "200")

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/CaseLawSearchController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/CaseLawSearchController.java
@@ -95,9 +95,9 @@ public class CaseLawSearchController {
       path = ApiConfig.Paths.CASELAW + "/courts",
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(
-      summary = "List courts whose decisions are published in this database",
+      summary = "List courts",
       description =
-          "Lists courts with long and short name and number of associated decisions. The prefix parameter may be used to filter this list.")
+          "Lists courts with long and short name and number of associated decisions. The prefix parameter may be used to filter this list. Only includes courts whose decisions have been published in this database.")
   public ResponseEntity<List<CourtSearchResult>> getCourts(@Nullable String prefix) {
     var result = caseLawService.getCourts(prefix);
     return ResponseEntity.ok(result);

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/api/parameters/CaseLawSearchParams.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/api/parameters/CaseLawSearchParams.java
@@ -22,11 +22,7 @@ public class CaseLawSearchParams {
   @Schema(
       name = "legalEffect",
       description =
-          "Corresponds to “Rechtskraft”, meaning that the decision referred to is legally binding.",
-      allowableValues = {
-        "true", "false"
-      } /* accepted by {@link LegalEffect::extendedValueOf} in addition to the enum
-        values */)
+          "Corresponds to “Rechtskraft”, meaning that the decision referred to is legally binding.")
   LegalEffect legalEffect;
 
   public void setLegalEffect(@NotNull String force) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/LegislationWorkSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/LegislationWorkSchema.java
@@ -26,7 +26,7 @@ public record LegislationWorkSchema(
             description = "Amtliche Langüberschrift")
         String name,
     @Schema(
-            example = "eli/bund/bgbl-1/1975/s1760",
+            example = "eli/bund/bgbl-1/1975/s1760/regelungstext-1",
             description = "European Legislation Identifier (ELI)")
         String legislationIdentifier,
     @Schema(example = "Kakaoverordnung", description = "Amtliche Kurzüberschrift")
@@ -48,4 +48,8 @@ public record LegislationWorkSchema(
                 """)
         LocalDate datePublished,
     @Nullable PublicationIssueSchema isPartOf,
-    @Nullable LegislationExpressionSchema workExample) {}
+    @Schema(
+            description =
+                "Expression-level details (<i>an \"exemplary\" expression of this work</i>)")
+        @Nullable
+        LegislationExpressionSchema workExample) {}


### PR DESCRIPTION
This PR improves the API endpoint documentation (auto-generated from OpenAPI annotations).

- Provides a terser summary, to help distinguish different operations in an overview. A more detailed description can be found in the description field.
  - Background: These summaries are used in the navigation, which is quite hard to read at the moment.
- References FRBR terms, as a short preview, until we implement a dedicated FRBR guide page in our documentation.
- Adds missing `regelungstext-1` suffix in workEli examples.
- Adds a fixed `.html` suffix for article HTML for clarity (other formats are not supported by the method).
- Removes `true` and `false` aliases for "Rechtskraft" parameter.
- Clarifies the `workExample` field name.