### PR TITLE
RIDEV-7620 Replace full-width transform hack by full-width layout

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -49,27 +49,6 @@ mark {
   @apply bg-yellow-200;
 }
 
-.portal-fullwidth-white {
-  background: white;
-  position: relative;
-  @apply z-10;
-
-  &:before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 50%;
-    width: 100vw;
-    transform: translateX(-50%);
-    bottom: 0;
-    background: white;
-    z-index: -1;
-  }
-  &.separator:before {
-    box-shadow: 0 -1px 0 0 var(--color-gray-600);
-  }
-}
-
 @utility list-custom {
   li {
     @apply relative ml-56;

--- a/frontend/src/components/HeroBanner.vue
+++ b/frontend/src/components/HeroBanner.vue
@@ -1,7 +1,0 @@
-<script setup lang="ts"></script>
-
-<template>
-  <div class="ml-[50%] w-screen -translate-x-1/2">
-    <slot />
-  </div>
-</template>

--- a/frontend/src/components/Tabs.styles.ts
+++ b/frontend/src/components/Tabs.styles.ts
@@ -16,11 +16,14 @@ export const tabStyles: TabPassThroughOptions = {
   },
 };
 export const tabPanelStyles: TabPanelPassThroughOptions = {
-  root: { class: "py-24 min-h-96 portal-fullwidth-white print:py-0" },
+  root: { class: "py-24 min-h-96 bg-white print:py-0" },
 };
 export const tabListStyles: TabListPassThroughOptions = {
-  tabList: {
+  content: {
     class:
-      "flex relative before:absolute before:left-[50%] before:-translate-x-1/2 before:w-screen before:h-px before:bottom-0 before:bg-gray-600 print:hidden",
+      "relative before:absolute before:left-[50%] before:-translate-x-1/2 before:w-full before:h-px before:bottom-0 before:bg-gray-600 print:hidden",
+  },
+  tabList: {
+    class: "flex container",
   },
 };

--- a/frontend/src/error.vue
+++ b/frontend/src/error.vue
@@ -40,7 +40,7 @@ useHead({ title: pageTitle.value });
 
 <template>
   <NuxtLayout>
-    <div class="pt-48 pb-24">
+    <div class="container pt-48 pb-24">
       <template v-if="isNotFoundError">
         <p class="ris-heading2-regular inline-block font-semibold">
           Diese Seite existiert nicht

--- a/frontend/src/layouts/base.vue
+++ b/frontend/src/layouts/base.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import AppFooter from "@/components/AppFooter.vue";
+import ConsentBanner from "~/components/Analytics/ConsentBanner.vue";
+import AppHeader from "@/components/AppHeader.vue";
+import NavbarTop from "@/components/NavbarTop.vue";
+import { isPublicProfile, isPrototypeProfile } from "@/utils/config";
+import AppFooterPrototype from "~/components/AppFooterPrototype.vue";
+/* v8 ignore start */
+const isPublic = isPublicProfile();
+const isPrototype = isPrototypeProfile();
+const showPublicProfileHeader = isPublic || isPrototype;
+/* v8 ignore stop */
+</script>
+
+<template>
+  <client-only>
+    <ConsentBanner />
+  </client-only>
+  <div class="flex flex-col gap-48">
+    <div class="min-h-[50vh] bg-gray-100">
+      <AppHeader v-if="showPublicProfileHeader" />
+      <NavbarTop v-else />
+      <slot />
+    </div>
+    <AppFooterPrototype v-if="true" />
+    <AppFooter v-else />
+  </div>
+</template>

--- a/frontend/src/layouts/default.vue
+++ b/frontend/src/layouts/default.vue
@@ -1,30 +1,16 @@
 <script setup lang="ts">
-import AppFooter from "@/components/AppFooter.vue";
-import ConsentBanner from "~/components/Analytics/ConsentBanner.vue";
-import AppHeader from "@/components/AppHeader.vue";
-import NavbarTop from "@/components/NavbarTop.vue";
-import { isPublicProfile, isPrototypeProfile } from "@/utils/config";
-import AppFooterPrototype from "~/components/AppFooterPrototype.vue";
-/* v8 ignore start */
-const isPublic = isPublicProfile();
-const isPrototype = isPrototypeProfile();
-const showPublicProfileHeader = isPublic || isPrototype;
-/* v8 ignore stop */
+/*
+The default layout provides a container, but uses the base layout, which
+provides header and footer elements.
+Pages that need to use full-width ("hero style") elements should use the base
+layout directly.
+*/
+import BaseLayout from "./base.vue";
 </script>
-
 <template>
-  <client-only>
-    <ConsentBanner />
-  </client-only>
-  <div class="flex flex-col gap-48">
-    <div class="min-h-[50vh] bg-gray-100">
-      <AppHeader v-if="showPublicProfileHeader" />
-      <NavbarTop v-else />
-      <div class="container md:mx-auto">
-        <slot />
-      </div>
+  <BaseLayout>
+    <div class="container md:mx-auto">
+      <slot />
     </div>
-    <AppFooterPrototype v-if="true" />
-    <AppFooter v-else />
-  </div>
+  </BaseLayout>
 </template>

--- a/frontend/src/pages/case-law/[documentNumber]/index.vue
+++ b/frontend/src/pages/case-law/[documentNumber]/index.vue
@@ -45,6 +45,8 @@ const { data: html, error: contentError } = await useFetch<string>(
 
 useHead({ title: caseLaw.value?.fileNumbers?.[0] });
 
+definePageMeta({ layout: "base" }); // use "base" layout to allow for full-width tab backgrounds
+
 const tocEntries: ComputedRef<TableOfContentsEntry[] | null> = computed(() => {
   return html.value ? getAllSectionsFromHtml(html.value, "section") : null;
 });
@@ -68,8 +70,8 @@ if (contentError?.value) {
 
 <template>
   <ContentWrapper border>
-    <div v-if="status == 'pending'">Lade ...</div>
-    <div v-if="!!caseLaw" class="text-left">
+    <div v-if="status == 'pending'" class="container">Lade ...</div>
+    <div v-if="!!caseLaw" class="container text-left">
       <div class="flex items-center gap-8 print:hidden">
         <RisBreadcrumb
           class="grow"
@@ -115,65 +117,62 @@ if (contentError?.value) {
           :value="caseLaw.fileNumbers?.join(', ')"
         />
       </div>
+    </div>
+    <Tabs v-if="!!caseLaw" value="0">
+      <TabList :pt="tabListStyles">
+        <Tab
+          class="flex items-center gap-8"
+          :pt="tabStyles"
+          value="0"
+          aria-label="Text der Gerichtsentscheidung"
+          ><IcBaselineSubject />Text</Tab
+        >
+        <Tab
+          data-attr="caselaw-metadata-tab"
+          class="flex items-center gap-8"
+          :pt="tabStyles"
+          value="1"
+          aria-label="Details zur Gerichtsentscheidung"
+          ><IcOutlineInfo />Details</Tab
+        >
+      </TabList>
+      <TabPanels>
+        <TabPanel value="0" :pt="tabPanelStyles">
+          <!-- Content -->
+          <SidebarLayout class="container">
+            <template #content>
+              <IncompleteDataMessage class="mb-16" />
+              <main class="case-law" v-html="html"></main>
+            </template>
+            <template #sidebar>
+              <client-only>
+                <TableOfContents :table-of-content-entries="tocEntries || []" />
+              </client-only>
+            </template>
+          </SidebarLayout>
+        </TabPanel>
+        <TabPanel value="1" :pt="tabPanelStyles" class="pt-24 pb-80">
+          <section aria-labelledby="detailsTabPanelTitle" class="container">
+            <h2 id="detailsTabPanelTitle" class="ris-heading3-bold my-24">
+              Details
+            </h2>
+            <IncompleteDataMessage class="my-24" />
 
-      <Tabs value="0">
-        <TabList :pt="tabListStyles">
-          <Tab
-            class="flex items-center gap-8"
-            :pt="tabStyles"
-            value="0"
-            aria-label="Text der Gerichtsentscheidung"
-            ><IcBaselineSubject />Text</Tab
-          >
-          <Tab
-            data-attr="caselaw-metadata-tab"
-            class="flex items-center gap-8"
-            :pt="tabStyles"
-            value="1"
-            aria-label="Details zur Gerichtsentscheidung"
-            ><IcOutlineInfo />Details</Tab
-          >
-        </TabList>
-        <TabPanels>
-          <TabPanel value="0" :pt="tabPanelStyles">
-            <!-- Content -->
-            <SidebarLayout>
-              <template #content>
-                <IncompleteDataMessage class="mb-16" />
-                <main class="case-law" v-html="html"></main>
-              </template>
-              <template #sidebar>
-                <client-only>
-                  <TableOfContents
-                    :table-of-content-entries="tocEntries || []"
-                  />
-                </client-only>
-              </template>
-            </SidebarLayout>
-          </TabPanel>
-          <TabPanel value="1" :pt="tabPanelStyles" class="pt-24 pb-80">
-            <section aria-labelledby="detailsTabPanelTitle">
-              <h2 id="detailsTabPanelTitle" class="ris-heading3-bold my-24">
-                Details
-              </h2>
-              <IncompleteDataMessage class="my-24" />
-
-              <Properties>
-                <PropertiesItem
-                  label="Spruchkörper:"
-                  :value="caseLaw.judicialBody"
-                />
-                <PropertiesItem label="ECLI:" :value="caseLaw.ecli" />
-                <PropertiesItem label="Normen:" value="" />
-                <PropertiesItem
-                  label="Entscheidungsname:"
-                  :value="caseLaw.decisionName?.join(', ')"
-                />
-                <PropertiesItem label="Vorinstanz:" value="" />
-              </Properties>
-            </section>
-          </TabPanel>
-        </TabPanels>
-      </Tabs></div
+            <Properties>
+              <PropertiesItem
+                label="Spruchkörper:"
+                :value="caseLaw.judicialBody"
+              />
+              <PropertiesItem label="ECLI:" :value="caseLaw.ecli" />
+              <PropertiesItem label="Normen:" value="" />
+              <PropertiesItem
+                label="Entscheidungsname:"
+                :value="caseLaw.decisionName?.join(', ')"
+              />
+              <PropertiesItem label="Vorinstanz:" value="" />
+            </Properties>
+          </section>
+        </TabPanel>
+      </TabPanels> </Tabs
   ></ContentWrapper>
 </template>

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -1,16 +1,17 @@
 <script setup lang="ts">
 import SimpleSearchInput from "@/components/Search/SimpleSearch/SimpleSearchInput.vue";
 import { useRedirectToSearch } from "@/composables/useRedirectToSearch";
-import HeroBanner from "~/components/HeroBanner.vue";
 import Message from "primevue/message";
 import IcBaselineLaunch from "~icons/ic/baseline-launch";
 import ButtonLink from "~/components/ButtonLink.vue";
 import bmjvLogo from "~/assets/img/BMJV_de_v1__Web_farbig.svg";
 const redirectToSearch = useRedirectToSearch();
+
+definePageMeta({ layout: "base" });
 </script>
 
 <template>
-  <HeroBanner class="flex gap-16 bg-blue-800 pt-64 pb-96 text-white">
+  <div class="flex gap-16 bg-blue-800 pt-64 pb-96 text-white">
     <div class="container md:max-w-(--spacing-prose)">
       <div
         class="mb-8 inline-block rounded-[3px] border border-[#FFFFFF1A] bg-blue-700 px-8 py-4 text-sm font-bold uppercase"
@@ -26,7 +27,7 @@ const redirectToSearch = useRedirectToSearch();
         Bundes – an einem zentralen Ort.
       </p>
     </div>
-  </HeroBanner>
+  </div>
   <div class="my-56 flex flex-col gap-24 pb-48">
     <FeatureCard>
       <div>

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/[eId].vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/[eId].vue
@@ -22,6 +22,7 @@ definePageMeta({
   // plus the article eId
   alias:
     "/eli/:jurisdiction/:agent/:year/:naturalIdentifier/:pointInTime/:version/:language/:subtype/:eId",
+  layout: "base", // use "base" layout to allow for full-width text background
 });
 
 const route = useRoute();
@@ -111,30 +112,33 @@ useHead({ title: article.value?.name });
 
 <template>
   <ContentWrapper border>
-    <div v-if="status == 'pending'">Lade ...</div>
+    <div v-if="status == 'pending'" class="container">Lade ...</div>
     <template v-if="!!norm">
-      <RisBreadcrumb
-        type="norm"
-        :items="items"
-        :title="normBreadcrumbTitle"
-        :base-path="normPath"
-      />
-      <div class="max-w-prose">
-        <NuxtLink
-          class="ris-heading3-bold link-hover mt-24 line-clamp-2 items-center text-blue-800"
-          :to="normPath"
-          ><MdiArrowTopLeft class="inline-block" />
-          {{ norm.name || norm.alternateName }}</NuxtLink
-        >
-        <h2
-          class="ris-heading2-bold my-24 mb-24 inline-block"
-          v-html="htmlTitle"
+      <div class="container">
+        <RisBreadcrumb
+          type="norm"
+          :items="items"
+          :title="normBreadcrumbTitle"
+          :base-path="normPath"
         />
+        <div class="max-w-prose">
+          <NuxtLink
+            class="ris-heading3-bold link-hover mt-24 line-clamp-2 items-center text-blue-800"
+            :to="normPath"
+            ><MdiArrowTopLeft class="inline-block" />
+            {{ norm.name || norm.alternateName }}</NuxtLink
+          >
+          <h2
+            class="ris-heading2-bold my-24 mb-24 inline-block"
+            v-html="htmlTitle"
+          />
+        </div>
       </div>
+
       <!-- Metadata -->
       <div
         v-if="!!article && showNormArticleStatus"
-        class="mb-24 flex flex-col space-y-16 space-x-0 md:space-y-0 lg:flex-row lg:space-x-24"
+        class="container mb-24 flex flex-col space-y-16 space-x-0 md:space-y-0 lg:flex-row lg:space-x-24"
         data-testid="metadata"
       >
         <MetadataField
@@ -160,55 +164,57 @@ useHead({ title: article.value?.name });
           :value="formattedDate(article.expiryDate)"
         />
       </div>
-      <TableOfContentsLayout class="portal-fullwidth-white separator py-24">
-        <template v-if="!!articleHtml" #content>
-          <IncompleteDataMessage />
-          <main class="single-article akn-act" v-html="articleHtml" />
-          <div class="flex flex-row justify-between">
-            <div class="flex flex-col">
-              <router-link
-                v-if="previousArticleUrl"
-                :to="previousArticleUrl"
-                class="text-blue-800 hover:underline"
-              >
-                <div class="flex items-center space-x-8">
-                  <IcBaselineArrowBack class="mt-1 shrink-0" />
-                  <span>Vorheriger Paragraf</span>
-                </div>
-              </router-link>
+      <div class="border-t border-gray-600 bg-white">
+        <TableOfContentsLayout class="container py-24">
+          <template v-if="!!articleHtml" #content>
+            <IncompleteDataMessage />
+            <main class="single-article akn-act" v-html="articleHtml" />
+            <div class="flex flex-row justify-between">
+              <div class="flex flex-col">
+                <router-link
+                  v-if="previousArticleUrl"
+                  :to="previousArticleUrl"
+                  class="text-blue-800 hover:underline"
+                >
+                  <div class="flex items-center space-x-8">
+                    <IcBaselineArrowBack class="mt-1 shrink-0" />
+                    <span>Vorheriger Paragraf</span>
+                  </div>
+                </router-link>
+              </div>
+              <div class="flex flex-col">
+                <router-link
+                  v-if="nextArticleUrl"
+                  :to="nextArticleUrl"
+                  class="text-blue-800 hover:underline"
+                >
+                  <div class="flex items-center space-x-8">
+                    <span>Nächster Paragraf</span>
+                    <IcBaselineArrowForward class="mt-1 shrink-0" />
+                  </div>
+                </router-link>
+              </div>
             </div>
-            <div class="flex flex-col">
-              <router-link
-                v-if="nextArticleUrl"
-                :to="nextArticleUrl"
-                class="text-blue-800 hover:underline"
-              >
-                <div class="flex items-center space-x-8">
-                  <span>Nächster Paragraf</span>
-                  <IcBaselineArrowForward class="mt-1 shrink-0" />
-                </div>
-              </router-link>
-            </div>
-          </div>
-        </template>
-        <template #sidebar>
-          <NormTableOfContents
-            v-if="norm.workExample.tableOfContents.length > 0"
-            :table-of-contents="tableOfContents"
-            :selected-key="eId"
-          >
-            <template #header>
-              <router-link
-                v-if="normTitle"
-                :to="normPath"
-                class="link-hover font-bold text-blue-800"
-              >
-                {{ normTitle }}
-              </router-link>
-            </template>
-          </NormTableOfContents>
-        </template>
-      </TableOfContentsLayout>
+          </template>
+          <template #sidebar>
+            <NormTableOfContents
+              v-if="norm.workExample.tableOfContents.length > 0"
+              :table-of-contents="tableOfContents"
+              :selected-key="eId"
+            >
+              <template #header>
+                <router-link
+                  v-if="normTitle"
+                  :to="normPath"
+                  class="link-hover font-bold text-blue-800"
+                >
+                  {{ normTitle }}
+                </router-link>
+              </template>
+            </NormTableOfContents>
+          </template>
+        </TableOfContentsLayout>
+      </div>
     </template></ContentWrapper
   >
 </template>

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
@@ -43,6 +43,7 @@ definePageMeta({
   // note: this is an expression ELI that additionally specifies the subtype component of a manifestation ELI
   alias:
     "/eli/:jurisdiction/:agent/:year/:naturalIdentifier/:pointInTime/:version/:language/:subtype",
+  layout: "base", // use "base" layout to allow for full-width tab backgrounds
 });
 
 const route = useRoute();
@@ -131,43 +132,44 @@ const breadcrumbItems: ComputedRef<BreadcrumbItem[]> = computed(() => {
   <ContentWrapper border>
     <div v-if="status == 'pending'">Lade ...</div>
     <div v-if="!!metadata">
-      <div class="flex items-center gap-8 print:hidden">
-        <RisBreadcrumb type="norm" :items="breadcrumbItems" class="grow" />
-        <FileActionsMenu :xml-url="xmlUrl" />
-      </div>
-      <NormHeadingGroup :metadata="metadata" :html-parts="htmlParts" />
+      <div class="container">
+        <div class="flex items-center gap-8 print:hidden">
+          <RisBreadcrumb type="norm" :items="breadcrumbItems" class="grow" />
+          <FileActionsMenu :xml-url="xmlUrl" />
+        </div>
+        <NormHeadingGroup :metadata="metadata" :html-parts="htmlParts" />
 
-      <VersionWarningMessage
-        v-if="normVersionsStatus === 'success'"
-        :versions="normVersions"
-        :current-expression="metadata.workExample.legislationIdentifier"
-      />
-      <div class="mt-8 mb-48 flex flex-wrap items-end gap-24">
-        <MetadataField
-          v-if="metadata.abbreviation"
-          id="abbreviation"
-          label="Abkürzung"
-          :value="metadata.abbreviation"
+        <VersionWarningMessage
+          v-if="normVersionsStatus === 'success'"
+          :versions="normVersions"
+          :current-expression="metadata.workExample.legislationIdentifier"
         />
-        <MetadataField
-          id="status"
-          label="Status"
-          :value="translatedLegalForce"
-        />
-        <MetadataField
-          v-if="temporalCoverage[0]"
-          id="validFrom"
-          label="Fassung gültig seit"
-          :value="temporalCoverage[0]"
-        />
-        <MetadataField
-          v-if="temporalCoverage[1]"
-          id="validTo"
-          label="Fassung gültig bis"
-          :value="temporalCoverage[1]"
-        />
+        <div class="mt-8 mb-48 flex flex-wrap items-end gap-24">
+          <MetadataField
+            v-if="metadata.abbreviation"
+            id="abbreviation"
+            label="Abkürzung"
+            :value="metadata.abbreviation"
+          />
+          <MetadataField
+            id="status"
+            label="Status"
+            :value="translatedLegalForce"
+          />
+          <MetadataField
+            v-if="temporalCoverage[0]"
+            id="validFrom"
+            label="Fassung gültig seit"
+            :value="temporalCoverage[0]"
+          />
+          <MetadataField
+            v-if="temporalCoverage[1]"
+            id="validTo"
+            label="Fassung gültig bis"
+            :value="temporalCoverage[1]"
+          />
+        </div>
       </div>
-
       <Tabs value="0" lazy>
         <TabList :pt="tabListStyles">
           <Tab
@@ -202,7 +204,7 @@ const breadcrumbItems: ComputedRef<BreadcrumbItem[]> = computed(() => {
         </TabList>
         <TabPanels>
           <TabPanel value="0" :pt="tabPanelStyles">
-            <TableOfContentsLayout>
+            <TableOfContentsLayout class="container">
               <template #content>
                 <IncompleteDataMessage />
                 <Accordion
@@ -224,7 +226,7 @@ const breadcrumbItems: ComputedRef<BreadcrumbItem[]> = computed(() => {
             </TableOfContentsLayout>
           </TabPanel>
           <TabPanel value="1" :pt="tabPanelStyles" class="pt-24 pb-80">
-            <section aria-labelledby="detailsTabPanelTitle">
+            <section aria-labelledby="detailsTabPanelTitle" class="container">
               <h2 id="detailsTabPanelTitle" class="ris-heading3-bold my-24">
                 Details
               </h2>
@@ -280,6 +282,7 @@ const breadcrumbItems: ComputedRef<BreadcrumbItem[]> = computed(() => {
             class="pt-24 pb-80"
           >
             <NormVersionList
+              class="container"
               :status="normVersionsStatus"
               :versions="normVersions"
             />


### PR DESCRIPTION
Using the previous solution,
```css
left: 50%; transform: translateX(-50%);
```
caused overflow problems in Windows browsers.

This PR adds a new full-width layout so that certain pages can use the whole space without CSS overlay hacks.