### PR TITLE
RISDEV-8529

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/MappingDefinitions.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/MappingDefinitions.java
@@ -20,7 +20,7 @@ public class MappingDefinitions {
   static {
     normsOpenSearchToSchemaMap =
         Map.ofEntries(
-            Map.entry(Norm.Fields.WORK_ELI, "legislationIdentifier"),
+            Map.entry(Norm.Fields.WORK_ELI_KEYWORD, "legislationIdentifier"),
             Map.entry(Norm.Fields.OFFICIAL_TITLE, "name"),
             Map.entry(Norm.Fields.OFFICIAL_SHORT_TITLE, "alternateName"),
             Map.entry(Norm.Fields.OFFICIAL_ABBREVIATION, "abbreviation"),

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/CaseLawDocumentationUnit.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/CaseLawDocumentationUnit.java
@@ -67,6 +67,7 @@ public record CaseLawDocumentationUnit(
     public static final String ID = "id";
     public static final String DOCUMENT_NUMBER = "document_number";
     public static final String ECLI = "ecli";
+    public static final String ECLI_KEYWORD = "ecli.keyword";
     public static final String CASE_FACTS = "case_facts";
     public static final String DECISION_GROUNDS = "decision_grounds";
     public static final String DISSENTING_OPINION = "dissenting_opinion";
@@ -79,7 +80,7 @@ public record CaseLawDocumentationUnit(
     public static final String TENOR = "tenor";
     public static final String DECISION_DATE = "decision_date";
     public static final String FILE_NUMBERS = "file_numbers";
-    public static final String FILE_NUMBERS_TEXT = "file_numbers.text";
+    public static final String FILE_NUMBERS_KEYWORD = "file_numbers.keyword";
 
     /** Field holding the type of court, e.g., FG, BVerwG */
     public static final String COURT_TYPE = "court_type";

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/Norm.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/Norm.java
@@ -117,11 +117,16 @@ public final class Norm implements AbstractSearchEntity {
     public static final String NORMS_DATE = "norms_date";
     public static final String DATE_PUBLISHED = "date_published";
     public static final String OFFICIAL_ABBREVIATION = "official_abbreviation";
+    public static final String OFFICIAL_ABBREVIATION_KEYWORD = "official_abbreviation.keyword";
     public static final String OFFICIAL_SHORT_TITLE = "official_short_title";
+    public static final String OFFICIAL_SHORT_TITLE_KEYWORD = "official_short_title.keyword";
     public static final String OFFICIAL_TITLE = "official_title";
+    public static final String OFFICIAL_TITLE_KEYWORD = "official_title.keyword";
     public static final String PUBLISHED_IN = "published_in";
     public static final String WORK_ELI = "work_eli";
+    public static final String WORK_ELI_KEYWORD = "work_eli.keyword";
     public static final String EXPRESSION_ELI = "expression_eli";
+    public static final String EXPRESSION_ELI_KEYWORD = "expression_eli.keyword";
     public static final String LATEST_MANIFESTATION_ELI = "latest_manifestation_eli";
     public static final String TABLE_OF_CONTENTS = "table_of_contents";
     public static final String CONCLUSIONS_FORMULA = "conclusions_formula";

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/RisHighlightBuilder.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/RisHighlightBuilder.java
@@ -66,12 +66,7 @@ public final class RisHighlightBuilder {
   private static HighlightBuilder addCaseLawFields(HighlightBuilder builder) {
     CASE_LAW_HIGHLIGHT_CONTENT_FIELDS.forEach(builder::field);
     builder.field(getFieldBasic(CaseLawDocumentationUnit.Fields.ECLI));
-    /*
-     * Note that this uses the .text variant of file_numbers
-     * */
-    builder.field(
-        getFieldBasic(CaseLawDocumentationUnit.Fields.FILE_NUMBERS_TEXT)
-            .numOfFragments(5) /* Support highlighting multiple (partial) file numbers */);
+    builder.field(getFieldBasic(CaseLawDocumentationUnit.Fields.FILE_NUMBERS));
     return builder;
   }
 

--- a/backend/src/main/resources/openSearch/caselaw_mappings.json
+++ b/backend/src/main/resources/openSearch/caselaw_mappings.json
@@ -222,7 +222,13 @@
       }
     },
     "ecli": {
-      "type": "keyword",
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "normalizer": "normalized_keyword"
+        }
+      },
       "boost": 2
     },
     "grounds": {
@@ -261,12 +267,12 @@
       "index_options": "offsets"
     },
     "file_numbers": {
-      "type": "keyword",
-      "normalizer": "file_number_normalizer",
+      "type": "text",
       "boost": 2.5,
       "fields": {
-        "text": {
-          "type": "text",
+        "keyword": {
+          "type": "keyword",
+          "normalizer": "normalized_keyword",
           "boost": 2.5
         }
       }

--- a/backend/src/main/resources/openSearch/german_analyzer.json
+++ b/backend/src/main/resources/openSearch/german_analyzer.json
@@ -108,11 +108,6 @@
         "type": "custom",
         "char_filter": [],
         "filter": ["asciifolding", "lowercase"]
-      },
-      "file_number_normalizer": {
-        "type": "custom",
-        "filter": ["lowercase"],
-        "char_filter": ["replace_special_char_whitespace_filter"]
       }
     }
   }

--- a/backend/src/main/resources/openSearch/norms_mapping.json
+++ b/backend/src/main/resources/openSearch/norms_mapping.json
@@ -35,6 +35,12 @@
     "official_title": {
       "type": "text",
       "analyzer": "custom_german_analyzer",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "normalizer": "normalized_keyword"
+        }
+      },
       "boost": 2
     },
     "norms_date": {
@@ -46,25 +52,43 @@
     "official_short_title": {
       "type": "text",
       "analyzer": "custom_german_analyzer",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "normalizer": "normalized_keyword"
+        }
+      },
       "boost": 2
     },
     "official_abbreviation": {
-      "type": "keyword",
-      "normalizer": "lowercase",
+      "type": "text",
       "boost": 3,
       "fields": {
-        "text": {
-          "type": "text",
+        "keyword": {
+          "type": "keyword",
+          "normalizer": "normalized_keyword",
           "boost": 3
         }
       }
     },
     "work_eli": {
-      "type": "keyword",
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "normalizer": "normalized_keyword"
+        }
+      },
       "boost": 2
     },
     "expression_eli": {
-      "type": "keyword",
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "normalizer": "normalized_keyword"
+        }
+      },
       "boost": 2
     },
     "manifestation_eli": {

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/AdvancedSearchControllerApiTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/AdvancedSearchControllerApiTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -61,7 +60,7 @@ class AdvancedSearchControllerApiTest extends ContainersIntegrationBase {
     if (initialized) return; // replacement for @BeforeAll setup, which causes errors
     initialized = true;
 
-    assertTrue(openSearchContainer.isRunning());
+    Assertions.assertTrue(openSearchContainer.isRunning());
     super.recreateIndex();
     super.updateMapping();
 
@@ -273,7 +272,7 @@ class AdvancedSearchControllerApiTest extends ContainersIntegrationBase {
   @DisplayName("Should return 200 when looking for a specific document number and aliases")
   void shouldReturnOkDocumentNumberQuery(String queryParam) throws Exception {
 
-    var document = CaseLawTestData.allDocuments.get(0);
+    var document = CaseLawTestData.allDocuments.getFirst();
     mockMvc
         .perform(
             get(ApiConfig.Paths.CASELAW_ADVANCED_SEARCH
@@ -366,7 +365,7 @@ class AdvancedSearchControllerApiTest extends ContainersIntegrationBase {
     mockMvc
         .perform(
             get(ApiConfig.Paths.LEGISLATION_ADVANCED_SEARCH
-                    + "?query=work_eli:eli\\/2024\\/teg\\/*")
+                    + "?query=work_eli.keyword:eli\\/2024\\/teg\\/*")
                 .contentType(MediaType.APPLICATION_JSON))
         .andDo(print())
         .andExpect(jsonPath("$.member", hasSize(2)))

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/NormsControllerApiTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/NormsControllerApiTest.java
@@ -281,7 +281,7 @@ class NormsControllerApiTest extends ContainersIntegrationBase {
 
     final Elements articles = parsed.body().selectXpath("//article");
     assertThat(articles).hasSize(1);
-    final String articleId = Objects.requireNonNull(articles.get(0).attribute("id")).getValue();
+    final String articleId = Objects.requireNonNull(articles.getFirst().attribute("id")).getValue();
     assertThat(articleId).isEqualTo("hauptteil-1_para-1");
   }
 
@@ -335,7 +335,7 @@ class NormsControllerApiTest extends ContainersIntegrationBase {
         .perform(get(uri).contentType(MediaType.APPLICATION_JSON))
         .andExpectAll(
             status().isOk(),
-            jsonPath("$.member", hasSize(1)),
+            jsonPath("$.member", hasSize(3)),
             jsonPath("$.member[0]['item'].abbreviation", is("TeG")));
   }
 
@@ -387,7 +387,7 @@ class NormsControllerApiTest extends ContainersIntegrationBase {
   @Test
   @DisplayName("Should find a norm when searching for its expression ELI explicitly")
   void shouldFindNormByExpressionEli() throws Exception {
-    final String eli = NormsTestData.allDocuments.get(0).getExpressionEli();
+    final String eli = NormsTestData.allDocuments.getFirst().getExpressionEli();
     final String uri = ApiConfig.Paths.LEGISLATION + "?searchTerm=\"%s\"".formatted(eli);
     mockMvc
         .perform(get(uri).contentType(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
Simple search | title search failing
*Refactor fields that are used as an identifier (ecli, eli, file number, etc.) to be indexed both as text and keyword. Text is used for the filtering logic just like the rest of the fields (every result must contain every token). Keyword is used for the targeted search boost ranking logic. An exact match (after normalization) of the entire search string gets a very large boost. *Fixed tests failing
*Refactored case law file number logic to work like the rest of the targeted search cases *Removed case law file number test that no longer makes sense *Fixed missing AND logic on search fields other than "searchTerm"