### PR TITLE
RISDEV-8010

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/CaseLawLdmlToOpenSearchMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/CaseLawLdmlToOpenSearchMapper.java
@@ -23,9 +23,7 @@ import jakarta.xml.bind.DataBindingException;
 import jakarta.xml.bind.JAXB;
 import jakarta.xml.bind.ValidationException;
 import java.io.StringReader;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.Instant;
 import javax.xml.transform.stream.StreamSource;
 import org.eclipse.persistence.exceptions.DescriptorException;
 
@@ -131,7 +129,7 @@ public class CaseLawLdmlToOpenSearchMapper {
         .dissentingOpinion(jaxbToSanitizedHtml(dissentingOpinion))
 
         // Internal (portal team) fields
-        .indexedAt(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT))
+        .indexedAt(Instant.now().toString())
         .articles(null)
         .build();
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormLdmlToOpenSearchMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormLdmlToOpenSearchMapper.java
@@ -10,6 +10,7 @@ import de.bund.digitalservice.ris.search.models.opensearch.TableOfContentsItem;
 import de.bund.digitalservice.ris.search.utils.DateUtils;
 import de.bund.digitalservice.ris.search.utils.XmlDocument;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -126,6 +127,7 @@ public class NormLdmlToOpenSearchMapper {
               .articles(articles)
               .articleNames(articleNames)
               .articleTexts(articleTexts)
+              .indexedAt(Instant.now().toString())
               .build());
     } catch (Exception e) {
       logger.warn("Error to create Norms from XML content.", e);

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/CaseLawSynthesizedRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/CaseLawSynthesizedRepository.java
@@ -15,5 +15,7 @@ public interface CaseLawSynthesizedRepository
 
   void deleteByIndexedAtBefore(String indexedAt);
 
+  void deleteByIndexedAtIsNull();
+
   void deleteAllById(Iterable<? extends String> ids);
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/NormsSynthesizedRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/NormsSynthesizedRepository.java
@@ -31,4 +31,6 @@ public interface NormsSynthesizedRepository extends ElasticsearchRepository<Norm
   Page<Norm> findAll(@NotNull Pageable pageable);
 
   void deleteByIndexedAtBefore(String indexedAt);
+
+  void deleteByIndexedAtIsNull();
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexCaselawService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexCaselawService.java
@@ -39,6 +39,7 @@ public class IndexCaselawService implements IndexService {
     List<String> ldmlFiles = getAllCaseLawFilenames();
     indexFileList(ldmlFiles);
     repository.deleteByIndexedAtBefore(startingTimestamp);
+    repository.deleteByIndexedAtIsNull();
   }
 
   @Override

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
@@ -178,6 +178,7 @@ public class IndexNormsService implements IndexService {
 
   private void clearOldNorms(String timestamp) {
     normsSynthesizedRepository.deleteByIndexedAtBefore(timestamp);
+    normsSynthesizedRepository.deleteByIndexedAtIsNull();
   }
 
   public int getNumberOfIndexedDocuments() {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexSyncJob.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexSyncJob.java
@@ -43,6 +43,7 @@ public class IndexSyncJob {
   }
 
   public void runJob() throws ObjectStoreServiceException {
+    logger.info("Starting index sync job for {}", statusFileName);
     // load current state and lock if possible
     IndexingState state =
         indexStatusService.loadStatus(statusFileName).withStartTime(Instant.now().toString());
@@ -53,6 +54,7 @@ public class IndexSyncJob {
 
     fetchAndProcessChanges(state);
     indexStatusService.unlockIndex(statusFileName);
+    logger.info("Finished index sync job for {}", statusFileName);
   }
 
   public List<String> getNewChangelogs(


### PR DESCRIPTION
Backend part (api)
*Added indexed_at to norms (was only there for case law) *Changed reindex all to also delete documentation units that have indexed_at null *Added logging to see start and stop of job
*Small refactor to use more simple Instant.now()