### PR TITLE
RISDEV-8647 Reduce events sent to sentry in frontend and backend

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/SentryConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/SentryConfig.java
@@ -1,7 +1,9 @@
 package de.bund.digitalservice.ris.search.config;
 
+import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,6 +22,16 @@ public class SentryConfig {
       } else {
         return null;
       }
+    };
+  }
+
+  @Bean
+  SentryOptions.BeforeSendCallback beforeSendCallback() {
+    return (event, hint) -> {
+      if (List.of(SentryLevel.ERROR, SentryLevel.FATAL).contains(event.getLevel())) {
+        return event;
+      }
+      return null;
     };
   }
 }

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/nuxt";
-import { isStringEmpty, getStringOrDefault } from "~/utils/textFormatting";
+import { getStringOrDefault, isStringEmpty } from "~/utils/textFormatting";
 
 const dsn = process.env.NUXT_PUBLIC_SENTRY_DSN;
 const release = getStringOrDefault(
@@ -15,8 +15,10 @@ Sentry.init({
   // It has to be in the environment of the server when building the app
   // See: https://nuxt.com/docs/guide/directory-structure/env#production
   dsn,
-  tracesSampleRate: 0.1,
+  tracesSampleRate: 1.0,
   debug: false,
   release, // this will be set from the CI/CD as the commit SHA
+  beforeSend: (event) =>
+    event.level === "error" || event.level === "fatal" ? event : null,
   environment,
 });

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -15,7 +15,7 @@ Sentry.init({
   // It has to be in the environment of the server when building the app
   // See: https://nuxt.com/docs/guide/directory-structure/env#production
   dsn,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.1,
   debug: false,
   release, // this will be set from the CI/CD as the commit SHA
   environment,

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -15,7 +15,7 @@ Sentry.init({
   // It has to be in the environment of the server when building the app
   // See: https://nuxt.com/docs/guide/directory-structure/env#production
   dsn,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.1,
   debug: false,
   release, // this will be set from the CI/CD as the commit SHA
   beforeSend: (event) =>


### PR DESCRIPTION
This PR addresses the issue highlighted in the ticket [RISDEV-8647](https://digitalservicebund.atlassian.net/browse/RISDEV-8647) about the responsibility of the portal team to ~60% of the events in sentry for the company. 

- **Acceptance Criteria**
We expect to send ~10K events per month or less

[RISDEV-8647]: https://digitalservicebund.atlassian.net/browse/RISDEV-8647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