### PR TITLE
Sort by temporal coverage

### DIFF
--- a/frontend/src/composables/useNormVersions.ts
+++ b/frontend/src/composables/useNormVersions.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { computed } from "vue";
 import { type AsyncDataRequestStatus, useFetch } from "#app";
 import type { JSONLDList, LegislationWork, SearchResult } from "~/types";
@@ -13,12 +12,7 @@ export function useNormVersions(workEli?: string): UseNormVersions {
     eli: workEli,
     sort: "-temporalCoverageFrom",
   });
-  const sortedVersions = computed(() =>
-    _.sortBy(
-      data.value?.member ?? [],
-      (member) => member.item.workExample.temporalCoverage,
-    ),
-  );
+  const sortedVersions = computed(() => data.value?.member ?? []);
   return { status, sortedVersions };
 }
 

--- a/frontend/src/composables/useNormVersions.ts
+++ b/frontend/src/composables/useNormVersions.ts
@@ -9,7 +9,10 @@ interface UseNormVersions {
 }
 
 export function useNormVersions(workEli?: string): UseNormVersions {
-  const { data, status } = getNorms({ eli: workEli });
+  const { data, status } = getNorms({
+    eli: workEli,
+    sort: "-temporalCoverageFrom",
+  });
   const sortedVersions = computed(() =>
     _.sortBy(
       data.value?.member ?? [],
@@ -23,6 +26,7 @@ function getNorms(params: {
   eli?: string;
   temporalCoverageFrom?: string;
   temporalCoverageTo?: string;
+  sort?: string;
 }) {
   const backendURL = useBackendURL();
   const immediate = params.eli !== undefined;


### PR DESCRIPTION
this PR sorts norms by temporalCoverageFrom in decreasing order via the api to ensure the newest ones are always on top, independent from the number of results.