### PR TITLE
enable sorting by temporalCoverageFrom

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/MappingDefinitions.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/MappingDefinitions.java
@@ -25,6 +25,7 @@ public class MappingDefinitions {
             Map.entry(Norm.Fields.OFFICIAL_SHORT_TITLE, "alternateName"),
             Map.entry(Norm.Fields.OFFICIAL_ABBREVIATION, "abbreviation"),
             Map.entry(Norm.Fields.NORMS_DATE, "legislationDate"),
+            Map.entry(Norm.Fields.ENTRY_INTO_FORCE_DATE, "temporalCoverageFrom"),
             Map.entry("DATUM", "date") // alias shared with caseLaw
             );
     caseLawOpenSearchToSchemaMap =

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/SortingDefinitions.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/SortingDefinitions.java
@@ -18,7 +18,7 @@ public class SortingDefinitions {
   public static final Set<String> caseLawSortFields =
       Set.of("date", DATE_ALIAS_FIELD, "courtName", "documentNumber");
   public static final Set<String> normsSortFields =
-      Set.of("date", DATE_ALIAS_FIELD, "legislationIdentifier");
+      Set.of("date", DATE_ALIAS_FIELD, "legislationIdentifier", "temporalCoverageFrom");
 
   public static boolean canSortByField(
       String openSearchFieldName, MappingDefinitions.ResolutionMode resolutionMode) {

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/NormsControllerApiTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/NormsControllerApiTest.java
@@ -556,6 +556,41 @@ class NormsControllerApiTest extends ContainersIntegrationBase {
     }
   }
 
+  @Test
+  void itSortsByTemporalCoverageFrom() throws Exception {
+
+    super.recreateIndex();
+    super.updateMapping();
+
+    var normTestOne =
+        Norm.builder()
+            .id("n1")
+            .officialTitle("title1")
+            .entryIntoForceDate(LocalDate.of(2026, 1, 1))
+            .build();
+
+    var normTestTwo =
+        Norm.builder()
+            .id("id2")
+            .officialTitle("title2")
+            .entryIntoForceDate(LocalDate.of(2025, 1, 1))
+            .build();
+
+    normsRepository.saveAll(List.of(normTestOne, normTestTwo));
+
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LEGISLATION + String.format("?sort=%s", "temporalCoverageFrom"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.member[*].item.name", is(List.of("title2", "title1"))));
+
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LEGISLATION + String.format("?sort=%s", "-temporalCoverageFrom"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.member[*].item.name", is(List.of("title1", "title2"))));
+  }
+
   private TableOfContentsSchema mapToTableOfContentsSchema(TableOfContentsItem item) {
     return new TableOfContentsSchema(
         item.id(),


### PR DESCRIPTION
added an integration test that doesn't rely on shared static testdata to prevent data dependencies across tests. 