### PR TITLE
 RISDEV-8404: Display inforce date in search if not prototype

### DIFF
--- a/backend/e2e-data/norm/eli/bund/bgbl-1/1964/s902/2009-02-05/19/deu/2009-02-05/regelungstext-1.xml
+++ b/backend/e2e-data/norm/eli/bund/bgbl-1/1964/s902/2009-02-05/19/deu/2009-02-05/regelungstext-1.xml
@@ -62,6 +62,9 @@
                     <akn:shortTitle GUID="11111111-0000-4222-3333-444444444444" eId="einleitung-n1_doktitel-n1_text-n1_kurztitel-n1">(Musterverordnung - TestV)</akn:shortTitle>
                 </akn:p>
             </akn:longTitle>
+            <akn:block eId="einleitung-n1_block-n1" GUID="11111111-0000-4222-3333-444444444456" name="attributsemantik-noch-undefiniert">
+                <akn:date date="1964-08-01" eId="einleitung-n1_block-n1_datum-n1" GUID="11111111-0000-4222-3333-444444444820" refersTo="ausfertigung-datum"/>
+            </akn:block>
         </akn:preface>
         <akn:preamble GUID="22222222-0000-4333-4444-555555555555" eId="präambel-n1"/>
         <akn:body GUID="33333333-0000-4444-5555-666666666666" eId="hauptteil-n1">

--- a/frontend/src/components/Search/Result/Caselaw/CaselawSearchResult.vue
+++ b/frontend/src/components/Search/Result/Caselaw/CaselawSearchResult.vue
@@ -2,7 +2,6 @@
 import _ from "lodash";
 import GavelIcon from "virtual:icons/material-symbols/gavel";
 import type { CaseLaw, SearchResult, TextMatch } from "~/types";
-import { formattedDate } from "~/utils/dateFormatting";
 import { sanitizeSearchResult } from "~/utils/sanitize";
 import { addEllipsis, removeOuterParentheses } from "~/utils/textFormatting";
 
@@ -94,7 +93,7 @@ const metadata = computed(() => {
       "Titelzeile nicht vorhanden",
     url: `/case-law/${props.searchResult.item.documentNumber}`,
     courtName: item.courtName,
-    decisionDate: formattedDate(item.decisionDate),
+    decisionDate: dateFormattedDDMMYYYY(item.decisionDate),
     fileNumbers: getFileNumbers(item),
     decisionName: item.decisionName?.at(0),
     documentType: item.documentType || "Entscheidung",

--- a/frontend/src/components/Search/Result/Norms/NormSearchResult.vue
+++ b/frontend/src/components/Search/Result/Norms/NormSearchResult.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import LegalIcon from "virtual:icons/mdi/legal";
 import type { LegislationWork, SearchResult, TextMatch } from "~/types";
-import { formattedDate } from "~/utils/dateFormatting";
+import { dateFormattedDDMMYYYY } from "~/utils/dateFormatting";
 
 const props = defineProps<{
   searchResult: SearchResult<LegislationWork>;
@@ -28,6 +28,16 @@ const link = computed(() => {
   return prefix + expressionEli;
 });
 
+const formattedDate = computed(() => {
+  const date = isPrototypeProfile()
+    ? item.value?.legislationDate
+    : temporalCoverageToValidityInterval(
+        item.value?.workExample?.temporalCoverage,
+      )?.from;
+
+  return dateFormattedDDMMYYYY(date);
+});
+
 const relevantHighlights = computed(() => {
   return highlights.value
     .filter((highlight) => highlight.name != "name")
@@ -46,7 +56,7 @@ function openResult(url: string) {
         <span>Norm</span>
       </div>
       <span v-if="item.abbreviation">{{ item.abbreviation }}</span>
-      <span>{{ formattedDate(item.legislationDate) }}</span>
+      <span v-if="formattedDate">{{ formattedDate }}</span>
     </div>
     <NuxtLink
       v-if="!!link"

--- a/frontend/src/pages/case-law/[documentNumber]/index.vue
+++ b/frontend/src/pages/case-law/[documentNumber]/index.vue
@@ -108,7 +108,7 @@ if (contentError?.value) {
         <MetadataField
           id="decision_date"
           label="Entscheidungsdatum"
-          :value="formattedDate(caseLaw.decisionDate)"
+          :value="dateFormattedDDMMYYYY(caseLaw.decisionDate)"
         />
         <MetadataField
           id="file_numbers"

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[subtype]/index.vue
@@ -217,7 +217,7 @@ const breadcrumbItems: ComputedRef<BreadcrumbItem[]> = computed(() => {
               <Properties>
                 <PropertiesItem
                   label="Ausfertigungsdatum:"
-                  :value="formattedDate(metadata.legislationDate)"
+                  :value="dateFormattedDDMMYYYY(metadata.legislationDate)"
                 />
                 <PropertiesItem
                   label="Vollzitat:"

--- a/frontend/src/utils/dateFormatting.ts
+++ b/frontend/src/utils/dateFormatting.ts
@@ -8,14 +8,16 @@ dayjs.extend(timezone);
 
 const TIMEZONE_GERMANY = "Europe/Berlin";
 
-export function formattedDate(
-  date: string | null | undefined,
+export function dateFormattedDDMMYYYY(
+  date?: Dayjs | string,
 ): string | undefined {
-  return date ? dateFormattedDDMMYYYY(dayjs(date)) : undefined;
-}
+  const dayjsDate = typeof date === "string" ? dayjs(date) : date;
 
-export function dateFormattedDDMMYYYY(date?: Dayjs): string | undefined {
-  return date ? date.format("DD.MM.YYYY") : undefined;
+  if (!dayjsDate?.isValid()) {
+    return undefined;
+  }
+
+  return dayjsDate.format("DD.MM.YYYY");
 }
 
 export function parseDateGermanLocalTime(

--- a/frontend/src/utils/dateFormatting.unit.spec.ts
+++ b/frontend/src/utils/dateFormatting.unit.spec.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { describe, vi } from "vitest";
 import { getCurrentDateInGermanyFormatted } from "./dateFormatting";
 
@@ -14,5 +15,23 @@ describe("getCurrentDateInGermany", () => {
     expect(getCurrentDateInGermanyFormatted()).toBe("1970-01-02");
 
     vi.useRealTimers();
+  });
+});
+
+describe("dateFormattedDDMMYYYY", () => {
+  it("returns undefined if input is undefined", () => {
+    expect(dateFormattedDDMMYYYY()).toBe(undefined);
+  });
+
+  it("returns undefined if input not a valid date", () => {
+    expect(dateFormattedDDMMYYYY("foo")).toBe(undefined);
+  });
+
+  it("returns formatted date if input is valid date string", () => {
+    expect(dateFormattedDDMMYYYY("2042-04-02")).toBe("02.04.2042");
+  });
+
+  it("returns formatted date if input is dayjs object", () => {
+    expect(dateFormattedDDMMYYYY(dayjs("2042-04-02"))).toBe("02.04.2042");
   });
 });


### PR DESCRIPTION
- in none prototype environment: display the in force date (Inkraftdatum) for each result item instead of the ausfertigungsdatum
- in the prototype keep displaying the ausfertigungsdatum