### PR TITLE
Add loading indicator

### DIFF
--- a/frontend/src/layouts/base.vue
+++ b/frontend/src/layouts/base.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { NuxtLoadingIndicator } from "#components";
 import AppFooter from "@/components/AppFooter.vue";
 import ConsentBanner from "~/components/Analytics/ConsentBanner.vue";
 import AppHeader from "@/components/AppHeader.vue";
@@ -13,6 +14,10 @@ const showPublicProfileHeader = isPublic || isPrototype;
 </script>
 
 <template>
+  <NuxtLoadingIndicator
+    :color="false"
+    class="bg-linear-to-r from-blue-900 to-blue-500"
+  />
   <client-only>
     <ConsentBanner />
   </client-only>


### PR DESCRIPTION
This enables the NuxtLoadingIndicator to indicate that a page is loading after a navigation action.

To see it in action, you may add a delay to `api/[...].ts`:

```ts
function delay(timeout: number = 1000): Promise<void> {
  return new Promise((resolve) => setTimeout(resolve, timeout));
}

export default defineEventHandler(async (event): Promise<unknown> => {
  await delay(1000);
  ...
}
```
