### PR TITLE
RISDEV-8529

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/helper/UniversalDocumentQueryBuilder.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/helper/UniversalDocumentQueryBuilder.java
@@ -80,7 +80,12 @@ public class UniversalDocumentQueryBuilder {
                 .operator(Operator.AND)
                 .type(Type.CROSS_FIELDS);
         query.must(unquotedQuery);
-        articleNestedQuery.should(unquotedQuery);
+        MultiMatchQueryBuilder nestedMatchQuery =
+            new MultiMatchQueryBuilder(term)
+                .zeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL)
+                .operator(Operator.OR)
+                .type(Type.BEST_FIELDS);
+        articleNestedQuery.should(nestedMatchQuery);
       }
 
       for (String phrase : quotedSearchPhrases) {


### PR DESCRIPTION
Simple search | title search failing
*Fix bug with ranking of articles within a search hit. Searches like "§4 Fremdrentengesetz" should rank §4 to the top of the 3 previewed articles again.