### PR TITLE
Fix several issues with Sitemap files generation

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/LocalFilesystemObjectStorageClient.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/LocalFilesystemObjectStorageClient.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -52,19 +53,24 @@ public class LocalFilesystemObjectStorageClient implements ObjectStorageClient {
   @Override
   public List<String> listKeysByPrefix(String prefix) {
     Path bucketPath = localStorageDirectory.resolve(bucket);
+    return listKeysByPrefix(
+        prefix, path -> path.toString().substring(bucketPath.toString().length() + 1));
+  }
 
-    Path basePath = bucketPath.resolve(StringUtils.substringBeforeLast(prefix, "/"));
-
-    try (Stream<Path> stream = Files.walk(basePath)) {
-      return stream
-          .filter(Files::isRegularFile)
-          .filter(f -> f.toString().contains(prefix))
-          .map(p -> p.toString().substring(bucketPath.toString().length() + 1))
-          .toList();
-    } catch (IOException e) {
-      LOGGER.info("Could not list files in {}", basePath);
-      return List.of();
-    }
+  @Override
+  public List<ObjectKeyInfo> listByPrefixWithLastModified(String prefix) {
+    Path bucketPath = localStorageDirectory.resolve(bucket);
+    return listKeysByPrefix(
+        prefix,
+        path -> {
+          try {
+            return new ObjectKeyInfo(
+                path.toString().substring(bucketPath.toString().length() + 1),
+                Files.getLastModifiedTime(path).toInstant());
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 
   @Override
@@ -126,5 +132,21 @@ public class LocalFilesystemObjectStorageClient implements ObjectStorageClient {
       LOGGER.error(e.toString());
     }
     return file.length();
+  }
+
+  private <T> List<T> listKeysByPrefix(String prefix, Function<Path, T> mappingFunction) {
+    Path basePath =
+        localStorageDirectory.resolve(bucket).resolve(StringUtils.substringBeforeLast(prefix, "/"));
+
+    try (Stream<Path> stream = Files.walk(basePath)) {
+      return stream
+          .filter(Files::isRegularFile)
+          .filter(f -> f.toString().contains(prefix))
+          .map(mappingFunction)
+          .toList();
+    } catch (IOException e) {
+      LOGGER.info("Could not list files in {}", basePath);
+      return List.of();
+    }
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/LocalFilesystemObjectStorageClient.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/LocalFilesystemObjectStorageClient.java
@@ -1,5 +1,6 @@
 package de.bund.digitalservice.ris.search.repository.objectstorage;
 
+import de.bund.digitalservice.ris.search.exception.FileTransformationException;
 import de.bund.digitalservice.ris.search.exception.NoSuchKeyException;
 import java.io.DataInputStream;
 import java.io.File;
@@ -68,7 +69,7 @@ public class LocalFilesystemObjectStorageClient implements ObjectStorageClient {
                 path.toString().substring(bucketPath.toString().length() + 1),
                 Files.getLastModifiedTime(path).toInstant());
           } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new FileTransformationException(e.getMessage());
           }
         });
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectKeyInfo.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectKeyInfo.java
@@ -1,0 +1,10 @@
+package de.bund.digitalservice.ris.search.repository.objectstorage;
+
+import java.time.Instant;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+public record ObjectKeyInfo(String key, Instant lastModified) {
+  public static ObjectKeyInfo fromS3Object(S3Object s3Object) {
+    return new ObjectKeyInfo(s3Object.key(), s3Object.lastModified());
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectStorage.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectStorage.java
@@ -31,6 +31,10 @@ public class ObjectStorage {
     return client.listKeysByPrefix(path);
   }
 
+  public List<ObjectKeyInfo> getAllKeyInfosByPrefix(String path) {
+    return client.listByPrefixWithLastModified(path);
+  }
+
   public Optional<String> getFileAsString(String filename) throws ObjectStoreServiceException {
     Optional<byte[]> s3Response = get(filename);
     return s3Response.map(bytes -> new String(bytes, StandardCharsets.UTF_8));

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectStorageClient.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectStorageClient.java
@@ -9,6 +9,8 @@ import java.util.List;
 public interface ObjectStorageClient {
   public List<String> listKeysByPrefix(String path);
 
+  List<ObjectKeyInfo> listByPrefixWithLastModified(String prefix);
+
   public FilterInputStream getStream(String objectKey) throws NoSuchKeyException;
 
   public void save(String fileName, String fileContent);

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapService.java
@@ -10,6 +10,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import java.io.StringWriter;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,6 +56,12 @@ public class SitemapService {
     this.setSitemapType(SitemapType.CASELAW);
     String path = this.getBatchSitemapPath(batchNumber);
     this.portalBucket.save(path, this.generateCaselawSitemap(paths));
+  }
+
+  public void deleteSitemapFiles(Instant beforeDateTime) {
+    this.portalBucket.getAllKeyInfosByPrefix(SITEMAP_PREFIX).stream()
+        .filter(info -> info.lastModified().isBefore(beforeDateTime))
+        .forEach((info) -> portalBucket.delete(info.key()));
   }
 
   private String generateSitemap(List<?> items, Function<Object, Url> urlMapper) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapService.java
@@ -61,7 +61,7 @@ public class SitemapService {
   public void deleteSitemapFiles(Instant beforeDateTime) {
     this.portalBucket.getAllKeyInfosByPrefix(SITEMAP_PREFIX).stream()
         .filter(info -> info.lastModified().isBefore(beforeDateTime))
-        .forEach((info) -> portalBucket.delete(info.key()));
+        .forEach(info -> portalBucket.delete(info.key()));
   }
 
   private String generateSitemap(List<?> items, Function<Object, Url> urlMapper) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapsUpdateJob.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapsUpdateJob.java
@@ -5,10 +5,9 @@ import de.bund.digitalservice.ris.search.repository.objectstorage.CaseLawBucket;
 import de.bund.digitalservice.ris.search.repository.objectstorage.NormsBucket;
 import de.bund.digitalservice.ris.search.utils.eli.ExpressionEli;
 import de.bund.digitalservice.ris.search.utils.eli.ManifestationEli;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.logging.log4j.LogManager;
@@ -30,23 +29,26 @@ public class SitemapsUpdateJob implements Job {
   private final SitemapService sitemapService;
 
   public Job.ReturnCode runJob() {
+    Instant jobStarted = Instant.now();
     logger.info("Starting sitemaps update job for norms");
     createSitemapsForNorms();
     logger.info("Starting sitemaps update job for caselaw");
     createSitemapsForCaselaw();
+    logger.info("Clear old sitemap files");
+    sitemapService.deleteSitemapFiles(jobStarted);
     return ReturnCode.SUCCESS;
   }
 
   public void createSitemapsForNorms() {
     List<ManifestationEli> manifestations =
         normsBucket.getAllKeysByPrefix("eli/").stream()
+            .filter(path -> path.contains("/regelungstext-verkuendung-"))
             .map(ManifestationEli::fromString)
             .flatMap(Optional::stream)
             .toList();
-    Set<ExpressionEli> expressions =
-        manifestations.stream().map(ManifestationEli::getExpressionEli).collect(Collectors.toSet());
-    List<List<ExpressionEli>> batches =
-        ListUtils.partition(expressions.stream().toList(), urlsPerPage);
+    List<ExpressionEli> expressions =
+        manifestations.stream().map(ManifestationEli::getExpressionEli).distinct().toList();
+    List<List<ExpressionEli>> batches = ListUtils.partition(expressions, urlsPerPage);
     for (int i = 0; i < batches.size(); i++) {
       logger.info("Creating Sitemap for norms of batch {} of {}.", (i + 1), batches.size());
       sitemapService.createNormsBatchSitemap(i + 1, batches.get(i));

--- a/backend/src/main/resources/application-prototype.yaml
+++ b/backend/src/main/resources/application-prototype.yaml
@@ -1,6 +1,7 @@
 server:
   port: 8080
   docs-url: "https://docs.rechtsinformationen.bund.de/"
+  front-end-url: https://rechtsinformationen.bund.de/
 
 spring:
   config:

--- a/backend/src/main/resources/application-staging.yaml
+++ b/backend/src/main/resources/application-staging.yaml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  front-end-url: https://ris-portal.dev.ds4g.net/
   technical-users: []
 
 spring:
@@ -22,7 +23,7 @@ spring:
 
 swagger:
   server:
-    url: https://ris-search.dev.ds4g.net/
+    url: https://ris-portal.dev.ds4g.net/
     description: Public staging server
 
 sentry:

--- a/backend/src/main/resources/application-uat.yaml
+++ b/backend/src/main/resources/application-uat.yaml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  front-end-url: https://ris-search.uat.ds4g.net/
   technical-users: []
 
 spring:

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/repository/LocalFilesystemObjectStorageClientTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/repository/LocalFilesystemObjectStorageClientTest.java
@@ -1,7 +1,6 @@
 package de.bund.digitalservice.ris.search.integration.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import de.bund.digitalservice.ris.search.exception.NoSuchKeyException;
 import de.bund.digitalservice.ris.search.repository.objectstorage.LocalFilesystemObjectStorageClient;
@@ -9,7 +8,6 @@ import de.bund.digitalservice.ris.search.repository.objectstorage.ObjectKeyInfo;
 import java.io.ByteArrayInputStream;
 import java.io.FilterInputStream;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -97,24 +95,13 @@ class LocalFilesystemObjectStorageClientTest {
 
   @Test
   void itListsKeysWithLastModified() {
-    await()
-        .atMost(101, TimeUnit.MILLISECONDS)
-        .until(
-            () -> {
-              client.save("sitemaps/norms/1.xml", "old");
-              return true;
-            });
-    client.save("sitemaps/norms/2.xml", "new");
+    client.save("sitemaps/norms/1.xml", "new");
 
     List<ObjectKeyInfo> infos = client.listByPrefixWithLastModified("sitemaps/");
-    ObjectKeyInfo oldFileInfo =
+    ObjectKeyInfo fileInfo =
         infos.stream().filter(info -> info.key().contains("1.xml")).toList().getFirst();
-    ObjectKeyInfo newFileInfo =
-        infos.stream().filter(info -> info.key().contains("2.xml")).toList().getFirst();
 
-    assertThat(oldFileInfo.lastModified()).isNotNull();
-    assertThat(newFileInfo.lastModified()).isNotNull();
-    assertThat(oldFileInfo.lastModified()).isBefore(newFileInfo.lastModified());
+    assertThat(fileInfo.lastModified()).isNotNull();
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/repository/LocalFilesystemObjectStorageClientTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/repository/LocalFilesystemObjectStorageClientTest.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.search.integration.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import de.bund.digitalservice.ris.search.exception.NoSuchKeyException;
 import de.bund.digitalservice.ris.search.repository.objectstorage.LocalFilesystemObjectStorageClient;
@@ -8,6 +9,7 @@ import de.bund.digitalservice.ris.search.repository.objectstorage.ObjectKeyInfo;
 import java.io.ByteArrayInputStream;
 import java.io.FilterInputStream;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -94,9 +96,14 @@ class LocalFilesystemObjectStorageClientTest {
   }
 
   @Test
-  void itListsKeysWithLastModified() throws InterruptedException {
-    client.save("sitemaps/norms/1.xml", "old");
-    Thread.sleep(1);
+  void itListsKeysWithLastModified() {
+    await()
+        .atMost(101, TimeUnit.MILLISECONDS)
+        .until(
+            () -> {
+              client.save("sitemaps/norms/1.xml", "old");
+              return true;
+            });
     client.save("sitemaps/norms/2.xml", "new");
 
     List<ObjectKeyInfo> infos = client.listByPrefixWithLastModified("sitemaps/");

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/repository/objectstorage/S3ObjectStorageClientTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/repository/objectstorage/S3ObjectStorageClientTest.java
@@ -308,9 +308,9 @@ class S3ObjectStorageClientTest {
 
     when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(page);
 
-    List<ObjectKeyInfo> infos = s3Service.listByPrefixWithLastModified(prefix);
-    assertThat(infos).hasSize(2);
-    assertThat(infos).containsAll(List.of(objectKeyInfo1, objectKeyInfo2));
+    assertThat(s3Service.listByPrefixWithLastModified(prefix))
+        .hasSize(2)
+        .containsAll(List.of(objectKeyInfo1, objectKeyInfo2));
 
     ArgumentCaptor<ListObjectsV2Request> captor =
         ArgumentCaptor.forClass(ListObjectsV2Request.class);

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/repository/objectstorage/S3ObjectStorageClientTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/repository/objectstorage/S3ObjectStorageClientTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,9 @@ import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
@@ -279,5 +283,110 @@ class S3ObjectStorageClientTest {
 
     assertEquals(maxByteCount, totalBytesRead);
     assertArrayEquals(data, readData);
+  }
+
+  @Test
+  void listByPrefixWithLastModified_singlePage_returnsKeyInfos() {
+    String prefix = "sitemaps/";
+    ObjectKeyInfo objectKeyInfo1 =
+        new ObjectKeyInfo("sitemaps/norms/1.xml", Instant.parse("2023-01-01T00:00:00Z"));
+    ObjectKeyInfo objectKeyInfo2 =
+        new ObjectKeyInfo("sitemaps/norms/2.xml", Instant.parse("2023-01-02T00:00:00Z"));
+    S3Object obj1 =
+        S3Object.builder()
+            .key(objectKeyInfo1.key())
+            .lastModified(objectKeyInfo1.lastModified())
+            .build();
+    S3Object obj2 =
+        S3Object.builder()
+            .key(objectKeyInfo2.key())
+            .lastModified(objectKeyInfo2.lastModified())
+            .build();
+
+    ListObjectsV2Response page =
+        ListObjectsV2Response.builder().isTruncated(false).contents(obj1, obj2).build();
+
+    when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(page);
+
+    List<ObjectKeyInfo> infos = s3Service.listByPrefixWithLastModified(prefix);
+    assertThat(infos).hasSize(2);
+    assertThat(infos).containsAll(List.of(objectKeyInfo1, objectKeyInfo2));
+
+    ArgumentCaptor<ListObjectsV2Request> captor =
+        ArgumentCaptor.forClass(ListObjectsV2Request.class);
+    verify(s3Client).listObjectsV2(captor.capture());
+    assertThat(captor.getValue().bucket()).isEqualTo(BUCKET_NAME);
+    assertThat(captor.getValue().prefix()).isEqualTo(prefix);
+  }
+
+  @Test
+  void listByPrefixWithLastModified_handlesPagination_andAggregatesAllPages() {
+    String prefix = "sitemaps/";
+    ObjectKeyInfo objectKeyInfo1 =
+        new ObjectKeyInfo("sitemaps/norms/1.xml", Instant.parse("2023-01-01T00:00:00Z"));
+    ObjectKeyInfo objectKeyInfo2 =
+        new ObjectKeyInfo("sitemaps/norms/2.xml", Instant.parse("2023-01-02T00:00:00Z"));
+    ObjectKeyInfo objectKeyInfo3 =
+        new ObjectKeyInfo("sitemaps/caselaw/3.xml", Instant.parse("2023-01-03T00:00:00Z"));
+    S3Object p1o1 =
+        S3Object.builder()
+            .key(objectKeyInfo1.key())
+            .lastModified(objectKeyInfo1.lastModified())
+            .build();
+    S3Object p1o2 =
+        S3Object.builder()
+            .key(objectKeyInfo2.key())
+            .lastModified(objectKeyInfo2.lastModified())
+            .build();
+    ListObjectsV2Response page1 =
+        ListObjectsV2Response.builder()
+            .isTruncated(true)
+            .nextContinuationToken("token-1")
+            .contents(p1o1, p1o2)
+            .build();
+
+    S3Object p2o1 =
+        S3Object.builder()
+            .key(objectKeyInfo3.key())
+            .lastModified(objectKeyInfo3.lastModified())
+            .build();
+    ListObjectsV2Response page2 =
+        ListObjectsV2Response.builder().isTruncated(false).contents(p2o1).build();
+
+    when(s3Client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .thenReturn(page1)
+        .thenReturn(page2);
+
+    assertThat(s3Service.listByPrefixWithLastModified(prefix))
+        .isEqualTo(List.of(objectKeyInfo1, objectKeyInfo2, objectKeyInfo3));
+
+    ArgumentCaptor<ListObjectsV2Request> captor =
+        ArgumentCaptor.forClass(ListObjectsV2Request.class);
+    verify(s3Client, times(2)).listObjectsV2(captor.capture());
+    List<ListObjectsV2Request> calls = captor.getAllValues();
+
+    assertThat(calls.getFirst().bucket()).isEqualTo(BUCKET_NAME);
+    assertThat(calls.getFirst().prefix()).isEqualTo(prefix);
+    assertThat(calls.getFirst().continuationToken()).isNull();
+
+    assertThat(calls.getLast().bucket()).isEqualTo(BUCKET_NAME);
+    assertThat(calls.getLast().prefix()).isEqualTo(prefix);
+    assertThat(calls.getLast().continuationToken()).isEqualTo("token-1");
+  }
+
+  @Test
+  void listByPrefixWithLastModified_emptyPage_returnsEmptyList() {
+    String prefix = "sitemaps/";
+    ListObjectsV2Response empty =
+        ListObjectsV2Response.builder().isTruncated(false).contents(List.of()).build();
+
+    when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(empty);
+
+    assertThat(s3Service.listByPrefixWithLastModified(prefix)).isEmpty();
+
+    ArgumentCaptor<ListObjectsV2Request> captor =
+        ArgumentCaptor.forClass(ListObjectsV2Request.class);
+    verify(s3Client).listObjectsV2(captor.capture());
+    assertThat(captor.getValue().prefix()).isEqualTo(prefix);
   }
 }

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -15,8 +15,6 @@ const sentryEnabled = !isStringEmpty(process.env.NUXT_PUBLIC_SENTRY_DSN);
 
 const secureCookie = !config.devMode;
 
-const backendBaseUrl = process.env.NUXT_RIS_BACKEND_URL;
-
 export default defineNuxtConfig({
   app: {
     head: {
@@ -148,17 +146,21 @@ export default defineNuxtConfig({
     },
   },
   routeRules: {
-    "/api/docs/**": {
-      proxy: `${backendBaseUrl}/swagger-ui/**`,
-    },
-    "v3/api-docs/**": {
-      proxy: `${backendBaseUrl}/**`,
-    },
     "/sitemaps/norms/**": {
-      proxy: `${backendBaseUrl}/v1/sitemaps/norms/**`,
+      proxy: {
+        to: "/api/v1/sitemaps/norms/**",
+        headers: {
+          Accept: "application/xml",
+        },
+      },
     },
     "/sitemaps/caselaw/**": {
-      proxy: `${backendBaseUrl}/v1/sitemaps/caselaw/**`,
+      proxy: {
+        to: "/api/v1/sitemaps/caselaw/**",
+        headers: {
+          Accept: "application/xml",
+        },
+      },
     },
   },
   vite: {

--- a/frontend/src/public/openapi.json
+++ b/frontend/src/public/openapi.json
@@ -181,7 +181,7 @@
             "in": "query",
             "description": "The number of the page to request. The page starts with the value 0",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" },
+            "schema": { "type": "integer", "format": "int32", "minimum": 0 },
             "example": 0
           },
           {
@@ -978,7 +978,7 @@
             "in": "query",
             "description": "The number of the page to request. The page starts with the value 0",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" },
+            "schema": { "type": "integer", "format": "int32", "minimum": 0 },
             "example": 0
           }
         ],
@@ -1126,7 +1126,7 @@
             "in": "query",
             "description": "The number of the page to request. The page starts with the value 0",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" },
+            "schema": { "type": "integer", "format": "int32", "minimum": 0 },
             "example": 0
           },
           {

--- a/frontend/src/public/openapi.json
+++ b/frontend/src/public/openapi.json
@@ -187,11 +187,12 @@
           {
             "name": "sort",
             "in": "query",
-            "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date (sort by date ascending), -date (sort by date descending) and not setting the sort field (sort by relevance descending).",
+            "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date, temporalCoverageFrom, legislationIdentifier and not setting the sort field (sort by relevance descending).Add a leading - to set the order to descending (-date)",
             "required": false,
             "schema": {
               "type": "string",
-              "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date (sort by date ascending), -date (sort by date descending) and not setting the sort field (sort by relevance descending)."
+              "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date, temporalCoverageFrom, legislationIdentifier and not setting the sort field (sort by relevance descending).Add a leading - to set the order to descending (-date)",
+              "pattern": "^-?(|default|date|temporalCoverageFrom|legislationIdentifier|DATUM)$"
             }
           }
         ],
@@ -938,6 +939,17 @@
             }
           },
           {
+            "name": "sort",
+            "in": "query",
+            "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date, temporalCoverageFrom, legislationIdentifier, courtName, documentNumber and not setting the sort field (sort by relevance descending).Add a leading - to set the order to descending (-date)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date, temporalCoverageFrom, legislationIdentifier, courtName, documentNumber and not setting the sort field (sort by relevance descending).Add a leading - to set the order to descending (-date)",
+              "pattern": "^-?(|default|date|DATUM|courtName|documentNumber|temporalCoverageFrom|legislationIdentifier)$"
+            }
+          },
+          {
             "name": "documentKind",
             "in": "query",
             "description": "Filter by document kind. Specify R for case law (<u>R</u>echtsprechung), or N for legislation (<u>N</u>ormen).",
@@ -968,16 +980,6 @@
             "required": false,
             "schema": { "type": "integer", "format": "int32" },
             "example": 0
-          },
-          {
-            "name": "sort",
-            "in": "query",
-            "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date (sort by date ascending), -date (sort by date descending) and not setting the sort field (sort by relevance descending).",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date (sort by date ascending), -date (sort by date descending) and not setting the sort field (sort by relevance descending)."
-            }
           }
         ],
         "responses": {
@@ -1130,11 +1132,12 @@
           {
             "name": "sort",
             "in": "query",
-            "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date (sort by date ascending), -date (sort by date descending) and not setting the sort field (sort by relevance descending).",
+            "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date, courtName, documentNumber and not setting the sort field (sort by relevance descending).Add a leading - to set the order to descending (-date)",
             "required": false,
             "schema": {
               "type": "string",
-              "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date (sort by date ascending), -date (sort by date descending) and not setting the sort field (sort by relevance descending)."
+              "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date, courtName, documentNumber and not setting the sort field (sort by relevance descending).Add a leading - to set the order to descending (-date)",
+              "pattern": "^-?(|default|date|DATUM|courtName|documentNumber)$"
             }
           }
         ],


### PR DESCRIPTION
This PR addresses several issues detected with generating sitemaps for norms and caselaw files:

1. The sitemap files that were not overwritten in the sitemap files generation process are deleted after the process is finished.
2. The links to the sitemaps for norms and caselaw were broken on staging due to an issue with routeRules in nuxt config. Now this is fixed.
3. The links for norms were filtered to only include links to unique expressions.