### PR TITLE
Downgrade current-version error

### DIFF
--- a/frontend/src/components/Norm/VersionWarningMessage.vue
+++ b/frontend/src/components/Norm/VersionWarningMessage.vue
@@ -32,9 +32,10 @@ const currentVersion: ComputedRef<SearchResult<LegislationWork> | undefined> =
         props.currentExpression,
     );
     if (!current)
-      showError({
-        statusMessage: `The provided current expression (${props.currentExpression}) does not exist in the provided versions`,
-      });
+      console.warn(
+        `The provided current expression (${props.currentExpression}) does not exist in the provided list`,
+        props.versions,
+      );
     return current;
   });
 


### PR DESCRIPTION
Log a warning only, but don't prevent rendering of the page if the current version is not found in the list of versions.

This might happen if more versions exist than are requested in the API call, as currently happens with StGB (the default limit is 100).