### PR TITLE
RISDEV-8403 Remove date filter

### DIFF
--- a/frontend/src/components/Search/SimpleSearch/SimpleSearch.unit.spec.ts
+++ b/frontend/src/components/Search/SimpleSearch/SimpleSearch.unit.spec.ts
@@ -29,4 +29,21 @@ describe("SimpleSearch", () => {
       "frühstück brötchen — Suche",
     );
   });
+
+  for (const testCase of [
+    { documentKind: DocumentKind.All, isFilterVisible: false },
+    { documentKind: DocumentKind.Norm, isFilterVisible: false },
+    { documentKind: DocumentKind.CaseLaw, isFilterVisible: true },
+  ]) {
+    it(`sets the visibility of the duration filter to ${testCase.isFilterVisible} when the document kind is ${testCase.documentKind}`, async () => {
+      const wrapper = await mountSuspended(SimpleSearch);
+      const store = useSimpleSearchParamsStore();
+      store.category = testCase.documentKind;
+      await nextTick();
+
+      expect(wrapper.findComponent({ name: "DateRangeFilter" }).exists()).toBe(
+        testCase.isFilterVisible,
+      );
+    });
+  }
 });

--- a/frontend/src/components/Search/SimpleSearch/SimpleSearch.vue
+++ b/frontend/src/components/Search/SimpleSearch/SimpleSearch.vue
@@ -118,7 +118,7 @@ useHead({ title });
       </legend>
       <CategoryFilter />
       <CourtFilter />
-      <DateRangeFilter />
+      <DateRangeFilter v-if="documentKind === DocumentKind.CaseLaw" />
     </fieldset>
     <main id="main" class="w-full flex-col justify-end gap-8 lg:w-9/12">
       <h1 class="sr-only">Suchergebnisse</h1>


### PR DESCRIPTION
This PR aims at removing the date filter from the search page for the Mixed Search results and the Norm search results, while keeping it for the caselaw search results' page.