### PR TITLE
RISDEV-8402

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/NormsController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/NormsController.java
@@ -34,8 +34,6 @@ import java.net.URLConnection;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -167,12 +165,11 @@ public class NormsController {
           String naturalIdentifier,
       @Parameter(example = "2020-06-19") @PathVariable LocalDate pointInTime,
       @PathVariable @Schema(example = "2") Integer version,
-      @PathVariable @Schema(example = "deu") String language,
-      @PathVariable @Schema(example = "regelungstext-1") String subtype) {
+      @PathVariable @Schema(example = "deu") String language) {
 
     var eli =
         new ExpressionEli(
-            jurisdiction, agent, year, naturalIdentifier, pointInTime, version, language, subtype);
+            jurisdiction, agent, year, naturalIdentifier, pointInTime, version, language);
     Optional<Norm> result = normsService.getByExpressionEli(eli);
 
     return result
@@ -333,17 +330,17 @@ public class NormsController {
       @PathVariable @Schema(example = "deu") String language,
       @PathVariable @Schema(example = "2020-06-19") LocalDate pointInTimeManifestation) {
     String prefix =
-        Stream.of(
-                "eli",
-                jurisdiction,
-                agent,
-                year,
-                naturalIdentifier,
-                pointInTime.toString(),
-                version.toString(),
-                language,
-                pointInTimeManifestation.toString())
-            .collect(Collectors.joining("/"));
+        String.join(
+            "/",
+            "eli",
+            jurisdiction,
+            agent,
+            year,
+            naturalIdentifier,
+            pointInTime.toString(),
+            version.toString(),
+            language,
+            pointInTimeManifestation.toString());
 
     String fileName = prefix + ".zip";
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/NormsRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/NormsRepository.java
@@ -32,5 +32,7 @@ public interface NormsRepository extends ElasticsearchRepository<Norm, String> {
 
   void deleteByIndexedAtBefore(String indexedAt);
 
+  void deleteByWorkEliAndIndexedAtBefore(String workEli, String indexedAt);
+
   void deleteByIndexedAtIsNull();
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapsUpdateJob.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapsUpdateJob.java
@@ -3,8 +3,8 @@ package de.bund.digitalservice.ris.search.service;
 import de.bund.digitalservice.ris.search.models.sitemap.SitemapType;
 import de.bund.digitalservice.ris.search.repository.objectstorage.CaseLawBucket;
 import de.bund.digitalservice.ris.search.repository.objectstorage.NormsBucket;
+import de.bund.digitalservice.ris.search.utils.eli.EliFile;
 import de.bund.digitalservice.ris.search.utils.eli.ExpressionEli;
-import de.bund.digitalservice.ris.search.utils.eli.ManifestationEli;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -38,13 +38,13 @@ public class SitemapsUpdateJob implements Job {
   }
 
   public void createSitemapsForNorms() {
-    List<ManifestationEli> manifestations =
+    List<EliFile> manifestations =
         normsBucket.getAllKeysByPrefix("eli/").stream()
-            .map(ManifestationEli::fromString)
+            .map(EliFile::fromString)
             .flatMap(Optional::stream)
             .toList();
     Set<ExpressionEli> expressions =
-        manifestations.stream().map(ManifestationEli::getExpressionEli).collect(Collectors.toSet());
+        manifestations.stream().map(EliFile::getExpressionEli).collect(Collectors.toSet());
     List<List<ExpressionEli>> batches =
         ListUtils.partition(expressions.stream().toList(), urlsPerPage);
     for (int i = 0; i < batches.size(); i++) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/XsltTransformerService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/XsltTransformerService.java
@@ -4,7 +4,7 @@ import de.bund.digitalservice.ris.search.exception.FileTransformationException;
 import de.bund.digitalservice.ris.search.exception.NoSuchKeyException;
 import de.bund.digitalservice.ris.search.repository.objectstorage.NormsBucket;
 import de.bund.digitalservice.ris.search.service.exception.XMLElementNotFoundException;
-import de.bund.digitalservice.ris.search.utils.eli.ManifestationEli;
+import de.bund.digitalservice.ris.search.utils.eli.EliFile;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringReader;
@@ -12,6 +12,7 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
@@ -59,8 +60,8 @@ public class XsltTransformerService {
           } else if (href.startsWith("eli/")) {
             logger.debug("Resolving attachment: {}", href);
             // validate that the href is a valid manifestation ELI
-            var eli = ManifestationEli.fromString(href);
-            return resolveManifestationEliResource(
+            Optional<EliFile> eli = EliFile.fromString(href);
+            return resolveEliResource(
                 eli.orElseThrow(() -> new TransformerException("Invalid ELI: " + href)));
           } else {
             throw new TransformerException("Invalid URI: " + href);
@@ -76,13 +77,12 @@ public class XsltTransformerService {
    *     more specific indications as to where the error occurred.
    */
   @NotNull
-  private StreamSource resolveManifestationEliResource(ManifestationEli eli)
-      throws TransformerException {
+  private StreamSource resolveEliResource(EliFile eliFile) throws TransformerException {
     try {
-      var response = this.normsBucket.getStream(eli.toString());
+      var response = this.normsBucket.getStream(eliFile.toString());
       return new StreamSource(response);
     } catch (NoSuchKeyException | NullPointerException e) {
-      throw new TransformerException("Failed to resolve: " + eli, e);
+      throw new TransformerException("Failed to resolve: " + eliFile, e);
     }
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/eli/EliFile.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/eli/EliFile.java
@@ -1,0 +1,74 @@
+package de.bund.digitalservice.ris.search.utils.eli;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public record EliFile(
+    String jurisdiction,
+    String agent,
+    String year,
+    String naturalIdentifier,
+    LocalDate pointInTime,
+    Integer version,
+    String language,
+    LocalDate pointInTimeManifestation,
+    String fileName,
+    String format) {
+
+  static final Pattern pattern =
+      Pattern.compile(
+          "eli/(?<jurisdiction>[^/]+)/(?<agent>[^/]+)/(?<year>[^/]+)/(?<naturalIdentifier>[^/]+)/(?<pointInTime>[^/]+)/(?<version>[^/]+)/(?<language>[^/]+)/(?<pointInTimeManifestation>[^/]+)/(?<fileName>[^/]+)\\.(?<format>[^/]+)");
+
+  public static Optional<EliFile> fromString(String fileName) {
+    Matcher matcher = pattern.matcher(fileName);
+
+    if (!matcher.matches()) {
+      return Optional.empty();
+    }
+    try {
+
+      return Optional.of(
+          new EliFile(
+              matcher.group("jurisdiction"),
+              matcher.group("agent"),
+              matcher.group("year"),
+              matcher.group("naturalIdentifier"),
+              LocalDate.parse(matcher.group("pointInTime"), DateTimeFormatter.ISO_LOCAL_DATE),
+              Integer.valueOf(matcher.group("version")),
+              matcher.group("language"),
+              LocalDate.parse(
+                  matcher.group("pointInTimeManifestation"), DateTimeFormatter.ISO_LOCAL_DATE),
+              matcher.group("fileName"),
+              matcher.group("format")));
+    } catch (IllegalStateException | IllegalArgumentException | DateTimeParseException e) {
+      return Optional.empty();
+    }
+  }
+
+  public WorkEli getWorkEli() {
+    return new WorkEli(jurisdiction(), agent(), year(), naturalIdentifier());
+  }
+
+  public ExpressionEli getExpressionEli() {
+    return new ExpressionEli(
+        jurisdiction(), agent(), year(), naturalIdentifier(), pointInTime(), version(), language());
+  }
+
+  public ManifestationEli getManifestationEli() {
+    return new ManifestationEli(
+        jurisdiction(),
+        agent(),
+        year(),
+        naturalIdentifier(),
+        pointInTime(),
+        version(),
+        language(),
+        pointInTimeManifestation(),
+        fileName(),
+        format());
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/eli/ExpressionEli.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/eli/ExpressionEli.java
@@ -2,8 +2,6 @@ package de.bund.digitalservice.ris.search.utils.eli;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public record ExpressionEli(
     String jurisdiction,
@@ -12,38 +10,10 @@ public record ExpressionEli(
     String naturalIdentifier,
     LocalDate pointInTime,
     Integer version,
-    String language,
-    String subtype) {
+    String language) {
 
   @Override
   public String toString() {
-    return "eli/%s/%s/%s/%s/%s/%d/%s/%s"
-        .formatted(
-            jurisdiction,
-            agent,
-            year,
-            naturalIdentifier,
-            pointInTime.format(DateTimeFormatter.ISO_LOCAL_DATE),
-            version,
-            language,
-            subtype);
-  }
-
-  /**
-   * Example return:
-   *
-   * <pre>eli/bund/bgbl-1/1979/s1325/2020-06-19/2/deu</pre>
-   *
-   * Full expression ELI:
-   *
-   * <pre>eli/bund/bgbl-1/1979/s1325/2020-06-19/2/deu/regelungstext-1</pre>
-   *
-   * @return A string corresponding to the FRBRuri property of the underlying LegalDocML.de files.
-   *     Unlike {@link #toString()}, this is a prefix of the manifestation ELI and can be used to
-   *     pre-filter. Note that it is missing the subtype, which is required to uniquely identify
-   *     documents.
-   */
-  public String getUriPrefix() {
     return "eli/%s/%s/%s/%s/%s/%d/%s"
         .formatted(
             jurisdiction,
@@ -53,31 +23,5 @@ public record ExpressionEli(
             pointInTime.format(DateTimeFormatter.ISO_LOCAL_DATE),
             version,
             language);
-  }
-
-  public WorkEli getWorkEli() {
-    return new WorkEli(jurisdiction, agent, year, naturalIdentifier, subtype);
-  }
-
-  static final Pattern pattern =
-      Pattern.compile(
-          "eli/(?<jurisdiction>[^/]+)/(?<agent>[^/]+)/(?<year>[^/]+)/(?<naturalIdentifier>[^/]+)/(?<pointInTime>[^/]+)/(?<version>[^/]+)/(?<language>[^/]+)/(?<subtype>[^/]+)");
-
-  public static ExpressionEli fromString(String expressionEli) {
-    Matcher matcher = pattern.matcher(expressionEli);
-
-    if (!matcher.matches()) {
-      throw new IllegalArgumentException("Invalid expression Eli");
-    }
-
-    return new ExpressionEli(
-        matcher.group("jurisdiction"),
-        matcher.group("agent"),
-        matcher.group("year"),
-        matcher.group("naturalIdentifier"),
-        LocalDate.parse(matcher.group("pointInTime"), DateTimeFormatter.ISO_LOCAL_DATE),
-        Integer.valueOf(matcher.group("version")),
-        matcher.group("language"),
-        matcher.group("subtype"));
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/eli/ManifestationEli.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/eli/ManifestationEli.java
@@ -2,10 +2,6 @@ package de.bund.digitalservice.ris.search.utils.eli;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public record ManifestationEli(
     String jurisdiction,
@@ -33,51 +29,5 @@ public record ManifestationEli(
             pointInTimeManifestation().format(DateTimeFormatter.ISO_LOCAL_DATE),
             subtype(),
             format());
-  }
-
-  public WorkEli getWorkEli() {
-    return new WorkEli(jurisdiction(), agent(), year(), naturalIdentifier(), subtype());
-  }
-
-  public ExpressionEli getExpressionEli() {
-    return new ExpressionEli(
-        jurisdiction(),
-        agent(),
-        year(),
-        naturalIdentifier(),
-        pointInTime(),
-        version(),
-        language(),
-        subtype());
-  }
-
-  static final Pattern pattern =
-      Pattern.compile(
-          "eli/(?<jurisdiction>[^/]+)/(?<agent>[^/]+)/(?<year>[^/]+)/(?<naturalIdentifier>[^/]+)/(?<pointInTime>[^/]+)/(?<version>[^/]+)/(?<language>[^/]+)/(?<pointInTimeManifestation>[^/]+)/(?<subtype>[^/]+)\\.(?<format>[^/]+)");
-
-  public static Optional<ManifestationEli> fromString(String manifestationEli) {
-    Matcher matcher = pattern.matcher(manifestationEli);
-
-    if (!matcher.matches()) {
-      return Optional.empty();
-    }
-    try {
-
-      return Optional.of(
-          new ManifestationEli(
-              matcher.group("jurisdiction"),
-              matcher.group("agent"),
-              matcher.group("year"),
-              matcher.group("naturalIdentifier"),
-              LocalDate.parse(matcher.group("pointInTime"), DateTimeFormatter.ISO_LOCAL_DATE),
-              Integer.valueOf(matcher.group("version")),
-              matcher.group("language"),
-              LocalDate.parse(
-                  matcher.group("pointInTimeManifestation"), DateTimeFormatter.ISO_LOCAL_DATE),
-              matcher.group("subtype"),
-              matcher.group("format")));
-    } catch (IllegalStateException | IllegalArgumentException | DateTimeParseException e) {
-      return Optional.empty();
-    }
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/eli/WorkEli.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/eli/WorkEli.java
@@ -1,31 +1,9 @@
 package de.bund.digitalservice.ris.search.utils.eli;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-public record WorkEli(
-    String jurisdiction, String agent, String year, String naturalIdentifier, String subtype) {
-
-  public static WorkEli fromString(String workEli) {
-    Matcher matcher =
-        Pattern.compile(
-                "eli/(?<jurisdiction>[^/]+)/(?<agent>[^/]+)/(?<year>[^/]+)/(?<naturalIdentifier>[^/]+)/(?<subtype>[^/]+)")
-            .matcher(workEli);
-
-    if (!matcher.matches()) {
-      throw new IllegalArgumentException("Invalid work Eli");
-    }
-
-    return new WorkEli(
-        matcher.group("jurisdiction"),
-        matcher.group("agent"),
-        matcher.group("year"),
-        matcher.group("naturalIdentifier"),
-        matcher.group("subtype"));
-  }
+public record WorkEli(String jurisdiction, String agent, String year, String naturalIdentifier) {
 
   @Override
   public String toString() {
-    return "eli/%s/%s/%s/%s/%s".formatted(jurisdiction, agent, year, naturalIdentifier, subtype);
+    return "eli/%s/%s/%s/%s".formatted(jurisdiction, agent, year, naturalIdentifier);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/SitemapServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/SitemapServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import de.bund.digitalservice.ris.search.models.sitemap.SitemapType;
 import de.bund.digitalservice.ris.search.repository.objectstorage.PortalBucket;
 import de.bund.digitalservice.ris.search.service.SitemapService;
+import de.bund.digitalservice.ris.search.utils.eli.EliFile;
 import de.bund.digitalservice.ris.search.utils.eli.ExpressionEli;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,8 +22,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class SitemapServiceTest {
-  private static final String TEST_EXPRESSION_ELI =
-      "eli/bund/bgbl-1/1991/s101/1991-01-01/1/deu/regelungstext-1";
+  private static final String TEST_ELI_FILE =
+      "eli/bund/bgbl-1/1991/s101/1991-01-01/1/deu/1991-01-20/regelungstext-1.xml";
   private SitemapService sitemapService;
   @Mock private PortalBucket portalBucket;
 
@@ -44,10 +45,9 @@ class SitemapServiceTest {
 
   @Test
   void testGenerateNormsSitemap() {
-    ExpressionEli norm = ExpressionEli.fromString(TEST_EXPRESSION_ELI);
+    ExpressionEli norm = EliFile.fromString(TEST_ELI_FILE).get().getExpressionEli();
     String normSitemap = sitemapService.generateNormsSitemap(List.of(norm));
-    assertTrue(
-        normSitemap.contains("<loc>https://test.local/norms/" + TEST_EXPRESSION_ELI + "</loc>"));
+    assertTrue(normSitemap.contains("<loc>https://test.local/norms/" + norm + "</loc>"));
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/utils/EliUtilsTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/utils/EliUtilsTest.java
@@ -1,8 +1,9 @@
 package de.bund.digitalservice.ris.search.unit.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import de.bund.digitalservice.ris.search.utils.eli.EliFile;
 import de.bund.digitalservice.ris.search.utils.eli.ExpressionEli;
 import de.bund.digitalservice.ris.search.utils.eli.ManifestationEli;
 import de.bund.digitalservice.ris.search.utils.eli.WorkEli;
@@ -14,32 +15,20 @@ class EliUtilsTest {
 
   @Test
   void testWorkEliParsesStringCorrectly() {
-    String workEliString = "eli/bund/bgbl-1/2021/1234/regelungstext-1";
-    WorkEli workEli = WorkEli.fromString(workEliString);
+    String eliFileString =
+        "eli/bund/bgbl-1/2021/1234/2021-01-01/1/deu/2021-01-20/regelungstext-1.xml";
+    WorkEli workEli = EliFile.fromString(eliFileString).get().getWorkEli();
     assertEquals("bund", workEli.jurisdiction());
     assertEquals("bgbl-1", workEli.agent());
     assertEquals("2021", workEli.year());
     assertEquals("1234", workEli.naturalIdentifier());
-    assertEquals("regelungstext-1", workEli.subtype());
-    assertEquals(workEliString, workEli.toString());
-  }
-
-  @ValueSource(
-      strings = {
-        "eli/bund/bgbl-1//2021/1234/regelungstext-1",
-        "eli/bund/bgbl-1/2021/1234",
-        "",
-        "eli/bund"
-      })
-  @ParameterizedTest
-  void testWorkEliThrowsErrorOnInvalidEli(String workEliString) {
-    assertThrows(Exception.class, () -> WorkEli.fromString(workEliString));
+    assertEquals("eli/bund/bgbl-1/2021/1234", workEli.toString());
   }
 
   @Test
   void testExpressionEliParsesStringCorrectly() {
-    var expressionEliString = "eli/bund/bgbl-1/1950/s69/1964-01-01/1/deu/regelungstext-1";
-    ExpressionEli expressionEli = ExpressionEli.fromString(expressionEliString);
+    var eliFileString = "eli/bund/bgbl-1/1950/s69/1964-01-01/1/deu/1964-01-01/regelungstext-1.xml";
+    ExpressionEli expressionEli = EliFile.fromString(eliFileString).get().getExpressionEli();
     assertEquals("bund", expressionEli.jurisdiction());
     assertEquals("bgbl-1", expressionEli.agent());
     assertEquals("1950", expressionEli.year());
@@ -47,29 +36,13 @@ class EliUtilsTest {
     assertEquals("1964-01-01", expressionEli.pointInTime().toString());
     assertEquals(1, expressionEli.version());
     assertEquals("deu", expressionEli.language());
-    assertEquals("regelungstext-1", expressionEli.subtype());
-    assertEquals(expressionEliString, expressionEli.toString());
-
-    assertEquals("eli/bund/bgbl-1/1950/s69/regelungstext-1", expressionEli.getWorkEli().toString());
-  }
-
-  @ValueSource(
-      strings = {
-        "eli/bund/bgbl-1/1950/s69/1964-01-01/a/deu",
-        "",
-        "eli/bund/bgbl-1/1950/s69/1964-1-1/1/deu"
-      })
-  @ParameterizedTest
-  void testExpressionEliThrowsErrorOnInvalidEli(String expressionEliString) {
-
-    assertThrows(Exception.class, () -> ExpressionEli.fromString(expressionEliString));
+    assertEquals("eli/bund/bgbl-1/1950/s69/1964-01-01/1/deu", expressionEli.toString());
   }
 
   @Test
   void testManifestationEliParsesStringCorrectly() {
-    var manifestationEliString =
-        "eli/bund/bgbl-1/1950/s69/1964-01-01/1/deu/1964-02-02/regelungstext-1.xml";
-    ManifestationEli manifestationEli = ManifestationEli.fromString(manifestationEliString).get();
+    String eliFile = "eli/bund/bgbl-1/1950/s69/1964-01-01/1/deu/1964-02-02/regelungstext-1.xml";
+    ManifestationEli manifestationEli = EliFile.fromString(eliFile).get().getManifestationEli();
     assertEquals("bund", manifestationEli.jurisdiction());
     assertEquals("bgbl-1", manifestationEli.agent());
     assertEquals("1950", manifestationEli.year());
@@ -79,21 +52,24 @@ class EliUtilsTest {
     assertEquals("deu", manifestationEli.language());
     assertEquals("1964-02-02", manifestationEli.pointInTimeManifestation().toString());
     assertEquals("regelungstext-1", manifestationEli.subtype());
-    assertEquals(manifestationEliString, manifestationEli.toString());
-
     assertEquals(
-        "eli/bund/bgbl-1/1950/s69/regelungstext-1", manifestationEli.getWorkEli().toString());
+        "eli/bund/bgbl-1/1950/s69/1964-01-01/1/deu/1964-02-02/regelungstext-1.xml",
+        manifestationEli.toString());
   }
 
   @ValueSource(
       strings = {
-        "eli/bund/bgbl-1/1950/s69/1964-01-01/a/deu/1964-2-2/regelungstext-1.xml",
         "",
+        "eli/bund",
+        "eli/bund/bgbl-1/2021/1234",
+        "eli/bund/bgbl-1//2021/1234/regelungstext-1",
+        "eli/bund/bgbl-1/1950/s69/1964-01-01/a/deu",
+        "eli/bund/bgbl-1/1950/s69/1964-1-1/1/deu",
+        "eli/bund/bgbl-1/1950/s69/1964-01-01/a/deu/1964-2-2/regelungstext-1.xml",
         "eli/bund/bgbl-1/1950/s69/1964-01-01/1/deu/regelungstext"
       })
   @ParameterizedTest
-  void testManifestationEliThrowsErrorOnInvalidEli(String expressionEliString) {
-
-    assertThrows(Exception.class, () -> ManifestationEli.fromString(expressionEliString).get());
+  void testInvalidEliFile(String eliFile) {
+    assertTrue(EliFile.fromString(eliFile).isEmpty());
   }
 }


### PR DESCRIPTION
Simple search | Show most relevant expression (backend)
* Added EliFile and refactored WorkEli, ExpressionEli and ManifestationEli classes.
* Norm attachments can now be an instance of EliFile, but not ManifestationEli. The code using the classes was adjusted to reflect this and now the names make more sense.
* Remove subtype from WorkEli because it was removed in ldml.de 1.8
* Remove subtype from ExpressionEli because it was removed in ldml.de 1.8
* Deleted dead code (and it's tests) that was only used in tests and not in the actual code
* Refactored IndexNormsService to group by norm work so that if any file related to a work is touched, then the whole work will be reindexed. This refactor is necessary for the next part of the user story. Calculation of the relevance window requires all expressions in the entire work.