### PR TITLE
Use @Parameter annotation for endpoint parameters

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/CaseLawController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/CaseLawController.java
@@ -145,11 +145,12 @@ public class CaseLawController {
   @ApiResponse(responseCode = "200")
   @ApiResponse(responseCode = "404", content = @Content())
   public ResponseEntity<byte[]> getImage(
-      @PathVariable @Schema(example = "BDRE000800001") String documentNumber,
-      @Schema(example = "image") @PathVariable String name,
-      @Schema(
+      @Parameter(example = "BDRE000800001") @PathVariable String documentNumber,
+      @Parameter(example = "image") @PathVariable String name,
+      @Parameter(
               example = "jpg",
-              allowableValues = {"png", "jpg", "jpeg", "gif", "wmf", "emf", "bitmap"})
+              schema =
+                  @Schema(allowableValues = {"png", "jpg", "jpeg", "gif", "wmf", "emf", "bitmap"}))
           @PathVariable
           String extension)
       throws ObjectStoreServiceException, FileNotFoundException {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/NormsController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/NormsController.java
@@ -153,22 +153,19 @@ public class NormsController {
   @ApiResponse(responseCode = "200")
   @ApiResponse(responseCode = "404", content = @Content)
   public ResponseEntity<LegislationWorkSchema> getLegislation(
-      @Parameter(description = BUND_DESCRIPTION, example = BUND_EXAMPLE)
+      @Parameter(description = BUND_DESCRIPTION, schema = @Schema(allowableValues = {BUND_EXAMPLE}))
           @PathVariable
-          @Schema(allowableValues = {BUND_EXAMPLE})
           String jurisdiction,
-      @Parameter(description = AGENT_DESCRIPTION, example = AGENT_EXAMPLE)
-          @PathVariable
-          @Schema(example = AGENT_EXAMPLE)
+      @Parameter(description = AGENT_DESCRIPTION, example = AGENT_EXAMPLE) @PathVariable
           String agent,
       @Parameter(description = YEAR_DESCRIPTION, example = YEAR_EXAMPLE) @PathVariable String year,
       @Parameter(description = NATURAL_IDENTIFIER_DESCRIPTION, example = NATURAL_IDENTIFIER_EXAMPLE)
           @PathVariable
           String naturalIdentifier,
       @Parameter(example = "2020-06-19") @PathVariable LocalDate pointInTime,
-      @PathVariable @Schema(example = "2") Integer version,
-      @PathVariable @Schema(example = "deu") String language,
-      @PathVariable @Schema(example = "regelungstext-1") String subtype) {
+      @Parameter(example = "2") @PathVariable Integer version,
+      @Parameter(example = "deu") @PathVariable String language,
+      @Parameter(example = "regelungstext-1") @PathVariable String subtype) {
 
     var eli =
         new ExpressionEli(
@@ -199,21 +196,23 @@ public class NormsController {
               mediaType = MediaType.TEXT_HTML_VALUE,
               schema = @Schema(example = HTML_FILE_NOT_FOUND)))
   public ResponseEntity<String> getLegislationSubtypeAsHtml(
-      @Parameter(description = BUND_DESCRIPTION, example = BUND_EXAMPLE)
+      @Parameter(
+              description = BUND_DESCRIPTION,
+              example = BUND_EXAMPLE,
+              schema = @Schema(allowableValues = {BUND_EXAMPLE}))
           @PathVariable
-          @Schema(allowableValues = {BUND_EXAMPLE})
           String jurisdiction,
       @Parameter(description = AGENT_DESCRIPTION, example = AGENT_EXAMPLE) @PathVariable
           String agent,
-      @PathVariable @Parameter(description = YEAR_DESCRIPTION, example = YEAR_EXAMPLE) String year,
+      @Parameter(description = YEAR_DESCRIPTION, example = YEAR_EXAMPLE) @PathVariable String year,
       @Parameter(description = NATURAL_IDENTIFIER_DESCRIPTION, example = NATURAL_IDENTIFIER_EXAMPLE)
           @PathVariable
           String naturalIdentifier,
       @Parameter(example = "2020-06-19") @PathVariable LocalDate pointInTime,
-      @PathVariable @Schema(example = "2") Integer version,
-      @PathVariable @Schema(example = "deu") String language,
-      @PathVariable @Schema(example = "2020-06-19") LocalDate pointInTimeManifestation,
-      @Schema(example = "regelungstext-1") @PathVariable String subtype,
+      @Parameter(example = "2") @PathVariable Integer version,
+      @Parameter(example = "deu") @PathVariable String language,
+      @Parameter(example = "2020-06-19") @PathVariable LocalDate pointInTimeManifestation,
+      @Parameter(example = "regelungstext-1") @PathVariable String subtype,
       @RequestHeader(
               name = ApiConfig.Headers.GET_RESOURCES_VIA,
               required = false,
@@ -268,9 +267,11 @@ public class NormsController {
   @ApiResponse(responseCode = "200")
   @ApiResponse(responseCode = "404", content = @Content(schema = @Schema()))
   public ResponseEntity<byte[]> getLegislationSubtypeAsXml(
-      @Parameter(description = BUND_DESCRIPTION, example = BUND_EXAMPLE)
+      @Parameter(
+              description = BUND_DESCRIPTION,
+              example = BUND_EXAMPLE,
+              schema = @Schema(allowableValues = {BUND_EXAMPLE}))
           @PathVariable
-          @Schema(allowableValues = {BUND_EXAMPLE})
           String jurisdiction,
       @Parameter(description = AGENT_DESCRIPTION, example = AGENT_EXAMPLE) @PathVariable
           String agent,
@@ -279,10 +280,10 @@ public class NormsController {
           @PathVariable
           String naturalIdentifier,
       @Parameter(example = "2020-06-19") @PathVariable LocalDate pointInTime,
-      @PathVariable @Schema(example = "2") Integer version,
-      @PathVariable @Schema(example = "deu") String language,
-      @PathVariable @Schema(example = "2020-06-19") LocalDate pointInTimeManifestation,
-      @Schema(example = "regelungstext-1") @PathVariable String subtype)
+      @Parameter(example = "2") @PathVariable Integer version,
+      @Parameter(example = "deu") @PathVariable String language,
+      @Parameter(example = "2020-06-19") @PathVariable LocalDate pointInTimeManifestation,
+      @Parameter(example = "regelungstext-1") @PathVariable String subtype)
       throws ObjectStoreServiceException {
     var eli =
         new ManifestationEli(
@@ -318,9 +319,11 @@ public class NormsController {
   @ApiResponse(responseCode = "200")
   @ApiResponse(responseCode = "404", content = @Content(schema = @Schema()))
   public ResponseEntity<StreamingResponseBody> getLegislationSubtypeAsZip(
-      @Parameter(description = BUND_DESCRIPTION, example = BUND_EXAMPLE)
+      @Parameter(
+              description = BUND_DESCRIPTION,
+              example = BUND_EXAMPLE,
+              schema = @Schema(allowableValues = {BUND_EXAMPLE}))
           @PathVariable
-          @Schema(allowableValues = {BUND_EXAMPLE})
           String jurisdiction,
       @Parameter(description = AGENT_DESCRIPTION, example = AGENT_EXAMPLE) @PathVariable
           String agent,
@@ -329,9 +332,9 @@ public class NormsController {
           @PathVariable
           String naturalIdentifier,
       @Parameter(example = "2020-06-19") @PathVariable LocalDate pointInTime,
-      @PathVariable @Schema(example = "2") Integer version,
-      @PathVariable @Schema(example = "deu") String language,
-      @PathVariable @Schema(example = "2020-06-19") LocalDate pointInTimeManifestation) {
+      @Parameter(example = "2") @PathVariable Integer version,
+      @Parameter(example = "deu") @PathVariable String language,
+      @Parameter(example = "2020-06-19") @PathVariable LocalDate pointInTimeManifestation) {
     String prefix =
         Stream.of(
                 "eli",
@@ -372,13 +375,15 @@ public class NormsController {
   @ApiResponse(responseCode = "200")
   @ApiResponse(responseCode = "404", content = @Content())
   public ResponseEntity<String> getLegislationArticleAsHtml(
-      @PathVariable
-          @Parameter(description = BUND_DESCRIPTION, example = BUND_EXAMPLE)
-          @Schema(allowableValues = {BUND_EXAMPLE})
+      @Parameter(
+              description = BUND_DESCRIPTION,
+              example = BUND_EXAMPLE,
+              schema = @Schema(allowableValues = {BUND_EXAMPLE}))
+          @PathVariable
           String jurisdiction,
       @Parameter(description = AGENT_DESCRIPTION, example = AGENT_EXAMPLE) @PathVariable
           String agent,
-      @PathVariable @Parameter(description = YEAR_DESCRIPTION, example = YEAR_EXAMPLE) String year,
+      @Parameter(description = YEAR_DESCRIPTION, example = YEAR_EXAMPLE) @PathVariable String year,
       @Parameter(description = NATURAL_IDENTIFIER_DESCRIPTION, example = NATURAL_IDENTIFIER_EXAMPLE)
           @PathVariable
           String naturalIdentifier,
@@ -437,24 +442,24 @@ public class NormsController {
   @ApiResponse(responseCode = "200")
   @ApiResponse(responseCode = "404", content = @Content())
   public ResponseEntity<byte[]> getFile(
-      @Parameter(description = BUND_DESCRIPTION, example = BUND_EXAMPLE)
+      @Parameter(
+              description = BUND_DESCRIPTION,
+              example = BUND_EXAMPLE,
+              schema = @Schema(allowableValues = {BUND_EXAMPLE}))
           @PathVariable
-          @Schema(allowableValues = {BUND_EXAMPLE})
           String jurisdiction,
       @Parameter(description = AGENT_DESCRIPTION, example = AGENT_EXAMPLE) @PathVariable
           String agent,
-      @PathVariable @Parameter(description = YEAR_DESCRIPTION, example = YEAR_EXAMPLE) String year,
+      @Parameter(description = YEAR_DESCRIPTION, example = YEAR_EXAMPLE) @PathVariable String year,
       @Parameter(description = NATURAL_IDENTIFIER_DESCRIPTION, example = NATURAL_IDENTIFIER_EXAMPLE)
           @PathVariable
           String naturalIdentifier,
       @Parameter(example = "2020-06-19") @PathVariable LocalDate pointInTime,
-      @PathVariable @Schema(example = "2") Integer version,
-      @PathVariable @Schema(example = "deu") String language,
-      @PathVariable @Schema(example = "2020-06-19") LocalDate pointInTimeManifestation,
-      @Schema(example = "image") @PathVariable String name,
-      @Schema(
-              example = "jpg",
-              allowableValues = {"pdf", "xml", "jpg", "gif"})
+      @Parameter(example = "2") @PathVariable Integer version,
+      @Parameter(example = "deu") @PathVariable String language,
+      @Parameter(example = "2020-06-19") @PathVariable LocalDate pointInTimeManifestation,
+      @Parameter(example = "image") @PathVariable String name,
+      @Parameter(example = "jpg", schema = @Schema(allowableValues = {"pdf", "xml", "jpg", "gif"}))
           @PathVariable
           String extension)
       throws ObjectStoreServiceException {


### PR DESCRIPTION
- consistently use the correct annotation (`@Parameter`) for endpoint parameter
- use `@Schema` inside the `@Parameter` annotation to define allowed values for the paramter