### PR TITLE
Unify validityStatus calculation

### DIFF
--- a/frontend/src/components/Norm/ArticleVersionWarning.unit.spec.ts
+++ b/frontend/src/components/Norm/ArticleVersionWarning.unit.spec.ts
@@ -6,22 +6,19 @@ vi.mock("~/utils/normUtils", async (importOriginal) => {
   const mod = (await importOriginal()) as Record<string, unknown>;
   return {
     ...mod,
-    getValidityStatus: vi.fn((entry, expiry) => {
-      if (entry === "past" && expiry === "past")
+    getValidityStatus: vi.fn((interval?: ValidityInterval) => {
+      if (
+        interval?.from === parseDateGermanLocalTime("1990-01-01") &&
+        interval?.to === parseDateGermanLocalTime("2000-01-01")
+      ) {
         return ValidityStatus.Historical;
-      if (entry === "future") return ValidityStatus.Future;
+      }
+      if (interval?.from === parseDateGermanLocalTime("2100-01-01"))
+        return ValidityStatus.Future;
       return ValidityStatus.InForce;
     }),
   };
 });
-
-const formattedDate = (d: string | null) => {
-  if (!d) return null;
-  if (d === "1990-01-01" || d === "2000-01-01") return "past";
-  if (d === "2100-01-01") return "future";
-  return "now";
-};
-vi.stubGlobal("formattedDate", formattedDate);
 
 const articleTestData = [
   {

--- a/frontend/src/components/Norm/ArticleVersionWarning.unit.spec.ts
+++ b/frontend/src/components/Norm/ArticleVersionWarning.unit.spec.ts
@@ -11,11 +11,11 @@ vi.mock("~/utils/normUtils", async (importOriginal) => {
         interval?.from === parseDateGermanLocalTime("1990-01-01") &&
         interval?.to === parseDateGermanLocalTime("2000-01-01")
       ) {
-        return ValidityStatus.Historical;
+        return "Expired";
       }
       if (interval?.from === parseDateGermanLocalTime("2100-01-01"))
-        return ValidityStatus.Future;
-      return ValidityStatus.InForce;
+        return "FutureInForce";
+      return "InForce";
     }),
   };
 });

--- a/frontend/src/components/Norm/ArticleVersionWarning.unit.spec.ts
+++ b/frontend/src/components/Norm/ArticleVersionWarning.unit.spec.ts
@@ -2,13 +2,19 @@ import { mount } from "@vue/test-utils";
 import ArticleVersionWarning from "./ArticleVersionWarning.vue";
 import type { Article } from "~/types";
 
