### PR TITLE
RISDEV-6886 display title of xml attachments

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/Attachment.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/Attachment.java
@@ -1,7 +1,12 @@
 package de.bund.digitalservice.ris.search.models;
 
 import lombok.Builder;
+import org.springframework.lang.Nullable;
 
 @Builder
 public record Attachment(
-    String marker, String docTitle, String eId, String textContent, String manifestationEli) {}
+    @Nullable String marker,
+    @Nullable String docTitle,
+    String eId,
+    String textContent,
+    String manifestationEli) {}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/XmlDocument.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/XmlDocument.java
@@ -58,9 +58,12 @@ public class XmlDocument {
   }
 
   public Optional<Node> getFirstMatchedNodeByXpath(String xpath) {
+    return getFirstMatchedNodeByXpath(xpath, document);
+  }
+
+  public Optional<Node> getFirstMatchedNodeByXpath(String xpath, Node item) {
     try {
-      return Optional.ofNullable(
-          (Node) xpathInstance.evaluate(xpath, document, XPathConstants.NODE));
+      return Optional.ofNullable((Node) xpathInstance.evaluate(xpath, item, XPathConstants.NODE));
     } catch (XPathExpressionException e) {
       return Optional.empty();
     }

--- a/backend/src/main/resources/XSLT/html/ldml_de/ris-portal.xsl
+++ b/backend/src/main/resources/XSLT/html/ldml_de/ris-portal.xsl
@@ -239,15 +239,15 @@
     -->
 
     <!-- Handle individual attachment -->
-    <xsl:template match="akn:attachment[@showAs='offene-struktur']" name="attachment">
-        <div class="attachment">
+    <xsl:template match="akn:attachment" name="attachment">
+        <div class="akn-attachment" id="{@eId}">
             <xsl:apply-templates/>
         </div>
     </xsl:template>
 
     <!-- Handle document references -->
     <xsl:template match="akn:documentRef">
-        <div class="included-document">
+        <div class="included-document" data-source="{@href}">
             <xsl:try>
                 <!-- Include referenced document -->
                 <xsl:apply-templates select="document(@href)/akn:akomaNtoso/*">
@@ -267,16 +267,23 @@
             <xsl:when test="not($is-single-article)">
                 <a href="{concat($dokumentpfad, '/', akn:encode-for-uri($attachment-eId))}">
                     <h2 class="{$einzelvorschrift}">
-                        Anlage <xsl:apply-templates/>
+                        <xsl:apply-templates/>
                     </h2>
                 </a>
             </xsl:when>
             <xsl:otherwise>
                 <h2 class="{$einzelvorschrift}">
-                    Anlage <xsl:apply-templates/>
+                    <xsl:apply-templates/>
                 </h2>
             </xsl:otherwise>
         </xsl:choose>
+    </xsl:template>
+
+    <!-- Insert space between attachment number and "Bezug" -->
+    <xsl:template
+            match="akn:inline[@refersTo='anlageregelungstext-num' and following-sibling::akn:inline[@refersTo='anlageregelungstext-bezug']]">
+        <span id="{@eId}" class="anlageregelungstext-num"><xsl:value-of select="text()"/></span>
+        <xsl:text> </xsl:text>
     </xsl:template>
 
     <!-- Handle attachments without preface (and therefore lacking a title) -->

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/NormLdmlToOpenSearchMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/NormLdmlToOpenSearchMapperTest.java
@@ -186,7 +186,7 @@ class NormLdmlToOpenSearchMapperTest {
     assertThat(attachment)
         .isEqualTo(
             new Article(
-                "Anlage (zu § 1) Testanlage",
+                "Anlage T1 (zu § 1)",
                 "This text appears in the attachment. This text also appears, inside a paragraph.",
                 null,
                 null,
@@ -215,8 +215,7 @@ class NormLdmlToOpenSearchMapperTest {
                 new TableOfContentsItem("preambel-1_formel-1", "", "Eingangsformel", List.of()),
                 new TableOfContentsItem("hauptteil-1_art-1", "§ 1", "", List.of()),
                 new TableOfContentsItem("schluss-1_formel-1", "", "Schlussformel", List.of()),
-                new TableOfContentsItem(
-                    "anlagen-1_anlage-1", "Anlage", "(zu § 1) Testanlage", List.of())));
+                new TableOfContentsItem("anlagen-1_anlage-1", "Anlage T1", "(zu § 1)", List.of())));
   }
 
   List<TableOfContentsItem> expectedToC =

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/XsltTransformerServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/XsltTransformerServiceTest.java
@@ -59,7 +59,7 @@ class XsltTransformerServiceTest {
     "blockList.xml, blockList.html, Should transform a blockList",
     "preformatted.xml, preformatted.html, Should transform preformatted paragraphs",
     "proprietary.xml, proprietary.html, Should transform proprietary metadata",
-    "offenestruktur-without-title.xml, offenestruktur-without-title.html, Should transform an attachment without title",
+    "anlage-regelungstext-without-title.xml, anlage-regelungstext-without-title.html, Should transform an attachment without title",
   })
   void testTransformNormLegalDocMlFull(
       String inputFileName, String expectedFileName, String testName) throws IOException {
@@ -90,12 +90,12 @@ class XsltTransformerServiceTest {
 
     Mockito.when(
             normsBucketMock.getStream(
-                "eli/bund/bgbl-1/0000/s1000/2000-01-01/1/deu/2000-01-01/offenestruktur-1.xml"))
-        .thenReturn(makeInputStream.apply("offenestruktur-1.xml"));
+                "eli/bund/bgbl-1/0000/s1000/2000-01-01/1/deu/2000-01-01/anlage-regelungstext-1.xml"))
+        .thenReturn(makeInputStream.apply("anlage-regelungstext-1.xml"));
     Mockito.when(
             normsBucketMock.getStream(
-                "eli/bund/bgbl-1/0000/s1000/2000-01-01/1/deu/2000-01-01/offenestruktur-2.xml"))
-        .thenReturn(makeInputStream.apply("offenestruktur-2.xml"));
+                "eli/bund/bgbl-1/0000/s1000/2000-01-01/1/deu/2000-01-01/anlage-regelungstext-2.xml"))
+        .thenReturn(makeInputStream.apply("anlage-regelungstext-2.xml"));
 
     var actualHtml = service.transformNorm(bytes, "subtype", RESOURCES_BASE_PATH);
 
