### PR TITLE
RISDEV-8529

### DIFF
--- a/backend/src/main/resources/openSearch/README.md
+++ b/backend/src/main/resources/openSearch/README.md
@@ -12,23 +12,18 @@ The `analysis` section specifies custom analyzer definitions for text data in th
 
 #### `custom_german_analyzer`
 
-This analyzer is used for most text content in the project, such as headlines, document body, or metadata such as
-location.
-
-#### `court_keyword_custom_german_analyzer`
-
-This analyzer is similar to the `custom_german_analyzer`, but has support for domain-specific synonyms, such as "AG"
-for "Amtsgericht".
+This analyzer is used for all text content in the project, such as headlines, document body, or metadata such as
+location. The fields need to use the same analyzer in order to support our needed `CROSS_FIELDS` logic
 
 ## Normalizer Settings
 
-The normalizer section is mainly used for keyword fields, doing character-level replacements:
+The normalizer section is used for keyword fields.
 
-### `file_number_normalizer`
-
-This normalizer processes file numbers (Aktenzeichen) by filtering out special characters and spaces, and converting the
-token to lowercase.
-This way, both "IX ZR 100/10" and "ixzr10010" match the original input "IX ZR 100/10".
+### `normalized_keyword`
+All keyword fields are currently indexed twice. Once as text (for the filtering logic using `CROSS_FIELDS`) and once
+as keyword (with an exact match on keyword providing a large boost). Exact match means after normalization. The keyword
+fields use `normalized_keyword` to apply `lowercase` and `asciifolding` so that "exact" match works as expected. In
+particular "Abcü/123" will match "abcue/123", but will NOT match "Abcü 123".
 
 ## Document index definition
 
@@ -39,20 +34,6 @@ See [IndexAliasService.java](../../java/de/bund/digitalservice/ris/search/servic
 
 The [caselaw_mappings.json](./caselaw_mappings.json) document defines a list of aliases, so that both e.g. AZ,
 AKTENZEICHEN, and file_numbers may be used in Lucene queries to refer to document_numbers.
-
-### `_type` keywords fields
-
-For court_type and document_type, a `keyword` field is defined so that exact matching based on court type may be
-performed more efficiently.
-
-### `file_numbers`
-
-The file_numbers field is given a boost, so that users searching for a file number will see documents with that file
-number first, before other documents that quote that number or have parts of that file number across different fields.
-
-### `court_keyword`
-
-See `court_keyword_custom_german_analyzer`.
 
 ### `articles`
 

--- a/backend/src/main/resources/openSearch/caselaw_mappings.json
+++ b/backend/src/main/resources/openSearch/caselaw_mappings.json
@@ -187,12 +187,12 @@
     },
     "court_type": {
       "type": "text",
+      "analyzer": "custom_german_analyzer",
       "fields": {
         "keyword": {
           "type": "keyword"
         }
-      },
-      "analyzer": "court_keyword_custom_german_analyzer"
+      }
     },
     "decision_date": {
       "type": "date"
@@ -223,6 +223,7 @@
     },
     "ecli": {
       "type": "text",
+      "analyzer": "custom_german_analyzer",
       "fields": {
         "keyword": {
           "type": "keyword",
@@ -254,7 +255,8 @@
       "type": "keyword"
     },
     "location": {
-      "type": "text"
+      "type": "text",
+      "analyzer": "custom_german_analyzer"
     },
     "other_headnote": {
       "type": "text",
@@ -268,6 +270,7 @@
     },
     "file_numbers": {
       "type": "text",
+      "analyzer": "custom_german_analyzer",
       "boost": 2.5,
       "fields": {
         "keyword": {
@@ -292,11 +295,12 @@
       "analyzer": "custom_german_analyzer"
     },
     "keywords": {
-      "type": "text"
+      "type": "text",
+      "analyzer": "custom_german_analyzer"
     },
     "court_keyword": {
       "type": "text",
-      "analyzer": "court_keyword_custom_german_analyzer",
+      "analyzer": "custom_german_analyzer",
       "fields": {
         "keyword": {
           "type": "keyword"
@@ -342,7 +346,8 @@
       "path": "procedures"
     },
     "legal_effect": {
-      "type": "text"
+      "type": "text",
+      "analyzer": "custom_german_analyzer"
     },
     "RECHTSKRAFT": {
       "type": "alias",

--- a/backend/src/main/resources/openSearch/german_analyzer.json
+++ b/backend/src/main/resources/openSearch/german_analyzer.json
@@ -6,6 +6,7 @@
         "tokenizer": "standard",
         "filter": [
           "lowercase",
+          "court_type_synonyms",
           "german_decompounder",
           "german_normalization",
           "german_stemmer"
@@ -14,27 +15,12 @@
           "replace_article_character",
           "replace_euro_character"
         ]
-      },
-      "court_keyword_custom_german_analyzer": {
-        "type": "custom",
-        "tokenizer": "standard",
-        "filter": [
-          "lowercase",
-          "court_type_synonyms",
-          "german_decompounder",
-          "german_normalization",
-          "german_stemmer"
-        ]
       }
     },
     "filter": {
       "german_normalization": {
         "type": "asciifolding",
         "name": "nfkc_cf"
-      },
-      "german_stop": {
-        "type": "stop",
-        "stopwords": "_german_"
       },
       "german_stemmer": {
         "type": "stemmer",

--- a/backend/src/main/resources/openSearch/norms_mapping.json
+++ b/backend/src/main/resources/openSearch/norms_mapping.json
@@ -62,6 +62,7 @@
     },
     "official_abbreviation": {
       "type": "text",
+      "analyzer": "custom_german_analyzer",
       "boost": 3,
       "fields": {
         "keyword": {
@@ -73,6 +74,7 @@
     },
     "work_eli": {
       "type": "text",
+      "analyzer": "custom_german_analyzer",
       "fields": {
         "keyword": {
           "type": "keyword",
@@ -83,6 +85,7 @@
     },
     "expression_eli": {
       "type": "text",
+      "analyzer": "custom_german_analyzer",
       "fields": {
         "keyword": {
           "type": "keyword",
@@ -144,7 +147,8 @@
       "type": "date"
     },
     "published_in": {
-      "type": "text"
+      "type": "text",
+      "analyzer": "custom_german_analyzer"
     },
     "expiry_date": {
       "type": "date"


### PR DESCRIPTION
Simple search | title search failing
*Make sure all text fields use the same analyzer so that CROSS_FIELDS works as expected. This has a side effect that court synonyms will now be used in all fields. *Cleanup up old dead code
*Updated indexing documentation