-vi.mock("~/composables/useNormVersions", () => ({
-  getStatusLabel: vi.fn((entry, expiry) => {
-    if (entry === "past" && expiry === "past") return "historical";
-    if (entry === "future") return "future";
-    return "inForce";
-  }),
-}));
+vi.mock("~/utils/normUtils", async (importOriginal) => {
+  const mod = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...mod,
+    getValidityStatus: vi.fn((entry, expiry) => {
+      if (entry === "past" && expiry === "past")
+        return ValidityStatus.Historical;
+      if (entry === "future") return ValidityStatus.Future;
+      return ValidityStatus.InForce;
+    }),
+  };
+});
+
 const formattedDate = (d: string | null) => {
   if (!d) return null;
   if (d === "1990-01-01" || d === "2000-01-01") return "past";

--- a/frontend/src/components/Norm/ArticleVersionWarning.unit.spec.ts
+++ b/frontend/src/components/Norm/ArticleVersionWarning.unit.spec.ts
@@ -3,7 +3,7 @@ import ArticleVersionWarning from "./ArticleVersionWarning.vue";
 import type { Article } from "~/types";
 
 vi.mock("~/utils/normUtils", async (importOriginal) => {
-  const mod = (await importOriginal()) as Record<string, unknown>;
+  const mod = await importOriginal<Record<string, unknown>>();
   return {
     ...mod,
     getValidityStatus: vi.fn((interval?: ValidityInterval) => {

--- a/frontend/src/components/Norm/ArticleVersionWarning.vue
+++ b/frontend/src/components/Norm/ArticleVersionWarning.vue
@@ -9,10 +9,10 @@ const props = defineProps<{
 }>();
 
 const currentArticleStatus = computed(() =>
-  getValidityStatus(
-    parseDateGermanLocalTime(props.currentArticle.entryIntoForceDate),
-    parseDateGermanLocalTime(props.currentArticle.expiryDate),
-  ),
+  getValidityStatus({
+    from: parseDateGermanLocalTime(props.currentArticle.entryIntoForceDate),
+    to: parseDateGermanLocalTime(props.currentArticle.expiryDate),
+  }),
 );
 </script>
 

--- a/frontend/src/components/Norm/ArticleVersionWarning.vue
+++ b/frontend/src/components/Norm/ArticleVersionWarning.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import VersionWarningMessage from "~/components/Norm/VersionWarningMessage.vue";
 import type { Article } from "~/types";
-import { getStatusLabel } from "~/composables/useNormVersions";
+import { getValidityStatus } from "~/utils/normUtils";
 
 const props = defineProps<{
   inForceVersionLink: string;
@@ -9,16 +9,16 @@ const props = defineProps<{
 }>();
 
 const currentArticleStatus = computed(() =>
-  getStatusLabel(
-    formattedDate(props.currentArticle.entryIntoForceDate),
-    formattedDate(props.currentArticle.expiryDate),
+  getValidityStatus(
+    parseDateGermanLocalTime(props.currentArticle.entryIntoForceDate),
+    parseDateGermanLocalTime(props.currentArticle.expiryDate),
   ),
 );
 </script>
 
 <template>
   <VersionWarningMessage
-    :current-version-status="currentArticleStatus"
+    :current-version-validity-status="currentArticleStatus"
     :in-force-version-link="inForceVersionLink"
     historical-warning-message="Paragraf einer historischen Fassung."
     future-warning-message="Paragraf einer zukünftigen Fassung."

--- a/frontend/src/components/Norm/NormMetadataFields.unit.spec.ts
+++ b/frontend/src/components/Norm/NormMetadataFields.unit.spec.ts
@@ -86,7 +86,7 @@ describe("NormMetadataFields.vue", () => {
     const expectedValidFrom = "01.01.2025";
     const wrapper = mount(NormMetadataFields, {
       props: {
-        validFrom: expectedValidFrom,
+        validFrom: parseDateGermanLocalTime("2025-01-01"),
       },
     });
 
@@ -117,7 +117,7 @@ describe("NormMetadataFields.vue", () => {
     const expectedValidTo = "01.12.2025";
     const wrapper = mount(NormMetadataFields, {
       props: {
-        validTo: expectedValidTo,
+        validTo: parseDateGermanLocalTime("2025-12-01"),
       },
     });
 

--- a/frontend/src/components/Norm/NormMetadataFields.unit.spec.ts
+++ b/frontend/src/components/Norm/NormMetadataFields.unit.spec.ts
@@ -32,7 +32,7 @@ describe("NormMetadataFields.vue", () => {
     const expectedStatus = "Aktuell gültig";
     const wrapper = mount(NormMetadataFields, {
       props: {
-        status: ValidityStatus.InForce,
+        status: "InForce",
       },
     });
 
@@ -50,7 +50,7 @@ describe("NormMetadataFields.vue", () => {
     const expectedStatus = "Außer Kraft";
     const wrapper = mount(NormMetadataFields, {
       props: {
-        status: ValidityStatus.Historical,
+        status: "Expired",
       },
     });
 
@@ -68,7 +68,7 @@ describe("NormMetadataFields.vue", () => {
     const expectedStatus = "Zukünftig in Kraft";
     const wrapper = mount(NormMetadataFields, {
       props: {
-        status: ValidityStatus.Future,
+        status: "FutureInForce",
       },
     });
 

--- a/frontend/src/components/Norm/NormMetadataFields.unit.spec.ts
+++ b/frontend/src/components/Norm/NormMetadataFields.unit.spec.ts
@@ -32,7 +32,7 @@ describe("NormMetadataFields.vue", () => {
     const expectedStatus = "Aktuell gültig";
     const wrapper = mount(NormMetadataFields, {
       props: {
-        status: ExpressionStatus.InForce,
+        status: ValidityStatus.InForce,
       },
     });
 
@@ -50,7 +50,7 @@ describe("NormMetadataFields.vue", () => {
     const expectedStatus = "Außer Kraft";
     const wrapper = mount(NormMetadataFields, {
       props: {
-        status: ExpressionStatus.Historical,
+        status: ValidityStatus.Historical,
       },
     });
 
@@ -68,7 +68,7 @@ describe("NormMetadataFields.vue", () => {
     const expectedStatus = "Zukünftig in Kraft";
     const wrapper = mount(NormMetadataFields, {
       props: {
-        status: ExpressionStatus.Future,
+        status: ValidityStatus.Future,
       },
     });
 

--- a/frontend/src/components/Norm/NormMetadataFields.vue
+++ b/frontend/src/components/Norm/NormMetadataFields.vue
@@ -2,6 +2,7 @@
 import MetadataField from "~/components/MetadataField.vue";
 import { isPrototypeProfile } from "~/utils/config";
 import type { Dayjs } from "dayjs";
+import { getValidityStatusLabel } from "~/utils/normUtils";
 
 interface Props {
   abbreviation?: string;
@@ -21,7 +22,11 @@ defineProps<Props>();
       label="Abkürzung"
       :value="abbreviation"
     />
-    <MetadataField id="status" label="Status" :value="status" />
+    <MetadataField
+      id="status"
+      label="Status"
+      :value="getValidityStatusLabel(status)"
+    />
     <MetadataField
       v-if="!isPrototypeProfile()"
       id="validFrom"

--- a/frontend/src/components/Norm/NormMetadataFields.vue
+++ b/frontend/src/components/Norm/NormMetadataFields.vue
@@ -5,7 +5,7 @@ import type { Dayjs } from "dayjs";
 
 interface Props {
   abbreviation?: string;
-  status?: ExpressionStatus;
+  status?: ValidityStatus;
   validFrom?: Dayjs;
   validTo?: Dayjs;
 }

--- a/frontend/src/components/Norm/NormMetadataFields.vue
+++ b/frontend/src/components/Norm/NormMetadataFields.vue
@@ -1,20 +1,16 @@
 <script setup lang="ts">
 import MetadataField from "~/components/MetadataField.vue";
 import { isPrototypeProfile } from "~/utils/config";
+import type { Dayjs } from "dayjs";
 
 interface Props {
   abbreviation?: string;
   status?: ExpressionStatus;
-  validFrom?: string;
-  validTo?: string;
+  validFrom?: Dayjs;
+  validTo?: Dayjs;
 }
 
-const {
-  abbreviation,
-  status,
-  validFrom = "-",
-  validTo = "-",
-} = defineProps<Props>();
+defineProps<Props>();
 </script>
 
 <template>
@@ -30,13 +26,13 @@ const {
       v-if="!isPrototypeProfile()"
       id="validFrom"
       label="Gültig ab"
-      :value="validFrom"
+      :value="dateFormattedDDMMYYYY(validFrom) ?? '-'"
     />
     <MetadataField
       v-if="!isPrototypeProfile()"
       id="validTo"
       label="Gültig bis"
-      :value="validTo"
+      :value="dateFormattedDDMMYYYY(validTo) ?? '-'"
     />
   </div>
 </template>

--- a/frontend/src/components/Norm/NormVersionList.vue
+++ b/frontend/src/components/Norm/NormVersionList.vue
@@ -48,10 +48,7 @@ const tableRowData = computed<TableRowData[]>(() => {
     );
 
     const id = index;
-    const expressionStatus = getValidityStatus(
-      validityInterval?.from,
-      validityInterval?.to,
-    );
+    const expressionStatus = getValidityStatus(validityInterval);
     const status: Status = {
       label: expressionStatus ?? "Unbekannt",
       color: getStatusColor(expressionStatus),

--- a/frontend/src/components/Norm/NormVersionList.vue
+++ b/frontend/src/components/Norm/NormVersionList.vue
@@ -7,9 +7,9 @@ import Badge, { BadgeColor } from "@/components/Badge.vue";
 import IcBaselineLaunch from "~icons/ic/baseline-launch";
 import _ from "lodash";
 import {
-  getExpressionStatus,
+  getValidityStatus,
   temporalCoverageToValidityInterval,
-  ExpressionStatus,
+  ValidityStatus,
 } from "~/utils/normUtils";
 import { dateFormattedDDMMYYYY } from "~/utils/dateFormatting";
 
@@ -48,7 +48,7 @@ const tableRowData = computed<TableRowData[]>(() => {
     );
 
     const id = index;
-    const expressionStatus = getExpressionStatus(
+    const expressionStatus = getValidityStatus(
       validityInterval?.from,
       validityInterval?.to,
     );
@@ -74,13 +74,13 @@ const tableRowData = computed<TableRowData[]>(() => {
   });
 });
 
-function getStatusColor(expressionStatus?: ExpressionStatus): BadgeColor {
+function getStatusColor(expressionStatus?: ValidityStatus): BadgeColor {
   switch (expressionStatus) {
-    case ExpressionStatus.InForce:
+    case ValidityStatus.InForce:
       return BadgeColor.GREEN;
-    case ExpressionStatus.Future:
+    case ValidityStatus.Future:
       return BadgeColor.YELLOW;
-    case ExpressionStatus.Historical:
+    case ValidityStatus.Historical:
       return BadgeColor.RED;
     default:
       return BadgeColor.BLUE;

--- a/frontend/src/components/Norm/NormVersionList.vue
+++ b/frontend/src/components/Norm/NormVersionList.vue
@@ -8,8 +8,9 @@ import IcBaselineLaunch from "~icons/ic/baseline-launch";
 import _ from "lodash";
 import {
   getValidityStatus,
+  getValidityStatusLabel,
   temporalCoverageToValidityInterval,
-  ValidityStatus,
+  type ValidityStatus,
 } from "~/utils/normUtils";
 import { dateFormattedDDMMYYYY } from "~/utils/dateFormatting";
 
@@ -50,7 +51,7 @@ const tableRowData = computed<TableRowData[]>(() => {
     const id = index;
     const validityStatus = getValidityStatus(validityInterval);
     const status: Status = {
-      label: validityStatus ?? "Unbekannt",
+      label: getValidityStatusLabel(validityStatus) ?? "Unbekannt",
       color: getStatusColor(validityStatus),
     };
     const link = `/norms/${version.item.workExample.legislationIdentifier}`;
@@ -73,11 +74,11 @@ const tableRowData = computed<TableRowData[]>(() => {
 
 function getStatusColor(validityStatus?: ValidityStatus): BadgeColor {
   switch (validityStatus) {
-    case ValidityStatus.InForce:
+    case "InForce":
       return BadgeColor.GREEN;
-    case ValidityStatus.Future:
+    case "FutureInForce":
       return BadgeColor.YELLOW;
-    case ValidityStatus.Historical:
+    case "Expired":
       return BadgeColor.RED;
     default:
       return BadgeColor.BLUE;

--- a/frontend/src/components/Norm/NormVersionList.vue
+++ b/frontend/src/components/Norm/NormVersionList.vue
@@ -48,7 +48,10 @@ const tableRowData = computed<TableRowData[]>(() => {
     );
 
     const id = index;
-    const expressionStatus = getExpressionStatus(version.item.workExample);
+    const expressionStatus = getExpressionStatus(
+      validityInterval?.from,
+      validityInterval?.to,
+    );
     const status: Status = {
       label: expressionStatus ?? "Unbekannt",
       color: getStatusColor(expressionStatus),

--- a/frontend/src/components/Norm/NormVersionList.vue
+++ b/frontend/src/components/Norm/NormVersionList.vue
@@ -11,6 +11,7 @@ import {
   temporalCoverageToValidityInterval,
   ExpressionStatus,
 } from "~/utils/normUtils";
+import { dateFormattedDDMMYYYY } from "~/utils/dateFormatting";
 
 const props = defineProps<{
   status: string;
@@ -59,8 +60,8 @@ const tableRowData = computed<TableRowData[]>(() => {
 
     const rowData: TableRowData = {
       id: id,
-      fromDate: validityInterval?.from ?? "-",
-      toDate: validityInterval?.to ?? "-",
+      fromDate: dateFormattedDDMMYYYY(validityInterval?.from) ?? "-",
+      toDate: dateFormattedDDMMYYYY(validityInterval?.to) ?? "-",
       status: status,
       link: link,
       selectable: selectable,

--- a/frontend/src/components/Norm/NormVersionList.vue
+++ b/frontend/src/components/Norm/NormVersionList.vue
@@ -48,10 +48,10 @@ const tableRowData = computed<TableRowData[]>(() => {
     );
 
     const id = index;
-    const expressionStatus = getValidityStatus(validityInterval);
+    const validityStatus = getValidityStatus(validityInterval);
     const status: Status = {
-      label: expressionStatus ?? "Unbekannt",
-      color: getStatusColor(expressionStatus),
+      label: validityStatus ?? "Unbekannt",
+      color: getStatusColor(validityStatus),
     };
     const link = `/norms/${version.item.workExample.legislationIdentifier}`;
     const selectable =
@@ -71,8 +71,8 @@ const tableRowData = computed<TableRowData[]>(() => {
   });
 });
 
-function getStatusColor(expressionStatus?: ValidityStatus): BadgeColor {
-  switch (expressionStatus) {
+function getStatusColor(validityStatus?: ValidityStatus): BadgeColor {
+  switch (validityStatus) {
     case ValidityStatus.InForce:
       return BadgeColor.GREEN;
     case ValidityStatus.Future:

--- a/frontend/src/components/Norm/NormVersionWarning.vue
+++ b/frontend/src/components/Norm/NormVersionWarning.vue
@@ -26,13 +26,12 @@ const currentVersionValidityStatus = computed(() => {
 });
 
 const latestFutureVersion = computed(() => {
-  if (currentVersionValidityStatus.value !== ValidityStatus.InForce)
-    return undefined;
+  if (currentVersionValidityStatus.value !== "InForce") return undefined;
   const last = props.versions[props.versions.length - 1];
   const latestValidityInterval = temporalCoverageToValidityInterval(
     last.item.workExample.temporalCoverage,
   );
-  return getValidityStatus(latestValidityInterval) === ValidityStatus.Future
+  return getValidityStatus(latestValidityInterval) === "FutureInForce"
     ? last.item
     : undefined;
 });

--- a/frontend/src/components/Norm/NormVersionWarning.vue
+++ b/frontend/src/components/Norm/NormVersionWarning.vue
@@ -22,7 +22,7 @@ const currentVersionValidityStatus = computed(() => {
   const validityInterval = temporalCoverageToValidityInterval(
     props.currentVersion.workExample.temporalCoverage,
   );
-  return getValidityStatus(validityInterval?.from, validityInterval?.to);
+  return getValidityStatus(validityInterval);
 });
 
 const latestFutureVersion = computed(() => {
@@ -32,10 +32,7 @@ const latestFutureVersion = computed(() => {
   const latestValidityInterval = temporalCoverageToValidityInterval(
     last.item.workExample.temporalCoverage,
   );
-  return getValidityStatus(
-    latestValidityInterval?.from,
-    latestValidityInterval?.to,
-  ) === ValidityStatus.Future
+  return getValidityStatus(latestValidityInterval) === ValidityStatus.Future
     ? last.item
     : undefined;
 });

--- a/frontend/src/components/Norm/VersionWarningMessage.unit.spec.ts
+++ b/frontend/src/components/Norm/VersionWarningMessage.unit.spec.ts
@@ -35,7 +35,7 @@ describe("VersionWarningMessage.vue", () => {
   it("shows info message for inForce with futureVersion", () => {
     const wrapper = getWrapper({
       ...baseProps,
-      currentVersionStatus: "inForce",
+      currentVersionValidityStatus: ValidityStatus.InForce,
       futureVersion: futureVersion.item,
     });
     expect(wrapper.find("[data-testid='norm-warning-message']").exists()).toBe(
@@ -48,7 +48,7 @@ describe("VersionWarningMessage.vue", () => {
   it("shows no message for inForce without futureVersion", () => {
     const wrapper = getWrapper({
       ...baseProps,
-      currentVersionStatus: "inForce",
+      currentVersionValidityStatus: ValidityStatus.InForce,
     });
     expect(wrapper.find("[data-testid='norm-warning-message']").exists()).toBe(
       false,
@@ -58,7 +58,7 @@ describe("VersionWarningMessage.vue", () => {
   it("shows warning for historical version", () => {
     const wrapper = getWrapper({
       ...baseProps,
-      currentVersionStatus: "historical",
+      currentVersionValidityStatus: ValidityStatus.Historical,
     });
     expect(wrapper.find("[data-testid='norm-warning-message']").exists()).toBe(
       true,
@@ -70,7 +70,7 @@ describe("VersionWarningMessage.vue", () => {
   it("shows warning for future version", () => {
     const wrapper = getWrapper({
       ...baseProps,
-      currentVersionStatus: "future",
+      currentVersionValidityStatus: ValidityStatus.Future,
     });
     expect(wrapper.find("[data-testid='norm-warning-message']").exists()).toBe(
       true,

--- a/frontend/src/components/Norm/VersionWarningMessage.unit.spec.ts
+++ b/frontend/src/components/Norm/VersionWarningMessage.unit.spec.ts
@@ -35,7 +35,7 @@ describe("VersionWarningMessage.vue", () => {
   it("shows info message for inForce with futureVersion", () => {
     const wrapper = getWrapper({
       ...baseProps,
-      currentVersionValidityStatus: ValidityStatus.InForce,
+      currentVersionValidityStatus: "InForce",
       futureVersion: futureVersion.item,
     });
     expect(wrapper.find("[data-testid='norm-warning-message']").exists()).toBe(
@@ -48,7 +48,7 @@ describe("VersionWarningMessage.vue", () => {
   it("shows no message for inForce without futureVersion", () => {
     const wrapper = getWrapper({
       ...baseProps,
-      currentVersionValidityStatus: ValidityStatus.InForce,
+      currentVersionValidityStatus: "InForce",
     });
     expect(wrapper.find("[data-testid='norm-warning-message']").exists()).toBe(
       false,
@@ -58,7 +58,7 @@ describe("VersionWarningMessage.vue", () => {
   it("shows warning for historical version", () => {
     const wrapper = getWrapper({
       ...baseProps,
-      currentVersionValidityStatus: ValidityStatus.Historical,
+      currentVersionValidityStatus: "Expired",
     });
     expect(wrapper.find("[data-testid='norm-warning-message']").exists()).toBe(
       true,
@@ -70,7 +70,7 @@ describe("VersionWarningMessage.vue", () => {
   it("shows warning for future version", () => {
     const wrapper = getWrapper({
       ...baseProps,
-      currentVersionValidityStatus: ValidityStatus.Future,
+      currentVersionValidityStatus: "FutureInForce",
     });
     expect(wrapper.find("[data-testid='norm-warning-message']").exists()).toBe(
       true,

--- a/frontend/src/components/Norm/VersionWarningMessage.vue
+++ b/frontend/src/components/Norm/VersionWarningMessage.vue
@@ -14,17 +14,14 @@ export interface VersionWarningMessageProps {
 const props = defineProps<VersionWarningMessageProps>();
 
 const warningMessageType = computed(() =>
-  props.currentVersionValidityStatus === ValidityStatus.InForce
-    ? "info"
-    : "warn",
+  props.currentVersionValidityStatus === "InForce" ? "info" : "warn",
 );
 
 const showWarningMessage = computed(() => {
   return (
-    (props.currentVersionValidityStatus === ValidityStatus.InForce &&
-      props.futureVersion) ||
-    props.currentVersionValidityStatus === ValidityStatus.Historical ||
-    props.currentVersionValidityStatus === ValidityStatus.Future
+    (props.currentVersionValidityStatus === "InForce" && props.futureVersion) ||
+    props.currentVersionValidityStatus === "Expired" ||
+    props.currentVersionValidityStatus === "FutureInForce"
   );
 });
 </script>
@@ -38,11 +35,11 @@ const showWarningMessage = computed(() => {
     <Message :severity="warningMessageType" class="ris-body2-regular">
       <template #icon>
         <IcBaselineHistory
-          v-if="currentVersionValidityStatus === ValidityStatus.InForce"
+          v-if="currentVersionValidityStatus === 'InForce'"
           class="text-blue-800"
         />
         <IcBaselineHistory
-          v-else-if="currentVersionValidityStatus === ValidityStatus.Historical"
+          v-else-if="currentVersionValidityStatus === 'Expired'"
           class="scale-x-[-1]"
         />
         <IcBaselineHistory v-else />
@@ -50,8 +47,7 @@ const showWarningMessage = computed(() => {
       <p class="mt-2">
         <span
           v-if="
-            currentVersionValidityStatus === ValidityStatus.InForce &&
-            props.futureVersion
+            currentVersionValidityStatus === 'InForce' && props.futureVersion
           "
         >
           <span class="ris-body2-bold">
@@ -70,9 +66,7 @@ const showWarningMessage = computed(() => {
             Zur zukünftigen Fassung
           </NuxtLink>
         </span>
-        <span
-          v-else-if="currentVersionValidityStatus === ValidityStatus.Historical"
-        >
+        <span v-else-if="currentVersionValidityStatus === 'Expired'">
           <span class="ris-body2-bold">
             {{ historicalWarningMessage }}
           </span>
@@ -80,9 +74,7 @@ const showWarningMessage = computed(() => {
             Zur aktuell gültigen Fassung
           </NuxtLink>
         </span>
-        <span
-          v-else-if="currentVersionValidityStatus === ValidityStatus.Future"
-        >
+        <span v-else-if="currentVersionValidityStatus === 'FutureInForce'">
           <span class="ris-body2-bold">{{ futureWarningMessage }} </span>
           <NuxtLink v-if="props.inForceVersionLink" :to="inForceVersionLink">
             Zur aktuell gültigen Fassung

--- a/frontend/src/components/Norm/VersionWarningMessage.vue
+++ b/frontend/src/components/Norm/VersionWarningMessage.vue
@@ -51,7 +51,10 @@ const showWarningMessage = computed(() => {
       <p class="mt-2">
         <span v-if="currentVersionStatus === 'inForce' && props.futureVersion">
           <span class="ris-body2-bold">
-            Neue Fassung ab {{ getVersionDates(props.futureVersion)?.from }}.
+            Neue Fassung ab
+            {{
+              dateFormattedDDMMYYYY(getVersionDates(props.futureVersion)?.from)
+            }}.
           </span>
           <NuxtLink
             :to="`/norms/${props.futureVersion.workExample.legislationIdentifier}`"

--- a/frontend/src/composables/useNormVersions.ts
+++ b/frontend/src/composables/useNormVersions.ts
@@ -8,7 +8,10 @@ import type {
 import _ from "lodash";
 
 import { computed } from "vue";
-import { formattedDateToDateTime } from "~/utils/dateFormatting";
+import {
+  dateFormattedDDMMYYYY,
+  formattedDateToDateTime,
+} from "~/utils/dateFormatting";
 import { temporalCoverageToValidityInterval } from "~/utils/normUtils";
 
 interface UseNormVersions {
@@ -69,7 +72,11 @@ export const getVersionStatus = (
 ): VersionStatus => {
   const validityInterval = getVersionDates(version);
   const status = version?.workExample.legislationLegalForce;
-  return getStatusLabel(validityInterval?.from, validityInterval?.to, status);
+  return getStatusLabel(
+    dateFormattedDDMMYYYY(validityInterval?.from),
+    dateFormattedDDMMYYYY(validityInterval?.to),
+    status,
+  );
 };
 
 export function getStatusLabel(

--- a/frontend/src/composables/useNormVersions.ts
+++ b/frontend/src/composables/useNormVersions.ts
@@ -1,25 +1,13 @@
 import { type AsyncDataRequestStatus, useFetch } from "#app";
-import type {
-  JSONLDList,
-  LegalForceStatus,
-  LegislationWork,
-  SearchResult,
-} from "~/types";
+import type { JSONLDList, LegislationWork, SearchResult } from "~/types";
 import _ from "lodash";
 
 import { computed } from "vue";
-import {
-  dateFormattedDDMMYYYY,
-  formattedDateToDateTime,
-} from "~/utils/dateFormatting";
-import { temporalCoverageToValidityInterval } from "~/utils/normUtils";
 
 interface UseNormVersions {
   status: Ref<AsyncDataRequestStatus>;
   sortedVersions: ComputedRef<SearchResult<LegislationWork>[]>;
 }
-
-export type VersionStatus = "inForce" | "future" | "historical" | undefined;
 
 export function useNormVersions(workEli?: string): UseNormVersions {
   const { data, status } = getNorms({ eli: workEli });
@@ -60,44 +48,4 @@ export function useValidNormVersions(workEli?: string) {
     temporalCoverageFrom: today,
     temporalCoverageTo: today,
   });
-}
-
-export const getVersionDates = (version: LegislationWork | undefined) => {
-  const temporalCoverage = version?.workExample.temporalCoverage ?? "";
-  return temporalCoverageToValidityInterval(temporalCoverage);
-};
-
-export const getVersionStatus = (
-  version: LegislationWork | undefined,
-): VersionStatus => {
-  const validityInterval = getVersionDates(version);
-  const status = version?.workExample.legislationLegalForce;
-  return getStatusLabel(
-    dateFormattedDDMMYYYY(validityInterval?.from),
-    dateFormattedDDMMYYYY(validityInterval?.to),
-    status,
-  );
-};
-
-export function getStatusLabel(
-  startDate: string | undefined,
-  endDate: string | undefined,
-  status?: LegalForceStatus | undefined,
-): VersionStatus {
-  if (status === "InForce") {
-    return "inForce";
-  }
-  const dateFrom = startDate ? formattedDateToDateTime(startDate) : undefined;
-  const dateTo = endDate ? formattedDateToDateTime(endDate) : undefined;
-  const now = new Date();
-  if (dateFrom && dateFrom > now) {
-    return "future";
-  }
-  if (dateTo && dateTo < now) {
-    return "historical";
-  }
-  if (dateFrom && dateFrom <= now && (!dateTo || dateTo >= now)) {
-    return "inForce";
-  }
-  return undefined;
 }

--- a/frontend/src/composables/useNormVersions.unit.spec.ts
+++ b/frontend/src/composables/useNormVersions.unit.spec.ts
@@ -11,33 +11,6 @@ const dummyData = {
   ],
 } as unknown as SearchResult<LegislationWork>[];
 
-const statusTestData = {
-  historical: {
-    item: {
-      workExample: {
-        temporalCoverage: "2020-01-01/2022-12-31",
-        legislationLegalForce: "NotInForce",
-      },
-    },
-  } as unknown as SearchResult<LegislationWork>,
-  inForce: {
-    item: {
-      workExample: {
-        temporalCoverage: "2023-01-01/2923-12-31",
-        legislationLegalForce: "InForce",
-      },
-    },
-  } as unknown as SearchResult<LegislationWork>,
-  future: {
-    item: {
-      workExample: {
-        temporalCoverage: "2924-01-01/..",
-        legislationLegalForce: "NotInForce",
-      },
-    },
-  } as unknown as SearchResult<LegislationWork>,
-};
-
 vi.mock("#app", () => {
   return {
     useFetch: vi.fn(),
@@ -73,12 +46,5 @@ describe("useNormVersions", () => {
     } as unknown as ReturnType<typeof useFetch>);
     const { sortedVersions } = useNormVersions("dummy-eli");
     expect(sortedVersions.value).toEqual([]);
-  });
-
-  Object.keys(statusTestData).forEach((status) => {
-    it(`returns correct status for version with ${status} status`, () => {
-      const version = statusTestData[status as keyof typeof statusTestData];
-      expect(getVersionStatus(version.item)).toBe(status);
-    });
   });
 });

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
@@ -39,7 +39,7 @@ import Toast from "primevue/toast";
 import { useNormActions } from "./useNormActions";
 import NormMetadataFields from "~/components/Norm/NormMetadataFields.vue";
 import {
-  getExpressionStatus,
+  getValidityStatus,
   getManifestationUrl,
   temporalCoverageToValidityInterval,
 } from "~/utils/normUtils";
@@ -100,7 +100,7 @@ const validityInterval = computed(() =>
 
 const expressionStatus = computed(() => {
   if (metadata.value?.workExample && validityInterval)
-    return getExpressionStatus(
+    return getValidityStatus(
       validityInterval.value?.from,
       validityInterval.value?.to,
     );

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
@@ -98,7 +98,7 @@ const validityInterval = computed(() =>
       ),
 );
 
-const expressionStatus = computed(() => {
+const validityStatus = computed(() => {
   if (metadata.value?.workExample && validityInterval)
     return getValidityStatus(validityInterval.value);
   return undefined;
@@ -151,7 +151,7 @@ const { actions } = useNormActions(metadata);
         />
         <NormMetadataFields
           :abbreviation="metadata.abbreviation"
-          :status="expressionStatus"
+          :status="validityStatus"
           :valid-from="validityInterval?.from"
           :valid-to="validityInterval?.to"
         />

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
@@ -90,12 +90,6 @@ const tableOfContents: Ref<TreeNode[]> = computed(() => {
   );
 });
 
-const expressionStatus = computed(() => {
-  if (metadata.value?.workExample)
-    return getExpressionStatus(metadata.value?.workExample);
-  return undefined;
-});
-
 const validityInterval = computed(() =>
   isPrototypeProfile()
     ? undefined
@@ -103,6 +97,15 @@ const validityInterval = computed(() =>
         metadata.value?.workExample.temporalCoverage,
       ),
 );
+
+const expressionStatus = computed(() => {
+  if (metadata.value?.workExample && validityInterval)
+    return getExpressionStatus(
+      validityInterval.value?.from,
+      validityInterval.value?.to,
+    );
+  return undefined;
+});
 
 const { selectedEntry, vObserveElements } = useIntersectionObserver();
 

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
@@ -124,7 +124,7 @@ const breadcrumbItems: ComputedRef<BreadcrumbItem[]> = computed(() => {
   const isInForce =
     metadata.value?.workExample.legislationLegalForce === "InForce";
   if (!isInForce) {
-    const validityIntervalLabel = `${validityInterval.value?.from ?? ""}-${validityInterval.value?.to ?? ""}`;
+    const validityIntervalLabel = `${dateFormattedDDMMYYYY(validityInterval.value?.from) ?? ""}-${dateFormattedDDMMYYYY(validityInterval.value?.to) ?? ""}`;
     list.push({ route: route.fullPath, label: validityIntervalLabel });
   }
 

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
@@ -100,10 +100,7 @@ const validityInterval = computed(() =>
 
 const expressionStatus = computed(() => {
   if (metadata.value?.workExample && validityInterval)
-    return getValidityStatus(
-      validityInterval.value?.from,
-      validityInterval.value?.to,
-    );
+    return getValidityStatus(validityInterval.value);
   return undefined;
 });
 

--- a/frontend/src/utils/dateFormatting.ts
+++ b/frontend/src/utils/dateFormatting.ts
@@ -11,55 +11,18 @@ const TIMEZONE_GERMANY = "Europe/Berlin";
 export function formattedDate(
   date: string | null | undefined,
 ): string | undefined {
-  return date ? dayjs(date).format("DD.MM.YYYY") : undefined;
+  return date ? dateFormattedDDMMYYYY(dayjs(date)) : undefined;
 }
 
 export function dateFormattedDDMMYYYY(date?: Dayjs): string | undefined {
   return date ? date.format("DD.MM.YYYY") : undefined;
 }
 
-export function formattedDateToDateTime(date: string): Date {
-  const [day, month, year] = date.split(".").map(Number);
-  return new Date(year, month - 1, day);
-}
-
 export function parseDateGermanLocalTime(
-  dateString: string,
+  dateString?: string | null,
 ): Dayjs | undefined {
-  if (dateString === "") return undefined;
+  if (!dateString || dateString === "") return undefined;
   return dayjs.tz(dateString, TIMEZONE_GERMANY);
-}
-
-export function isActive(start: string | null, end: string | null): boolean {
-  const validDates = start !== null || end !== null;
-  const currentDateInGermany = dayjs().tz(TIMEZONE_GERMANY).startOf("day");
-  const hasStarted =
-    start === null || !dayjs(start).isAfter(currentDateInGermany);
-  const hasNotEnded =
-    end === null || !dayjs(end).isBefore(currentDateInGermany);
-  return validDates && hasStarted && hasNotEnded;
-}
-
-export function getTranslatedLegalForceByDates(
-  start: string | null,
-  end: string | null,
-): string | undefined {
-  return translateLegalForce(isActive(start, end) ? "InForce" : "NotInForce");
-}
-
-export function translateLegalForce(
-  legislationLegalForce?: string,
-): string | undefined {
-  switch (legislationLegalForce) {
-    case "InForce":
-      return "In Kraft";
-    case "PartiallyInForce":
-      return "Teilweise in Kraft";
-    case "NotInForce":
-      return "Nicht in Kraft";
-    default:
-      return undefined;
-  }
 }
 
 export function getCurrentDateInGermany(): Dayjs {

--- a/frontend/src/utils/dateFormatting.ts
+++ b/frontend/src/utils/dateFormatting.ts
@@ -6,10 +6,16 @@ import timezone from "dayjs/plugin/timezone";
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+const TIMEZONE_GERMANY = "Europe/Berlin";
+
 export function formattedDate(
   date: string | null | undefined,
 ): string | undefined {
   return date ? dayjs(date).format("DD.MM.YYYY") : undefined;
+}
+
+export function dateFormattedDDMMYYYY(date?: Dayjs): string | undefined {
+  return date ? date.format("DD.MM.YYYY") : undefined;
 }
 
 export function formattedDateToDateTime(date: string): Date {
@@ -17,9 +23,16 @@ export function formattedDateToDateTime(date: string): Date {
   return new Date(year, month - 1, day);
 }
 
+export function parseDateGermanLocalTime(
+  dateString: string,
+): Dayjs | undefined {
+  if (dateString === "") return undefined;
+  return dayjs.tz(dateString, TIMEZONE_GERMANY);
+}
+
 export function isActive(start: string | null, end: string | null): boolean {
   const validDates = start !== null || end !== null;
-  const currentDateInGermany = dayjs().tz("Europe/Berlin").startOf("day");
+  const currentDateInGermany = dayjs().tz(TIMEZONE_GERMANY).startOf("day");
   const hasStarted =
     start === null || !dayjs(start).isAfter(currentDateInGermany);
   const hasNotEnded =
@@ -50,7 +63,7 @@ export function translateLegalForce(
 }
 
 export function getCurrentDateInGermany(): Dayjs {
-  return dayjs().tz("Europe/Berlin");
+  return dayjs().tz(TIMEZONE_GERMANY);
 }
 
 export function getCurrentDateInGermanyFormatted(): string {

--- a/frontend/src/utils/normUtils.spec.ts
+++ b/frontend/src/utils/normUtils.spec.ts
@@ -78,20 +78,20 @@ describe("getValidityStatus", () => {
       const result = getValidityStatus(
         createInterval("2025-01-01", "2025-01-05"),
       );
-      expect(result).toBe(ValidityStatus.InForce);
+      expect(result).toBe("InForce");
     });
   }
 
   it("returns future if start date is after current date", () => {
     setCurrentDate("2024-12-31 23:59");
     const result = getValidityStatus(createInterval("2025-01-01"));
-    expect(result).toBe(ValidityStatus.Future);
+    expect(result).toBe("FutureInForce");
   });
 
   it("returns historical if end date is before current date", () => {
     setCurrentDate("2025-01-01 00:00");
     const result = getValidityStatus(createInterval(undefined, "2024-12-31"));
-    expect(result).toBe(ValidityStatus.Historical);
+    expect(result).toBe("Expired");
   });
 
   it("returns undefined if start and end date are undefined", () => {

--- a/frontend/src/utils/normUtils.spec.ts
+++ b/frontend/src/utils/normUtils.spec.ts
@@ -69,27 +69,17 @@ describe("getValidityStatus", () => {
   });
 
   it("returns InForce if current date is in validity interval", () => {
-    setCurrentDate("2025-01-03 00:00");
-    const result = getValidityStatus(
-      createInterval("2025-01-01", "2025-01-05"),
-    );
-    expect(result).toBe(ValidityStatus.InForce);
-  });
-
-  it("returns InForce if current date on lower boundary of validity interval", () => {
-    setCurrentDate("2025-01-01 00:00");
-    const result = getValidityStatus(
-      createInterval("2025-01-01", "2025-01-05"),
-    );
-    expect(result).toBe(ValidityStatus.InForce);
-  });
-
-  it("returns InForce if current date on upper boundary of validity interval", () => {
-    setCurrentDate("2025-01-05 00:00");
-    const result = getValidityStatus(
-      createInterval("2025-01-01", "2025-01-05"),
-    );
-    expect(result).toBe(ValidityStatus.InForce);
+    for (const currentDate of [
+      "2025-01-01 00:00",
+      "2025-01-03 00:00",
+      "2025-01-05 00:00",
+    ]) {
+      setCurrentDate(currentDate);
+      const result = getValidityStatus(
+        createInterval("2025-01-01", "2025-01-05"),
+      );
+      expect(result).toBe(ValidityStatus.InForce);
+    }
   });
 
   it("returns future if start date is after current date", () => {

--- a/frontend/src/utils/normUtils.spec.ts
+++ b/frontend/src/utils/normUtils.spec.ts
@@ -98,11 +98,4 @@ describe("getValidityStatus", () => {
     const result = getValidityStatus();
     expect(result).toBeUndefined();
   });
-
-  it("returns undefined if start date is after end date", () => {
-    const result = getValidityStatus(
-      createInterval("2025-01-01", "2024-12-31"),
-    );
-    expect(result).toBeUndefined();
-  });
 });

--- a/frontend/src/utils/normUtils.spec.ts
+++ b/frontend/src/utils/normUtils.spec.ts
@@ -52,6 +52,13 @@ function setCurrentDate(dateTimeString: string) {
   vi.setSystemTime(currentDate);
 }
 
+function createInterval(from?: string, to?: string): ValidityInterval {
+  return {
+    from: from ? parseDateGermanLocalTime(from) : undefined,
+    to: to ? parseDateGermanLocalTime(to) : undefined,
+  };
+}
+
 describe("getValidityStatus", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -63,44 +70,37 @@ describe("getValidityStatus", () => {
 
   it("returns InForce if current date is in validity interval", () => {
     setCurrentDate("2025-01-03 00:00");
-    const result = getValidityStatus({
-      from: parseDateGermanLocalTime("2025-01-01"),
-      to: parseDateGermanLocalTime("2025-01-05"),
-    });
+    const result = getValidityStatus(
+      createInterval("2025-01-01", "2025-01-05"),
+    );
     expect(result).toBe(ValidityStatus.InForce);
   });
 
   it("returns InForce if current date on lower boundary of validity interval", () => {
     setCurrentDate("2025-01-01 00:00");
-    const result = getValidityStatus({
-      from: parseDateGermanLocalTime("2025-01-01"),
-      to: parseDateGermanLocalTime("2025-01-05"),
-    });
+    const result = getValidityStatus(
+      createInterval("2025-01-01", "2025-01-05"),
+    );
     expect(result).toBe(ValidityStatus.InForce);
   });
 
   it("returns InForce if current date on upper boundary of validity interval", () => {
     setCurrentDate("2025-01-05 00:00");
-    const result = getValidityStatus({
-      from: parseDateGermanLocalTime("2025-01-01"),
-      to: parseDateGermanLocalTime("2025-01-05"),
-    });
+    const result = getValidityStatus(
+      createInterval("2025-01-01", "2025-01-05"),
+    );
     expect(result).toBe(ValidityStatus.InForce);
   });
 
   it("returns future if start date is after current date", () => {
     setCurrentDate("2024-12-31 23:59");
-    const result = getValidityStatus({
-      from: parseDateGermanLocalTime("2025-01-01"),
-    });
+    const result = getValidityStatus(createInterval("2025-01-01"));
     expect(result).toBe(ValidityStatus.Future);
   });
 
   it("returns historical if end date is before current date", () => {
     setCurrentDate("2025-01-01 00:00");
-    const result = getValidityStatus({
-      to: parseDateGermanLocalTime("2024-12-31"),
-    });
+    const result = getValidityStatus(createInterval(undefined, "2024-12-31"));
     expect(result).toBe(ValidityStatus.Historical);
   });
 
@@ -110,10 +110,9 @@ describe("getValidityStatus", () => {
   });
 
   it("returns undefined if start date is after end date", () => {
-    const result = getValidityStatus({
-      from: parseDateGermanLocalTime("2025-01-01"),
-      to: parseDateGermanLocalTime("2024-12-31"),
-    });
+    const result = getValidityStatus(
+      createInterval("2025-01-01", "2024-12-31"),
+    );
     expect(result).toBeUndefined();
   });
 });

--- a/frontend/src/utils/normUtils.spec.ts
+++ b/frontend/src/utils/normUtils.spec.ts
@@ -68,19 +68,19 @@ describe("getValidityStatus", () => {
     vi.useRealTimers();
   });
 
-  it("returns InForce if current date is in validity interval", () => {
-    for (const currentDate of [
-      "2025-01-01 00:00",
-      "2025-01-03 00:00",
-      "2025-01-05 00:00",
-    ]) {
+  for (const currentDate of [
+    "2025-01-01 00:00",
+    "2025-01-03 00:00",
+    "2025-01-05 00:00",
+  ]) {
+    it(`returns InForce for current date ${currentDate} and interval 2025-01-01-2025-01-05`, () => {
       setCurrentDate(currentDate);
       const result = getValidityStatus(
         createInterval("2025-01-01", "2025-01-05"),
       );
       expect(result).toBe(ValidityStatus.InForce);
-    }
-  });
+    });
+  }
 
   it("returns future if start date is after current date", () => {
     setCurrentDate("2024-12-31 23:59");

--- a/frontend/src/utils/normUtils.ts
+++ b/frontend/src/utils/normUtils.ts
@@ -18,16 +18,16 @@ export function temporalCoverageToValidityInterval(
   };
 }
 
-export enum ExpressionStatus {
+export enum ValidityStatus {
   InForce = "Aktuell gültig",
   Future = "Zukünftig in Kraft",
   Historical = "Außer Kraft",
 }
 
-export function getExpressionStatus(
+export function getValidityStatus(
   startDate?: Dayjs,
   endDate?: Dayjs,
-): ExpressionStatus | undefined {
+): ValidityStatus | undefined {
   if (!startDate && !endDate) return undefined;
 
   const currentDate = getCurrentDateInGermany();
@@ -38,17 +38,17 @@ export function getExpressionStatus(
     (start.isBefore(end, "day") || start.isSame(end, "day")) &&
     end.isBefore(currentDate, "day")
   ) {
-    return ExpressionStatus.Historical;
+    return ValidityStatus.Historical;
   } else if (
     (start.isBefore(currentDate, "day") || start.isSame(currentDate, "day")) &&
     (end.isSame(currentDate, "day") || end.isAfter(currentDate, "day"))
   ) {
-    return ExpressionStatus.InForce;
+    return ValidityStatus.InForce;
   } else if (
     start.isAfter(currentDate, "day") &&
     (end.isAfter(start, "day") || end.isSame(startDate, "day"))
   ) {
-    return ExpressionStatus.Future;
+    return ValidityStatus.Future;
   }
 
   return undefined;

--- a/frontend/src/utils/normUtils.ts
+++ b/frontend/src/utils/normUtils.ts
@@ -30,23 +30,21 @@ export function getValidityStatus(
   if (!validityInterval?.from && !validityInterval?.to) return undefined;
 
   const currentDate = getCurrentDateInGermany();
-  const start = validityInterval?.from ?? dayjs(new Date(-8640000000000000)); // mallest possible date
-  const end = validityInterval?.to ?? dayjs(new Date(8640000000000000)); // largest possible date
+  const start = validityInterval?.from ?? dayjs(new Date("0000-01-01"));
+  const end = validityInterval?.to ?? dayjs(new Date("9999-12-31"));
+
+  if (end.isBefore(currentDate, "day")) {
+    return ValidityStatus.Historical;
+  }
 
   if (
-    (start.isBefore(end, "day") || start.isSame(end, "day")) &&
-    end.isBefore(currentDate, "day")
-  ) {
-    return ValidityStatus.Historical;
-  } else if (
     (start.isBefore(currentDate, "day") || start.isSame(currentDate, "day")) &&
     (end.isSame(currentDate, "day") || end.isAfter(currentDate, "day"))
   ) {
     return ValidityStatus.InForce;
-  } else if (
-    start.isAfter(currentDate, "day") &&
-    (end.isAfter(start, "day") || end.isSame(start, "day"))
-  ) {
+  }
+
+  if (start.isAfter(currentDate, "day")) {
     return ValidityStatus.Future;
   }
 

--- a/frontend/src/utils/normUtils.ts
+++ b/frontend/src/utils/normUtils.ts
@@ -25,14 +25,13 @@ export enum ValidityStatus {
 }
 
 export function getValidityStatus(
-  startDate?: Dayjs,
-  endDate?: Dayjs,
+  validityInterval?: ValidityInterval,
 ): ValidityStatus | undefined {
-  if (!startDate && !endDate) return undefined;
+  if (!validityInterval?.from && !validityInterval?.to) return undefined;
 
   const currentDate = getCurrentDateInGermany();
-  const start = startDate ?? dayjs(new Date(-8640000000000000)); // Smallest possible date
-  const end = endDate ?? dayjs(new Date(8640000000000000)); // largest possible date
+  const start = validityInterval?.from ?? dayjs(new Date(-8640000000000000)); // mallest possible date
+  const end = validityInterval?.to ?? dayjs(new Date(8640000000000000)); // largest possible date
 
   if (
     (start.isBefore(end, "day") || start.isSame(end, "day")) &&
@@ -46,7 +45,7 @@ export function getValidityStatus(
     return ValidityStatus.InForce;
   } else if (
     start.isAfter(currentDate, "day") &&
-    (end.isAfter(start, "day") || end.isSame(startDate, "day"))
+    (end.isAfter(start, "day") || end.isSame(start, "day"))
   ) {
     return ValidityStatus.Future;
   }

--- a/frontend/src/utils/normUtils.ts
+++ b/frontend/src/utils/normUtils.ts
@@ -18,10 +18,21 @@ export function temporalCoverageToValidityInterval(
   };
 }
 
-export enum ValidityStatus {
-  InForce = "Aktuell gültig",
-  Future = "Zukünftig in Kraft",
-  Historical = "Außer Kraft",
+export type ValidityStatus = "InForce" | "FutureInForce" | "Expired";
+
+export function getValidityStatusLabel(
+  status?: ValidityStatus,
+): string | undefined {
+  switch (status) {
+    case "Expired":
+      return "Außer Kraft";
+    case "InForce":
+      return "Aktuell gültig";
+    case "FutureInForce":
+      return "Zukünftig in Kraft";
+    default:
+      return undefined;
+  }
 }
 
 export function getValidityStatus(
@@ -34,18 +45,18 @@ export function getValidityStatus(
   const end = validityInterval?.to ?? dayjs(new Date("9999-12-31"));
 
   if (end.isBefore(currentDate, "day")) {
-    return ValidityStatus.Historical;
+    return "Expired";
   }
 
   if (
     (start.isBefore(currentDate, "day") || start.isSame(currentDate, "day")) &&
     (end.isSame(currentDate, "day") || end.isAfter(currentDate, "day"))
   ) {
-    return ValidityStatus.InForce;
+    return "InForce";
   }
 
   if (start.isAfter(currentDate, "day")) {
-    return ValidityStatus.Future;
+    return "FutureInForce";
   }
 
   return undefined;

--- a/frontend/src/utils/normUtlis.spec.ts
+++ b/frontend/src/utils/normUtlis.spec.ts
@@ -52,7 +52,7 @@ function setCurrentDate(dateTimeString: string) {
   vi.setSystemTime(currentDate);
 }
 
-describe("expressionStatus", () => {
+describe("getValidityStatus", () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -63,43 +63,44 @@ describe("expressionStatus", () => {
 
   it("returns InForce if current date is in validity interval", () => {
     setCurrentDate("2025-01-03 00:00");
-    const result = getValidityStatus(
-      parseDateGermanLocalTime("2025-01-01"),
-      parseDateGermanLocalTime("2025-01-05"),
-    );
+    const result = getValidityStatus({
+      from: parseDateGermanLocalTime("2025-01-01"),
+      to: parseDateGermanLocalTime("2025-01-05"),
+    });
     expect(result).toBe(ValidityStatus.InForce);
   });
 
   it("returns InForce if current date on lower boundary of validity interval", () => {
     setCurrentDate("2025-01-01 00:00");
-    const result = getValidityStatus(
-      parseDateGermanLocalTime("2025-01-01"),
-      parseDateGermanLocalTime("2025-01-05"),
-    );
+    const result = getValidityStatus({
+      from: parseDateGermanLocalTime("2025-01-01"),
+      to: parseDateGermanLocalTime("2025-01-05"),
+    });
     expect(result).toBe(ValidityStatus.InForce);
   });
 
   it("returns InForce if current date on upper boundary of validity interval", () => {
     setCurrentDate("2025-01-05 00:00");
-    const result = getValidityStatus(
-      parseDateGermanLocalTime("2025-01-01"),
-      parseDateGermanLocalTime("2025-01-05"),
-    );
+    const result = getValidityStatus({
+      from: parseDateGermanLocalTime("2025-01-01"),
+      to: parseDateGermanLocalTime("2025-01-05"),
+    });
     expect(result).toBe(ValidityStatus.InForce);
   });
 
   it("returns future if start date is after current date", () => {
     setCurrentDate("2024-12-31 23:59");
-    const result = getValidityStatus(parseDateGermanLocalTime("2025-01-01"));
+    const result = getValidityStatus({
+      from: parseDateGermanLocalTime("2025-01-01"),
+    });
     expect(result).toBe(ValidityStatus.Future);
   });
 
   it("returns historical if end date is before current date", () => {
     setCurrentDate("2025-01-01 00:00");
-    const result = getValidityStatus(
-      undefined,
-      parseDateGermanLocalTime("2024-12-31"),
-    );
+    const result = getValidityStatus({
+      to: parseDateGermanLocalTime("2024-12-31"),
+    });
     expect(result).toBe(ValidityStatus.Historical);
   });
 
@@ -109,10 +110,10 @@ describe("expressionStatus", () => {
   });
 
   it("returns undefined if start date is after end date", () => {
-    const result = getValidityStatus(
-      parseDateGermanLocalTime("2025-01-01"),
-      parseDateGermanLocalTime("2024-12-31"),
-    );
+    const result = getValidityStatus({
+      from: parseDateGermanLocalTime("2025-01-01"),
+      to: parseDateGermanLocalTime("2024-12-31"),
+    });
     expect(result).toBeUndefined();
   });
 });

--- a/frontend/src/utils/normUtlis.spec.ts
+++ b/frontend/src/utils/normUtlis.spec.ts
@@ -18,25 +18,25 @@ describe("temporalCoverageToValidityInterval", () => {
   });
 
   it("extracts from and to date from full temporal coverage string", () => {
-    const expectedFrom = "01.09.2025";
-    const expectedTo = "01.12.2025";
+    const expectedFrom = parseDateGermanLocalTime("2025-09-01");
+    const expectedTo = parseDateGermanLocalTime("2025-12-01");
     const result = temporalCoverageToValidityInterval("2025-09-01/2025-12-01");
-    expect(result?.from).toBe(expectedFrom);
-    expect(result?.to).toBe(expectedTo);
+    expect(result?.from).toStrictEqual(expectedFrom);
+    expect(result?.to).toStrictEqual(expectedTo);
   });
 
   it("extracts from date from open end temporal coverage string", () => {
-    const expectedFrom = "01.09.2025";
+    const expectedFrom = parseDateGermanLocalTime("2025-09-01");
     const result = temporalCoverageToValidityInterval("2025-09-01/..");
-    expect(result?.from).toBe(expectedFrom);
+    expect(result?.from).toStrictEqual(expectedFrom);
     expect(result?.to).toBeUndefined();
   });
 
   it("extracts to date from open start temporal coverage string", () => {
-    const expectedTo = "01.12.2025";
+    const expectedTo = parseDateGermanLocalTime("2025-12-01");
     const result = temporalCoverageToValidityInterval("../2025-12-01");
     expect(result?.from).toBeUndefined();
-    expect(result?.to).toBe(expectedTo);
+    expect(result?.to).toStrictEqual(expectedTo);
   });
 
   it("extracts validity interval from open start and open end temporal coverage string", () => {
@@ -63,7 +63,9 @@ function createLegislationExpression(
 }
 
 function setCurrentDate(dateTimeString: string) {
-  const currentDate = dayjs.tz(dateTimeString, "Europe/Berlin").toDate();
+  const currentDate = dayjs
+    .tz(dateTimeString, "YYYY-MM-DD HH:mm", "Europe/Berlin")
+    .toDate();
   vi.setSystemTime(currentDate);
 }
 
@@ -78,6 +80,16 @@ describe("expressionStatus", () => {
 
   it("returns InForce if legalForce is in force", () => {
     const expression = createLegislationExpression("InForce", "");
+    const result = getExpressionStatus(expression);
+    expect(result).toBe(ExpressionStatus.InForce);
+  });
+
+  it("returns InForce if legalForce is NotInForce but current date is in temporalCoverage", () => {
+    setCurrentDate("2025-01-01 00:00");
+    const expression = createLegislationExpression(
+      "NotInForce",
+      "2025-01-01/2025-01-01",
+    );
     const result = getExpressionStatus(expression);
     expect(result).toBe(ExpressionStatus.InForce);
   });
@@ -100,16 +112,6 @@ describe("expressionStatus", () => {
     );
     const result = getExpressionStatus(expression);
     expect(result).toBe(ExpressionStatus.Historical);
-  });
-
-  it("returns undefined if legalForce is NotInForce but current date is in temporalCoverage", () => {
-    setCurrentDate("2025-01-01 00:00");
-    const expression = createLegislationExpression(
-      "NotInForce",
-      "2024-12-31/2025-01-01",
-    );
-    const result = getExpressionStatus(expression);
-    expect(result).toBeUndefined();
   });
 
   it("returns undefined if legalForce is partiallyInForce", () => {

--- a/frontend/src/utils/normUtlis.spec.ts
+++ b/frontend/src/utils/normUtlis.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, vi } from "vitest";
 import {
-  getExpressionStatus,
+  getValidityStatus,
   temporalCoverageToValidityInterval,
 } from "~/utils/normUtils";
 import dayjs from "dayjs";
@@ -63,53 +63,53 @@ describe("expressionStatus", () => {
 
   it("returns InForce if current date is in validity interval", () => {
     setCurrentDate("2025-01-03 00:00");
-    const result = getExpressionStatus(
+    const result = getValidityStatus(
       parseDateGermanLocalTime("2025-01-01"),
       parseDateGermanLocalTime("2025-01-05"),
     );
-    expect(result).toBe(ExpressionStatus.InForce);
+    expect(result).toBe(ValidityStatus.InForce);
   });
 
   it("returns InForce if current date on lower boundary of validity interval", () => {
     setCurrentDate("2025-01-01 00:00");
-    const result = getExpressionStatus(
+    const result = getValidityStatus(
       parseDateGermanLocalTime("2025-01-01"),
       parseDateGermanLocalTime("2025-01-05"),
     );
-    expect(result).toBe(ExpressionStatus.InForce);
+    expect(result).toBe(ValidityStatus.InForce);
   });
 
   it("returns InForce if current date on upper boundary of validity interval", () => {
     setCurrentDate("2025-01-05 00:00");
-    const result = getExpressionStatus(
+    const result = getValidityStatus(
       parseDateGermanLocalTime("2025-01-01"),
       parseDateGermanLocalTime("2025-01-05"),
     );
-    expect(result).toBe(ExpressionStatus.InForce);
+    expect(result).toBe(ValidityStatus.InForce);
   });
 
   it("returns future if start date is after current date", () => {
     setCurrentDate("2024-12-31 23:59");
-    const result = getExpressionStatus(parseDateGermanLocalTime("2025-01-01"));
-    expect(result).toBe(ExpressionStatus.Future);
+    const result = getValidityStatus(parseDateGermanLocalTime("2025-01-01"));
+    expect(result).toBe(ValidityStatus.Future);
   });
 
   it("returns historical if end date is before current date", () => {
     setCurrentDate("2025-01-01 00:00");
-    const result = getExpressionStatus(
+    const result = getValidityStatus(
       undefined,
       parseDateGermanLocalTime("2024-12-31"),
     );
-    expect(result).toBe(ExpressionStatus.Historical);
+    expect(result).toBe(ValidityStatus.Historical);
   });
 
   it("returns undefined if start and end date are undefined", () => {
-    const result = getExpressionStatus();
+    const result = getValidityStatus();
     expect(result).toBeUndefined();
   });
 
   it("returns undefined if start date is after end date", () => {
-    const result = getExpressionStatus(
+    const result = getValidityStatus(
       parseDateGermanLocalTime("2025-01-01"),
       parseDateGermanLocalTime("2024-12-31"),
     );


### PR DESCRIPTION
- use one function to calculate the validity status
- make sure time calculations happen in german local time
- rename ExpressionStatus to ValidityStatus as this better reflects what the status represents and also makes more sense when used with articles