@@ -108,13 +108,15 @@ class XsltTransformerServiceTest {
   @Test
   void testHandlesMissingAttachment() throws IOException {
     Mockito.reset(normsBucketMock);
+    // same file as in testTransformNormWithAttachments, but normsBucketMock isn't set up to serve
+    // included files
     byte[] bytes = Files.readAllBytes(Path.of(resourcesPath, "attachments.xml"));
 
     FileTransformationException exception =
         Assertions.assertThrows(
             FileTransformationException.class,
             () -> service.transformNorm(bytes, "subtype", RESOURCES_BASE_PATH));
-    assertThat(exception.getMessage()).endsWith("offenestruktur-1.xml");
+    assertThat(exception.getMessage()).endsWith("anlage-regelungstext-1.xml");
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/utils/XmlDocumentTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/utils/XmlDocumentTest.java
@@ -41,6 +41,16 @@ class XmlDocumentTest {
   }
 
   @Test
+  void testFirstMatchedNodeNested() throws ParserConfigurationException, IOException, SAXException {
+    String xml = "<xml><test><text>Test</text></test></xml>";
+    XmlDocument xmlDocument = new XmlDocument(xml.getBytes());
+    Optional<Node> parent = xmlDocument.getFirstMatchedNodeByXpath("/xml/test");
+    Optional<Node> nested =
+        xmlDocument.getFirstMatchedNodeByXpath(".//*[local-name()='text']", parent.orElseThrow());
+    Assertions.assertEquals("Test", nested.orElseThrow().getTextContent());
+  }
+
+  @Test
   void testFirstMatchedNodeNullpointerReturnsEmptyOption()
       throws ParserConfigurationException, IOException, SAXException {
     String xml = "<xml><test><text>Test</text></test></xml>";

--- a/backend/src/test/resources/data/XsltTransformerServiceTest/anlage-regelungstext-1.xml
+++ b/backend/src/test/resources/data/XsltTransformerServiceTest/anlage-regelungstext-1.xml
@@ -3,11 +3,16 @@
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://Inhaltsdaten.LegalDocML.de/1.8.1/ Grammatiken/legalDocML.de-offenestruktur.xsd">
     <akn:doc name="offene-struktur">
-        <akn:preface eId="einleitung-1">
-            <akn:block eId="einleitung-1_block-1"
-                       name="attributsemantik-noch-undefiniert">
-                <akn:docTitle eId="einleitung-1_block-1_doctitel-1">
-                    (Title part of offenestruktur-1.xml)
+        <akn:preface eId="einleitung-n1">
+            <akn:block eId="einleitung-n1_block-n1" name="attributsemantik-noch-undefiniert">
+                <akn:docTitle eId="einleitung-n1_block-n1_doctitel-n1">
+                    <akn:inline eId="einleitung-n1_block-n1_doctitel-n1_inline-n1"
+                                name="attributsemantik-noch-undefiniert" refersTo="anlageregelungstext-num"
+                    >Attachment 1</akn:inline>
+                    <akn:inline eId="einleitung-n1_block-n1_doctitel-n1_inline-n2"
+                                name="attributsemantik-noch-undefiniert" refersTo="anlageregelungstext-bezug">That Which
+                        Attachment 1 Refers To
+                    </akn:inline>
                 </akn:docTitle>
             </akn:block>
         </akn:preface>

--- a/backend/src/test/resources/data/XsltTransformerServiceTest/anlage-regelungstext-2.xml
+++ b/backend/src/test/resources/data/XsltTransformerServiceTest/anlage-regelungstext-2.xml
@@ -3,11 +3,11 @@
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://Inhaltsdaten.LegalDocML.de/1.8.1/ Grammatiken/legalDocML.de-offenestruktur.xsd">
     <akn:doc name="offene-struktur">
-        <akn:preface eId="einleitung-1">
-            <akn:block eId="einleitung-1_block-1"
-                       name="attributsemantik-noch-undefiniert">
-                <akn:docTitle eId="einleitung-1_block-1_doctitel-1">
-                    (Title part of offenestruktur-2.xml)
+        <akn:preface eId="einleitung-n2">
+            <akn:block eId="einleitung-n2_block-n1" name="attributsemantik-noch-undefiniert">
+                <akn:docTitle eId="einleitung-n2_block-n1_doctitel-n1">
+                    <akn:inline eId="einleitung-n2_block-n1_doctitel-n1_inline-n1" name="attributsemantik-noch-undefiniert" refersTo="anlageregelungstext-num">Attachment 2</akn:inline>
+                    <akn:inline eId="einleitung-n2_block-n1_doctitel-n1_inline-n2" name="attributsemantik-noch-undefiniert" refersTo="anlageregelungstext-bezug">That Which Attachment 2 Refers To</akn:inline>
                 </akn:docTitle>
             </akn:block>
         </akn:preface>

--- a/backend/src/test/resources/data/XsltTransformerServiceTest/anlage-regelungstext-without-title.html
+++ b/backend/src/test/resources/data/XsltTransformerServiceTest/anlage-regelungstext-without-title.html
@@ -2,6 +2,6 @@
   <a href="subtype/">
     <h2 class="einzelvorschrift">Anlage</h2></a>
   <div class="akn-mainBody" id="hauptteil-1">
-    <p id="hauptteil-1_text-1">Contents of offenestruktur-without-title.xml</p>
+    <p id="hauptteil-1_text-1">Contents of anlage-regelungstext-without-title.xml</p>
   </div>
 </div>

--- a/backend/src/test/resources/data/XsltTransformerServiceTest/anlage-regelungstext-without-title.xml
+++ b/backend/src/test/resources/data/XsltTransformerServiceTest/anlage-regelungstext-without-title.xml
@@ -5,7 +5,7 @@
     <akn:doc name="offene-struktur">
         <akn:mainBody eId="hauptteil-1">
             <akn:p eId="hauptteil-1_text-1">
-                Contents of offenestruktur-without-title.xml
+                Contents of anlage-regelungstext-without-title.xml
             </akn:p>
         </akn:mainBody>
     </akn:doc>

--- a/backend/src/test/resources/data/XsltTransformerServiceTest/attachments.html
+++ b/backend/src/test/resources/data/XsltTransformerServiceTest/attachments.html
@@ -4,14 +4,15 @@
       <h2 class="einzelvorschrift"></h2></a> Main article
   </article>
 </div>
-<div class="akn-attachments" id="anlagen-1">
-  <div class="akn-attachment" id="anlagen-1_anlage-1">
-    <div class="included-document">
+<div class="akn-attachments" id="anlagen-n1">
+  <div class="akn-attachment" id="anlagen-n1_anlage-n1">
+    <div class="included-document"
+         data-source="eli/bund/bgbl-1/0000/s1000/2000-01-01/1/deu/2000-01-01/anlage-regelungstext-1.xml">
       <div class="akn-doc" data-name="offene-struktur">
-        <section class="dokumentenkopf" id="einleitung-1">
-          <div id="einleitung-1_block-1">
-            <a href="subtype/anlagen-1_anlage-1">
-              <h2 class="einzelvorschrift">Anlage (Title part of offenestruktur-1.xml)</h2></a>
+        <section class="dokumentenkopf" id="einleitung-n1">
+          <div id="einleitung-n1_block-n1">
+            <a href="subtype/anlagen-n1_anlage-n1">
+              <h2 class="einzelvorschrift"><span id="einleitung-n1_block-n1_doctitel-n1_inline-n1" class="anlageregelungstext-num">Attachment 1</span> <span id="einleitung-n1_block-n1_doctitel-n1_inline-n2" class="anlageregelungstext-bezug">That Which Attachment 1 Refers To </span></h2></a>
           </div>
         </section>
         <div class="akn-mainBody" id="hauptteil-1">
@@ -19,13 +20,14 @@
       </div>
     </div>
   </div>
-  <div class="akn-attachment" id="anlagen-1_anlage-2">
-    <div class="included-document">
+  <div class="akn-attachment" id="anlagen-n1_anlage-n2">
+    <div class="included-document"
+         data-source="eli/bund/bgbl-1/0000/s1000/2000-01-01/1/deu/2000-01-01/anlage-regelungstext-2.xml">
       <div class="akn-doc" data-name="offene-struktur">
-        <section class="dokumentenkopf" id="einleitung-1">
-          <div id="einleitung-1_block-1">
-            <a href="subtype/anlagen-1_anlage-2">
-              <h2 class="einzelvorschrift">Anlage (Title part of offenestruktur-2.xml)</h2></a>
+        <section class="dokumentenkopf" id="einleitung-n2">
+          <div id="einleitung-n2_block-n1">
+            <a href="subtype/anlagen-n1_anlage-n2">
+              <h2 class="einzelvorschrift"><span id="einleitung-n2_block-n1_doctitel-n1_inline-n1" class="anlageregelungstext-num">Attachment 2</span> <span id="einleitung-n2_block-n1_doctitel-n1_inline-n2" class="anlageregelungstext-bezug">That Which Attachment 2 Refers To</span></h2></a>
           </div>
         </section>
         <div class="akn-mainBody" id="hauptteil-1">

--- a/backend/src/test/resources/data/XsltTransformerServiceTest/attachments.xml
+++ b/backend/src/test/resources/data/XsltTransformerServiceTest/attachments.xml
@@ -4,16 +4,12 @@
             Main article
         </akn:article>
     </akn:body>
-    <akn:attachments eId="anlagen-1">
-    <akn:attachment eId="anlagen-1_anlage-1">
-        <akn:documentRef eId="anlagen-1_anlage-1_verweis-1"
-                         href="eli/bund/bgbl-1/0000/s1000/2000-01-01/1/deu/2000-01-01/offenestruktur-1.xml"
-                         showAs="offene-struktur"/>
-    </akn:attachment>
-    <akn:attachment eId="anlagen-1_anlage-2">
-        <akn:documentRef eId="anlagen-1_anlage-2_verweis-1"
-                         href="eli/bund/bgbl-1/0000/s1000/2000-01-01/1/deu/2000-01-01/offenestruktur-2.xml"
-                         showAs="offene-struktur"/>
-    </akn:attachment>
+    <akn:attachments eId="anlagen-n1">
+        <akn:attachment eId="anlagen-n1_anlage-n1">
+            <akn:documentRef eId="anlagen-n1_anlage-n1_verweis-n1" href="eli/bund/bgbl-1/0000/s1000/2000-01-01/1/deu/2000-01-01/anlage-regelungstext-1.xml" showAs="/akn/ontology/de/concept/documenttype/bund/anlage-regelungstext"/>
+        </akn:attachment>
+        <akn:attachment eId="anlagen-n1_anlage-n2">
+            <akn:documentRef eId="anlagen-n1_anlage-n2_verweis-n1" href="eli/bund/bgbl-1/0000/s1000/2000-01-01/1/deu/2000-01-01/anlage-regelungstext-2.xml" showAs="/akn/ontology/de/concept/documenttype/bund/anlage-regelungstext"/>
+        </akn:attachment>
     </akn:attachments>
 </akn:akomaNtoso>

--- a/backend/src/test/resources/data/xmlTests/offenestruktur-1.xml
+++ b/backend/src/test/resources/data/xmlTests/offenestruktur-1.xml
@@ -75,9 +75,7 @@
         <akn:preface GUID="ca78411a-6a8a-4779-9958-f88fc48efbf7" eId="einleitung-1">
             <akn:block GUID="5f317c6b-a602-4e33-a85c-7c2fe1ec4060" eId="einleitung-1_block-1"
                        name="attributsemantik-noch-undefiniert">
-                <akn:docTitle GUID="d2495261-77bf-4e93-bfa0-f9eefee750a6" eId="einleitung-1_block-1_doctitel-1">
-                    (zu § 1)<akn:br eId="einleitung-1_block-1_doctitel-1_br-1"/>Testanlage
-                </akn:docTitle>
+                <akn:docTitle GUID="d2495261-77bf-4e93-bfa0-f9eefee750a6" eId="einleitung-1_block-1_doctitel-1"><akn:inline GUID="dff9e31d-d9a6-442f-a28a-9899fb5d9b01" eId="einleitung-n1_block-n1_doctitel-n1_inline-n1" name="attributsemantik-noch-undefiniert" refersTo="anlageregelungstext-num">Anlage T1</akn:inline><akn:inline GUID="f8610d9b-35f4-432b-a63e-5c759fbd3617" eId="einleitung-n1_block-n1_doctitel-n1_inline-n2" name="attributsemantik-noch-undefiniert" refersTo="anlageregelungstext-bezug">(zu § 1)</akn:inline></akn:docTitle>
             </akn:block>
         </akn:preface>
         <akn:mainBody GUID="43960b63-b71f-4f69-b6c8-cae9ab89741c" eId="hauptteil-1">

--- a/backend/src/test/resources/data/xmlTests/xmlContentTestWithPreambleAndConclusionsFormula.xml
+++ b/backend/src/test/resources/data/xmlTests/xmlContentTestWithPreambleAndConclusionsFormula.xml
@@ -53,7 +53,9 @@
         </akn:preamble>
         <akn:body eId="hauptteil-1">
             <akn:article eId="hauptteil-1_art-1"
-                         period="#meta-1_geltzeiten-1_geltungszeitgr-4" refersTo="stammform">
+                         period="#meta-1_geltzeiten-1_geltungszeitgr-4"
+                         GUID="666b10d9-8625-4418-99ed-980ee42402f4"
+                         refersTo="stammform">
             <akn:num eId="hauptteil-1_art-1_bezeichnung-1">§ 1</akn:num>
             <akn:heading eId="hauptteil-1_art-1_überschrift-1"/>
             <akn:paragraph eId="hauptteil-1_art-1_abs-1">


### PR DESCRIPTION
Given the introduction of LegalDocML.de 1.8.x, attachments now include a `num`/Einzelnormbezeichner `enbez`.

This PR
- parses both elements when creating the table of contents
- inserts a space between num and "bezug" when rendering HTML
- adds a utility method `getFirstMatchedNodeByXpath` to get child nodes of other nodes