### PR TITLE
RISDEV-8006 Page for historic versions of a norm

### DIFF
--- a/frontend/src/components/Ris/RisBreadcrumb.vue
+++ b/frontend/src/components/Ris/RisBreadcrumb.vue
@@ -35,7 +35,7 @@ const items = computed(() => {
         : "Gerichtsentscheidungen";
     const documentKind =
       props.type === "norm" ? DocumentKind.Norm : DocumentKind.CaseLaw;
-    const route = `/search?category=${documentKind}&sort=-date`;
+    const route = `/search?category=${documentKind}`;
     items.push({
       label,
       route,

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.integration.spec.ts
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.integration.spec.ts
@@ -148,7 +148,12 @@ describe("index.vue", () => {
     const wrapper = await mountComponent();
     expect(wrapper.get(".ris-heading3-regular").text()).toBe("alternateName");
     expect(wrapper.find(".titel").text()).toBe("Sample Norm");
-    expect(getBreadcrumbStub(wrapper).props("title")).toBe("abbreviation");
+    expect(getBreadcrumbStub(wrapper).props("items")).toStrictEqual(
+      Array.of({
+        route: "/norms/eli/work-LEG12345",
+        label: "abbreviation",
+      }),
+    );
   });
 
   it("uses the alternateName as title if the name is not present", async () => {
@@ -166,7 +171,12 @@ describe("index.vue", () => {
     const wrapper = await mountComponent();
     expect(wrapper.find(".ris-heading2-regular").exists()).toBe(false);
     expect(wrapper.find(".titel").text()).toBe("alternateName");
-    expect(getBreadcrumbStub(wrapper).props("title")).toBe("abbreviation");
+    expect(getBreadcrumbStub(wrapper).props("items")).toStrictEqual(
+      Array.of({
+        route: "/norms/eli/work-LEG12345",
+        label: "abbreviation",
+      }),
+    );
   });
 
   it("uses the abbreviation as title if the name and alternateName are not present", async () => {
@@ -181,7 +191,12 @@ describe("index.vue", () => {
     const wrapper = await mountComponent();
     expect(wrapper.find(".ris-heading2-regular").exists()).toBe(false);
     expect(wrapper.find(".titel").text()).toBe("abbreviation");
-    expect(getBreadcrumbStub(wrapper).props("title")).toBe("abbreviation");
+    expect(getBreadcrumbStub(wrapper).props("items")).toStrictEqual(
+      Array.of({
+        route: "/norms/eli/work-LEG12345",
+        label: "abbreviation",
+      }),
+    );
   });
 
   it("shows the FileActionsMenu with correct XML link", async () => {

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
@@ -37,6 +37,7 @@ import { isPrototypeProfile } from "~/utils/config";
 import ContentWrapper from "~/components/CustomLayouts/ContentWrapper.vue";
 import NormVersionList from "~/components/Norm/NormVersionList.vue";
 import VersionInfoBox from "~/components/Norm/VersionInfoBox.vue";
+import type { BreadcrumbItem } from "~/components/Ris/RisBreadcrumb.vue";
 
 definePageMeta({
   // note: this is an expression ELI that additionally specifies the subtype component of a manifestation ELI
@@ -111,6 +112,24 @@ const { status: normVersionsStatus, sortedVersions: normVersions } = metadata
       status: "error",
       sortedVersions: [] as SearchResult<LegislationWork>[],
     };
+
+const breadcrumbItems: ComputedRef<BreadcrumbItem[]> = computed(() => {
+  const list = [
+    {
+      route: `/norms/${metadata.value?.legislationIdentifier}`,
+      label: normBreadcrumbTitle.value,
+    },
+  ];
+
+  const isInForce =
+    metadata.value?.workExample.legislationLegalForce === "InForce";
+  if (!isInForce) {
+    const temporalCoverageLabel = temporalCoverage.value?.join("–");
+    list.push({ route: route.fullPath, label: temporalCoverageLabel });
+  }
+
+  return list;
+});
 </script>
 
 <template>
@@ -118,12 +137,7 @@ const { status: normVersionsStatus, sortedVersions: normVersions } = metadata
     <div v-if="status == 'pending'">Lade ...</div>
     <div v-if="!!metadata">
       <div class="flex items-center gap-8 print:hidden">
-        <RisBreadcrumb
-          type="norm"
-          :title="normBreadcrumbTitle"
-          :base-path="route.fullPath"
-          class="grow"
-        />
+        <RisBreadcrumb type="norm" :items="breadcrumbItems" class="grow" />
         <FileActionsMenu :xml-url="xmlUrl" />
       </div>
       <NormHeadingGroup :metadata="metadata" :html-parts="htmlParts" />

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[subtype]/index.logic.spec.ts
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[subtype]/index.logic.spec.ts
@@ -1,0 +1,80 @@
+import type {
+  LegislationExpression,
+  LegislationWork,
+  SearchResult,
+} from "~/types";
+import _ from "lodash";
+import { getMostRelevantExpression } from "~/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[subtype]/index.logic";
+
+vi.mock("~/utils/dateFormatting", () => ({
+  getCurrentDateInGermany: vi.fn().mockReturnValue("2000-01-01"),
+}));
+
+type PartialExpression = Pick<
+  LegislationExpression,
+  "legislationLegalForce" | "temporalCoverage" | "legislationIdentifier"
+>;
+
+describe("getMostRelevantExpression", () => {
+  const currentExpression: PartialExpression = {
+    legislationLegalForce: "InForce",
+    temporalCoverage: "1999-01-01/..",
+    legislationIdentifier: "currentExpression",
+  };
+  const veryOldExpression: PartialExpression = {
+    legislationLegalForce: "NotInForce",
+    temporalCoverage: "1871-05-15/1871-05-17",
+    legislationIdentifier: "veryOldExpression",
+  };
+  const oldExpression: PartialExpression = {
+    legislationLegalForce: "NotInForce",
+    temporalCoverage: "1900-01-01/1980-01-01",
+    legislationIdentifier: "oldExpression",
+  };
+  const upcomingExpression: PartialExpression = {
+    legislationLegalForce: "NotInForce",
+    temporalCoverage: "2001-01-01/..",
+    legislationIdentifier: "upcomingExpression",
+  };
+  const farFutureExpression: PartialExpression = {
+    legislationLegalForce: "NotInForce",
+    temporalCoverage: "3000-01-01/..",
+    legislationIdentifier: "farFutureExpression",
+  };
+
+  function transform(
+    partialExpressions: PartialExpression[],
+  ): SearchResult<LegislationWork>[] {
+    return partialExpressions.map(
+      (partialExpression) =>
+        ({
+          item: {
+            workExample: partialExpression as LegislationExpression,
+          },
+        }) as SearchResult<LegislationWork>,
+    );
+  }
+
+  const allExpressions = [
+    veryOldExpression,
+    oldExpression,
+    currentExpression,
+    upcomingExpression,
+    farFutureExpression,
+  ];
+
+  it("picks a current expression if available", () => {
+    const testCase = transform(allExpressions);
+    expect(getMostRelevantExpression(testCase)).toBe("currentExpression");
+  });
+
+  it("picks the nearest future expression if there is no current expression", () => {
+    const testCase = transform(_.without(allExpressions, currentExpression));
+    expect(getMostRelevantExpression(testCase)).toBe("upcomingExpression");
+  });
+
+  it("picks the most recent past expression if there is no current or future expression", () => {
+    const testCase = transform([veryOldExpression, oldExpression]);
+    expect(getMostRelevantExpression(testCase)).toBe("oldExpression");
+  });
+});

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[subtype]/index.logic.ts
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[subtype]/index.logic.ts
@@ -1,0 +1,39 @@
+import type { LegislationWork, SearchResult } from "~/types";
+import _ from "lodash";
+import { getCurrentDateInGermany } from "~/utils/dateFormatting";
+
+export function getMostRelevantExpression(
+  list: SearchResult<LegislationWork>[],
+): string | null {
+  if (list.length === 0) {
+    return null;
+  }
+  const expressions = list.map((member) => member.item.workExample);
+  const activeExpressions = expressions.filter(
+    (expression) => expression.legislationLegalForce === "InForce",
+  );
+  if (activeExpressions.length > 0) {
+    if (activeExpressions.length > 1) {
+      console.info(
+        "found more than one matching active expressions",
+        activeExpressions,
+      );
+    }
+    return activeExpressions[0].legislationIdentifier;
+  }
+  const referenceDate = getCurrentDateInGermany();
+  const [future, past] = _.partition(
+    expressions,
+    (item) => item.temporalCoverage >= referenceDate,
+  );
+  if (future.length > 0) {
+    return _.sortBy(future, "legislationLegalForce")[0].legislationIdentifier;
+  }
+  if (past.length > 0) {
+    return (
+      _.last(_.sortBy(past, "legislationLegalForce"))?.legislationIdentifier ??
+      null
+    );
+  }
+  throw new Error();
+}

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[subtype]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[subtype]/index.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { useFetch } from "#app";
+import type { JSONLDList, LegislationWork, SearchResult } from "~/types";
+import { getMostRelevantExpression } from "~/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[subtype]/index.logic";
+
+const route = useRoute();
+const workEli = [
+  "eli",
+  route.params.jurisdiction,
+  route.params.agent,
+  route.params.year,
+  route.params.naturalIdentifier,
+  route.params.subtype,
+].join("/");
+
+const backendURL = useBackendURL();
+const { data, error: loadError } = await useFetch<
+  JSONLDList<SearchResult<LegislationWork>>
+>(`${backendURL}/v1/legislation`, {
+  params: {
+    eli: workEli,
+  },
+});
+
+const matchedExpressionEli: ComputedRef<string | null> = computed(() => {
+  if (!data.value) return null;
+  return getMostRelevantExpression(data.value?.member);
+});
+
+if (matchedExpressionEli.value) {
+  navigateTo(`/norms/${matchedExpressionEli.value}`, { replace: true });
+}
+
+if (loadError?.value) {
+  showError(loadError.value);
+}
+
+if (data.value?.member.length === 0) {
+  showError({
+    statusCode: 404,
+    statusMessage: "no norms found matching work ELI",
+  });
+}
+</script>
+<template>
+  <DelayedLoadingMessage
+    >Suche aktuelle, zukünftige oder historische Fassung…</DelayedLoadingMessage
+  >
+</template>


### PR DESCRIPTION
This PR makes navigation between different versions of a norm more convenient.

The main feature is a new breadcrumb element that links back to the "most relevant" version of a norm. It directs to a Nuxt route that performs a redirect,
- to the currently active version if available, or
- to a future or past version otherwise.
The last breadcrumb item shows the validity range of the currently open version, unless the open version is in force.

A few end-to-end cases and unit tests were added.