### PR TITLE
RISDEV-9279 Fixed issues with headings and accessibility

### DIFF
--- a/e2e/test-results/accessibility-results/Accessibility Page Page.html
+++ b/e2e/test-results/accessibility-results/Accessibility Page Page.html
@@ -1,0 +1,879 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <!-- Required meta tags -->
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <style>
+            .card-header .btn-link {
+                color: #2557a7;
+            }
+            .violationCard {
+                width: 100%;
+                margin-bottom: 1rem;
+            }
+            .violationCardLine {
+                display: flex;
+                justify-content: space-between;
+                align-items: start;
+                font-weight: 500;
+                line-height: 1.2;
+            }
+            .card-title {
+                font-size: 1.25rem;
+            }
+            .violationCardTitleItem {
+                font-size: 1rem;
+                font-weight: 500;
+            }
+            .card-text {
+                font-size: 0.95rem;
+                font-weight: 300;
+            }
+            .learnMore {
+                margin-bottom: 0.75rem;
+                white-space: nowrap;
+                color: #2557a7;
+            }
+            .card-link {
+                color: #2557a7;
+            }
+            .violationNode {
+                font-size: 0.85rem;
+            }
+            .wrapBreakWord {
+                word-break: break-word;
+            }
+            .summary {
+                font-size: 1rem;
+            }
+            .summarySection {
+                margin: 0.5rem 0;
+            }
+            .hljs {
+                white-space: pre-wrap;
+                width: 100%;
+                background: #f0f0f0;
+            }
+            p {
+                margin-top: 0.3rem;
+            }
+            li {
+                line-height: 1.618;
+            }
+        </style>
+        <!-- Bootstrap CSS -->
+        <link
+            rel="stylesheet"
+            href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
+            integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z"
+            crossorigin="anonymous"
+        />
+        <script
+            src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+            integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+            crossorigin="anonymous"
+        ></script>
+        <script
+            src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"
+            integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
+            crossorigin="anonymous"
+        ></script>
+        <script
+            src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
+            integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+            crossorigin="anonymous"
+        ></script>
+        <link
+            rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/styles/stackoverflow-light.min.css"
+        />
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/highlight.min.js"></script>
+        <title>Axe-core® Accessibility Results</title>
+    </head>
+    <main role="main">
+        <div style="padding: 2rem">
+            <h1>
+                Axe-core® Accessibility Results
+            </h1>
+            <div class="summarySection">
+                <div class="summary">
+                    Page URL:
+                    <a href="http:&#x2F;&#x2F;localhost:3000&#x2F;barrierefreiheit" target="_blank" class="card-link">http:&#x2F;&#x2F;localhost:3000&#x2F;barrierefreiheit</a>
+                    <br />
+                </div>
+            </div>
+            <h2>axe-core found <span class="badge badge-success">0</span> violations</h2>
+                <tbody>
+                </tbody>
+            </table>
+            <div id="accordionPasses">
+                <div class="card">
+                    <div class="card-header" id="headingOne">
+                        <p class="mb-0">
+                            <button
+                                class="btn btn-link"
+                                data-toggle="collapse"
+                                data-target="#passes"
+                                aria-expanded="false"
+                                aria-controls="passes"
+                            >
+                                axe returned 37 passed axe
+                                checks. Expand details on
+                                click
+                            </button>
+                        </p>
+                    </div>
+                    <div
+                        id="passes"
+                        class="collapse"
+                        aria-labelledby="headingOne"
+                        data-parent="#accordionPasses"
+                    >
+                        <div class="card-body">
+                            <table class="table table-bordered">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 5%">#</th>
+                                        <th style="width: 40%">Description</th>
+                                        <th style="width: 5%">Axe rule ID</th>
+                                        <th style="width: 15%">WCAG</th>
+                                        <th style="width: 5%">Nodes passed check</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th scope="row">1</th>
+                                        <td>Elements must only use supported ARIA attributes</td>
+                                        <td>aria-allowed-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">2</th>
+                                        <td>ARIA attributes must be used as specified for the element&#39;s role</td>
+                                        <td>aria-conditional-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">3</th>
+                                        <td>aria-hidden&#x3D;&quot;true&quot; must not be present on the document body</td>
+                                        <td>aria-hidden-body</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">4</th>
+                                        <td>ARIA hidden element must not be focusable or contain focusable elements</td>
+                                        <td>aria-hidden-focus</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">5</th>
+                                        <td>Elements must only use permitted ARIA attributes</td>
+                                        <td>aria-prohibited-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">6</th>
+                                        <td>ARIA attributes must conform to valid values</td>
+                                        <td>aria-valid-attr-value</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">7</th>
+                                        <td>ARIA attributes must conform to valid names</td>
+                                        <td>aria-valid-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">8</th>
+                                        <td>Inline text spacing must be adjustable with custom stylesheets</td>
+                                        <td>avoid-inline-spacing</td>
+                                        <td>WCAG 2.1 Level AA, WCAG 1.4.1.2</td>
+                                        <td>2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">9</th>
+                                        <td>Buttons must have discernible text</td>
+                                        <td>button-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">10</th>
+                                        <td>Page must have means to bypass repeated blocks</td>
+                                        <td>bypass</td>
+                                        <td>WCAG 2 Level A, WCAG 2.4.1</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">11</th>
+                                        <td>Elements must meet minimum color contrast ratio thresholds</td>
+                                        <td>color-contrast</td>
+                                        <td>WCAG 2 Level AA, WCAG 1.4.3</td>
+                                        <td>44</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">12</th>
+                                        <td>Documents must have &lt;title&gt; element to aid in navigation</td>
+                                        <td>document-title</td>
+                                        <td>WCAG 2 Level A, WCAG 2.4.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">13</th>
+                                        <td>IDs used in ARIA and labels must be unique</td>
+                                        <td>duplicate-id-aria</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">14</th>
+                                        <td>Headings should not be empty</td>
+                                        <td>empty-heading</td>
+                                        <td>Best practice</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">15</th>
+                                        <td>Form field must not have multiple label elements</td>
+                                        <td>form-field-multiple-labels</td>
+                                        <td>WCAG 2 Level A, WCAG 3.3.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">16</th>
+                                        <td>Heading levels should only increase by one</td>
+                                        <td>heading-order</td>
+                                        <td>Best practice</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">17</th>
+                                        <td>&lt;html&gt; element must have a lang attribute</td>
+                                        <td>html-has-lang</td>
+                                        <td>WCAG 2 Level A, WCAG 3.1.1</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">18</th>
+                                        <td>&lt;html&gt; element must have a valid value for the lang attribute</td>
+                                        <td>html-lang-valid</td>
+                                        <td>WCAG 2 Level A, WCAG 3.1.1</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">19</th>
+                                        <td>Images must have alternative text</td>
+                                        <td>image-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">20</th>
+                                        <td>Alternative text of images should not be repeated as text</td>
+                                        <td>image-redundant-alt</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">21</th>
+                                        <td>Form elements should have a visible label</td>
+                                        <td>label-title-only</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">22</th>
+                                        <td>Form elements must have labels</td>
+                                        <td>label</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">23</th>
+                                        <td>Contentinfo landmark should not be contained in another landmark</td>
+                                        <td>landmark-contentinfo-is-top-level</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">24</th>
+                                        <td>Main landmark should not be contained in another landmark</td>
+                                        <td>landmark-main-is-top-level</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">25</th>
+                                        <td>Document should not have more than one contentinfo landmark</td>
+                                        <td>landmark-no-duplicate-contentinfo</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">26</th>
+                                        <td>Document should not have more than one main landmark</td>
+                                        <td>landmark-no-duplicate-main</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">27</th>
+                                        <td>Document should have one main landmark</td>
+                                        <td>landmark-one-main</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">28</th>
+                                        <td>Landmarks should have a unique role or role&#x2F;label&#x2F;title (i.e. accessible name) combination</td>
+                                        <td>landmark-unique</td>
+                                        <td>Best practice</td>
+                                        <td>5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">29</th>
+                                        <td>Links must be distinguishable without relying on color</td>
+                                        <td>link-in-text-block</td>
+                                        <td>WCAG 2 Level A, WCAG 1.4.1</td>
+                                        <td>4</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">30</th>
+                                        <td>Links must have discernible text</td>
+                                        <td>link-name</td>
+                                        <td>WCAG 2 Level A, WCAG 2.4.4, WCAG 4.1.2</td>
+                                        <td>20</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">31</th>
+                                        <td>&lt;ul&gt; and &lt;ol&gt; must only directly contain &lt;li&gt;, &lt;script&gt; or &lt;template&gt; elements</td>
+                                        <td>list</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                        <td>3</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">32</th>
+                                        <td>&lt;li&gt; elements must be contained in a &lt;ul&gt; or &lt;ol&gt;</td>
+                                        <td>listitem</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                        <td>13</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">33</th>
+                                        <td>Users should be able to zoom and scale the text up to 500%</td>
+                                        <td>meta-viewport-large</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">34</th>
+                                        <td>Zooming and scaling must not be disabled</td>
+                                        <td>meta-viewport</td>
+                                        <td>WCAG 2 Level AA, WCAG 1.4.4</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">35</th>
+                                        <td>Interactive controls must not be nested</td>
+                                        <td>nested-interactive</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">36</th>
+                                        <td>Page should contain a level-one heading</td>
+                                        <td>page-has-heading-one</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">37</th>
+                                        <td>All page content should be contained by landmarks</td>
+                                        <td>region</td>
+                                        <td>Best practice</td>
+                                        <td>136</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="accordionIncomplete">
+                <div class="card">
+                    <div class="card-header" id="headingTwo">
+                        <p class="mb-0">
+                            <button
+                                class="btn btn-link"
+                                data-toggle="collapse"
+                                data-target="#incomplete"
+                                aria-expanded="false"
+                                aria-controls="incomplete"
+                            >
+                                axe returned 3 incomplete checks. Expand
+                                details on click
+                            </button>
+                        </p>
+                    </div>
+                    <div
+                        id="incomplete"
+                        class="collapse"
+                        aria-labelledby="headingTwo"
+                        data-parent="#accordionIncomplete"
+                    >
+                        <div class="card-body">
+                            <p><em>What 'incomplete' axe checks means?</em></p>
+                            <p>
+                                Incomplete results were aborted and require further testing. This
+                                can happen either because of technical restrictions to what the rule
+                                can test, or because a javascript error occurred.
+                            </p>
+                            <p>
+                                <a
+                                    href="https://www.deque.com/axe/core-documentation/api-documentation/#results-object"
+                                    >Visit axe API Documentation</a
+                                >
+                                to learn more.
+                            </p>
+                            <table class="table table-bordered">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 5%">#</th>
+                                        <th style="width: 50%">Description</th>
+                                        <th style="width: 20%">Axe rule ID</th>
+                                        <th style="width: 15%">WCAG</th>
+                                        <th style="width: 10%">Nodes with incomplete check</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th scope="row">1</th>
+                                        <td>Elements must only use permitted ARIA attributes</td>
+                                        <td>aria-prohibited-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">2</th>
+                                        <td>ARIA attributes must conform to valid values</td>
+                                        <td>aria-valid-attr-value</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">3</th>
+                                        <td>Elements must meet minimum color contrast ratio thresholds</td>
+                                        <td>color-contrast</td>
+                                        <td>WCAG 2 Level AA, WCAG 1.4.3</td>
+                                        <td>1</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="accordionInapplicable">
+                <div class="card">
+                    <div class="card-header" id="headingThree">
+                        <p class="mb-0">
+                            <button
+                                class="btn btn-link"
+                                data-toggle="collapse"
+                                data-target="#inapplicable"
+                                aria-expanded="false"
+                                aria-controls="inapplicable"
+                            >
+                                axe returned 52 inapplicable checks.
+                                Expand details on click
+                            </button>
+                        </p>
+                    </div>
+                    <div
+                        id="inapplicable"
+                        class="collapse"
+                        aria-labelledby="headingThree"
+                        data-parent="#accordionInapplicable"
+                    >
+                        <div class="card-body">
+                            <p><em>What 'inapplicable' axe checks means?</em></p>
+                            <p>
+                                The inapplicable array lists all the rules for which no matching
+                                elements were found on the page.
+                            </p>
+                            <p>
+                                <a
+                                    href="https://www.deque.com/axe/core-documentation/api-documentation/#results-object"
+                                    >Visit axe API Documentation</a
+                                >
+                                to learn more.
+                            </p>
+                            <table class="table table-bordered">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 5%">#</th>
+                                        <th style="width: 50%">Description</th>
+                                        <th style="width: 20%">Axe rule ID</th>
+                                        <th style="width: 15%">WCAG</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th scope="row">1</th>
+                                        <td>accesskey attribute value should be unique</td>
+                                        <td>accesskeys</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">2</th>
+                                        <td>Active &lt;area&gt; elements must have alternative text</td>
+                                        <td>area-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 2.4.4, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">3</th>
+                                        <td>ARIA role should be appropriate for the element</td>
+                                        <td>aria-allowed-role</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">4</th>
+                                        <td>aria-braille attributes must have a non-braille equivalent</td>
+                                        <td>aria-braille-equivalent</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">5</th>
+                                        <td>ARIA commands must have an accessible name</td>
+                                        <td>aria-command-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">6</th>
+                                        <td>Deprecated ARIA roles must not be used</td>
+                                        <td>aria-deprecated-role</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">7</th>
+                                        <td>ARIA dialog and alertdialog nodes should have an accessible name</td>
+                                        <td>aria-dialog-name</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">8</th>
+                                        <td>ARIA input fields must have an accessible name</td>
+                                        <td>aria-input-field-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">9</th>
+                                        <td>ARIA meter nodes must have an accessible name</td>
+                                        <td>aria-meter-name</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">10</th>
+                                        <td>ARIA progressbar nodes must have an accessible name</td>
+                                        <td>aria-progressbar-name</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">11</th>
+                                        <td>Required ARIA attributes must be provided</td>
+                                        <td>aria-required-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">12</th>
+                                        <td>Certain ARIA roles must contain particular children</td>
+                                        <td>aria-required-children</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">13</th>
+                                        <td>Certain ARIA roles must be contained by particular parents</td>
+                                        <td>aria-required-parent</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">14</th>
+                                        <td>ARIA roles used must conform to valid values</td>
+                                        <td>aria-roles</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">15</th>
+                                        <td>&quot;role&#x3D;text&quot; should have no focusable descendants</td>
+                                        <td>aria-text</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">16</th>
+                                        <td>ARIA toggle fields must have an accessible name</td>
+                                        <td>aria-toggle-field-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">17</th>
+                                        <td>ARIA tooltip nodes must have an accessible name</td>
+                                        <td>aria-tooltip-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">18</th>
+                                        <td>ARIA treeitem nodes should have an accessible name</td>
+                                        <td>aria-treeitem-name</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">19</th>
+                                        <td>autocomplete attribute must be used correctly</td>
+                                        <td>autocomplete-valid</td>
+                                        <td>WCAG 2.1 Level AA, WCAG 1.3.5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">20</th>
+                                        <td>&lt;blink&gt; elements are deprecated and must not be used</td>
+                                        <td>blink</td>
+                                        <td>WCAG 2 Level A, WCAG 2.2.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">21</th>
+                                        <td>&lt;dl&gt; elements must only directly contain properly-ordered &lt;dt&gt; and &lt;dd&gt; groups, &lt;script&gt;, &lt;template&gt; or &lt;div&gt; elements</td>
+                                        <td>definition-list</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">22</th>
+                                        <td>&lt;dt&gt; and &lt;dd&gt; elements must be contained by a &lt;dl&gt;</td>
+                                        <td>dlitem</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">23</th>
+                                        <td>Table header text should not be empty</td>
+                                        <td>empty-table-header</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">24</th>
+                                        <td>Frames with focusable content must not have tabindex&#x3D;-1</td>
+                                        <td>frame-focusable-content</td>
+                                        <td>WCAG 2 Level A, WCAG 2.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">25</th>
+                                        <td>Frames should be tested with axe-core</td>
+                                        <td>frame-tested</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">26</th>
+                                        <td>Frames must have a unique title attribute</td>
+                                        <td>frame-title-unique</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">27</th>
+                                        <td>Frames must have an accessible name</td>
+                                        <td>frame-title</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">28</th>
+                                        <td>HTML elements with lang and xml:lang must have the same base language</td>
+                                        <td>html-xml-lang-mismatch</td>
+                                        <td>WCAG 2 Level A, WCAG 3.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">29</th>
+                                        <td>Input buttons must have discernible text</td>
+                                        <td>input-button-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">30</th>
+                                        <td>Image buttons must have alternative text</td>
+                                        <td>input-image-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">31</th>
+                                        <td>Banner landmark should not be contained in another landmark</td>
+                                        <td>landmark-banner-is-top-level</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">32</th>
+                                        <td>Aside should not be contained in another landmark</td>
+                                        <td>landmark-complementary-is-top-level</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">33</th>
+                                        <td>Document should not have more than one banner landmark</td>
+                                        <td>landmark-no-duplicate-banner</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">34</th>
+                                        <td>&lt;marquee&gt; elements are deprecated and must not be used</td>
+                                        <td>marquee</td>
+                                        <td>WCAG 2 Level A, WCAG 2.2.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">35</th>
+                                        <td>Delayed refresh under 20 hours must not be used</td>
+                                        <td>meta-refresh</td>
+                                        <td>WCAG 2 Level A, WCAG 2.2.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">36</th>
+                                        <td>&lt;object&gt; elements must have alternative text</td>
+                                        <td>object-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">37</th>
+                                        <td>Ensure elements marked as presentational are consistently ignored</td>
+                                        <td>presentation-role-conflict</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">38</th>
+                                        <td>[role&#x3D;&quot;img&quot;] elements must have an alternative text</td>
+                                        <td>role-img-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">39</th>
+                                        <td>scope attribute should be used correctly</td>
+                                        <td>scope-attr-valid</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">40</th>
+                                        <td>Scrollable region must have keyboard access</td>
+                                        <td>scrollable-region-focusable</td>
+                                        <td>WCAG 2 Level A, WCAG 2.1.1, WCAG 2.1.3</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">41</th>
+                                        <td>Select element must have an accessible name</td>
+                                        <td>select-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">42</th>
+                                        <td>Server-side image maps must not be used</td>
+                                        <td>server-side-image-map</td>
+                                        <td>WCAG 2 Level A, WCAG 2.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">43</th>
+                                        <td>The skip-link target should exist and be focusable</td>
+                                        <td>skip-link</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">44</th>
+                                        <td>Summary elements must have discernible text</td>
+                                        <td>summary-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">45</th>
+                                        <td>&lt;svg&gt; elements with an img role must have an alternative text</td>
+                                        <td>svg-img-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">46</th>
+                                        <td>Elements should not have tabindex greater than zero</td>
+                                        <td>tabindex</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">47</th>
+                                        <td>Tables should not have the same summary and caption</td>
+                                        <td>table-duplicate-name</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">48</th>
+                                        <td>Table cells that use the headers attribute must only refer to cells in the same table</td>
+                                        <td>td-headers-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">49</th>
+                                        <td>Table headers in a data table must refer to data cells</td>
+                                        <td>th-has-data-cells</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">50</th>
+                                        <td>lang attribute must have a valid value</td>
+                                        <td>valid-lang</td>
+                                        <td>WCAG 2 Level AA, WCAG 3.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">51</th>
+                                        <td>&lt;video&gt; elements must have captions</td>
+                                        <td>video-caption</td>
+                                        <td>WCAG 2 Level A, WCAG 1.2.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">52</th>
+                                        <td>&lt;video&gt; or &lt;audio&gt; elements must not play automatically</td>
+                                        <td>no-autoplay-audio</td>
+                                        <td>WCAG 2 Level A, WCAG 1.4.2</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="rulesSection">
+                <div class="card">
+                    <div class="card-header" id="ruleSection">
+                        <p class="mb-0">
+                            <button
+                                class="btn btn-link"
+                                data-toggle="collapse"
+                                data-target="#rules"
+                                aria-expanded="false"
+                                aria-controls="inapplicable"
+                            >
+                                axe was running with 0 rules. Expand details on click
+                            </button>
+                        </p>
+                    </div>
+                    <div
+                        id="rules"
+                        class="collapse"
+                        aria-labelledby="ruleSection"
+                        data-parent="#rules"
+                    >
+                        <div class="card-body">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <script>
+            hljs.initHighlightingOnLoad();
+        </script>
+    </main>
+</html>

--- a/e2e/test-results/accessibility-results/Data Protection Page Page.html
+++ b/e2e/test-results/accessibility-results/Data Protection Page Page.html
@@ -1,0 +1,881 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <!-- Required meta tags -->
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <style>
+            .card-header .btn-link {
+                color: #2557a7;
+            }
+            .violationCard {
+                width: 100%;
+                margin-bottom: 1rem;
+            }
+            .violationCardLine {
+                display: flex;
+                justify-content: space-between;
+                align-items: start;
+                font-weight: 500;
+                line-height: 1.2;
+            }
+            .card-title {
+                font-size: 1.25rem;
+            }
+            .violationCardTitleItem {
+                font-size: 1rem;
+                font-weight: 500;
+            }
+            .card-text {
+                font-size: 0.95rem;
+                font-weight: 300;
+            }
+            .learnMore {
+                margin-bottom: 0.75rem;
+                white-space: nowrap;
+                color: #2557a7;
+            }
+            .card-link {
+                color: #2557a7;
+            }
+            .violationNode {
+                font-size: 0.85rem;
+            }
+            .wrapBreakWord {
+                word-break: break-word;
+            }
+            .summary {
+                font-size: 1rem;
+            }
+            .summarySection {
+                margin: 0.5rem 0;
+            }
+            .hljs {
+                white-space: pre-wrap;
+                width: 100%;
+                background: #f0f0f0;
+            }
+            p {
+                margin-top: 0.3rem;
+            }
+            li {
+                line-height: 1.618;
+            }
+        </style>
+        <!-- Bootstrap CSS -->
+        <link
+            rel="stylesheet"
+            href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
+            integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z"
+            crossorigin="anonymous"
+        />
+        <script
+            src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+            integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+            crossorigin="anonymous"
+        ></script>
+        <script
+            src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"
+            integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
+            crossorigin="anonymous"
+        ></script>
+        <script
+            src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
+            integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+            crossorigin="anonymous"
+        ></script>
+        <link
+            rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/styles/stackoverflow-light.min.css"
+        />
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/highlight.min.js"></script>
+        <title>Axe-core® Accessibility Results</title>
+    </head>
+    <main role="main">
+        <div style="padding: 2rem">
+            <h1>
+                Axe-core® Accessibility Results
+            </h1>
+            <div class="summarySection">
+                <div class="summary">
+                    Page URL:
+                    <a href="http:&#x2F;&#x2F;localhost:3000&#x2F;datenschutz" target="_blank" class="card-link">http:&#x2F;&#x2F;localhost:3000&#x2F;datenschutz</a>
+                    <br />
+                </div>
+            </div>
+            <h2>axe-core found <span class="badge badge-success">0</span> violations</h2>
+                <tbody>
+                </tbody>
+            </table>
+            <div id="accordionPasses">
+                <div class="card">
+                    <div class="card-header" id="headingOne">
+                        <p class="mb-0">
+                            <button
+                                class="btn btn-link"
+                                data-toggle="collapse"
+                                data-target="#passes"
+                                aria-expanded="false"
+                                aria-controls="passes"
+                            >
+                                axe returned 39 passed axe
+                                checks. Expand details on
+                                click
+                            </button>
+                        </p>
+                    </div>
+                    <div
+                        id="passes"
+                        class="collapse"
+                        aria-labelledby="headingOne"
+                        data-parent="#accordionPasses"
+                    >
+                        <div class="card-body">
+                            <table class="table table-bordered">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 5%">#</th>
+                                        <th style="width: 40%">Description</th>
+                                        <th style="width: 5%">Axe rule ID</th>
+                                        <th style="width: 15%">WCAG</th>
+                                        <th style="width: 5%">Nodes passed check</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th scope="row">1</th>
+                                        <td>Elements must only use supported ARIA attributes</td>
+                                        <td>aria-allowed-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">2</th>
+                                        <td>ARIA attributes must be used as specified for the element&#39;s role</td>
+                                        <td>aria-conditional-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">3</th>
+                                        <td>aria-hidden&#x3D;&quot;true&quot; must not be present on the document body</td>
+                                        <td>aria-hidden-body</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">4</th>
+                                        <td>ARIA hidden element must not be focusable or contain focusable elements</td>
+                                        <td>aria-hidden-focus</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">5</th>
+                                        <td>Elements must only use permitted ARIA attributes</td>
+                                        <td>aria-prohibited-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">6</th>
+                                        <td>ARIA attributes must conform to valid values</td>
+                                        <td>aria-valid-attr-value</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">7</th>
+                                        <td>ARIA attributes must conform to valid names</td>
+                                        <td>aria-valid-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">8</th>
+                                        <td>Inline text spacing must be adjustable with custom stylesheets</td>
+                                        <td>avoid-inline-spacing</td>
+                                        <td>WCAG 2.1 Level AA, WCAG 1.4.1.2</td>
+                                        <td>2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">9</th>
+                                        <td>Buttons must have discernible text</td>
+                                        <td>button-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">10</th>
+                                        <td>Page must have means to bypass repeated blocks</td>
+                                        <td>bypass</td>
+                                        <td>WCAG 2 Level A, WCAG 2.4.1</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">11</th>
+                                        <td>Elements must meet minimum color contrast ratio thresholds</td>
+                                        <td>color-contrast</td>
+                                        <td>WCAG 2 Level AA, WCAG 1.4.3</td>
+                                        <td>93</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">12</th>
+                                        <td>&lt;dl&gt; elements must only directly contain properly-ordered &lt;dt&gt; and &lt;dd&gt; groups, &lt;script&gt;, &lt;template&gt; or &lt;div&gt; elements</td>
+                                        <td>definition-list</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">13</th>
+                                        <td>&lt;dt&gt; and &lt;dd&gt; elements must be contained by a &lt;dl&gt;</td>
+                                        <td>dlitem</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">14</th>
+                                        <td>Documents must have &lt;title&gt; element to aid in navigation</td>
+                                        <td>document-title</td>
+                                        <td>WCAG 2 Level A, WCAG 2.4.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">15</th>
+                                        <td>IDs used in ARIA and labels must be unique</td>
+                                        <td>duplicate-id-aria</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">16</th>
+                                        <td>Headings should not be empty</td>
+                                        <td>empty-heading</td>
+                                        <td>Best practice</td>
+                                        <td>29</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">17</th>
+                                        <td>Form field must not have multiple label elements</td>
+                                        <td>form-field-multiple-labels</td>
+                                        <td>WCAG 2 Level A, WCAG 3.3.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">18</th>
+                                        <td>Heading levels should only increase by one</td>
+                                        <td>heading-order</td>
+                                        <td>Best practice</td>
+                                        <td>29</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">19</th>
+                                        <td>&lt;html&gt; element must have a lang attribute</td>
+                                        <td>html-has-lang</td>
+                                        <td>WCAG 2 Level A, WCAG 3.1.1</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">20</th>
+                                        <td>&lt;html&gt; element must have a valid value for the lang attribute</td>
+                                        <td>html-lang-valid</td>
+                                        <td>WCAG 2 Level A, WCAG 3.1.1</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">21</th>
+                                        <td>Images must have alternative text</td>
+                                        <td>image-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">22</th>
+                                        <td>Alternative text of images should not be repeated as text</td>
+                                        <td>image-redundant-alt</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">23</th>
+                                        <td>Form elements should have a visible label</td>
+                                        <td>label-title-only</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">24</th>
+                                        <td>Form elements must have labels</td>
+                                        <td>label</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">25</th>
+                                        <td>Contentinfo landmark should not be contained in another landmark</td>
+                                        <td>landmark-contentinfo-is-top-level</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">26</th>
+                                        <td>Main landmark should not be contained in another landmark</td>
+                                        <td>landmark-main-is-top-level</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">27</th>
+                                        <td>Document should not have more than one contentinfo landmark</td>
+                                        <td>landmark-no-duplicate-contentinfo</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">28</th>
+                                        <td>Document should not have more than one main landmark</td>
+                                        <td>landmark-no-duplicate-main</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">29</th>
+                                        <td>Document should have one main landmark</td>
+                                        <td>landmark-one-main</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">30</th>
+                                        <td>Landmarks should have a unique role or role&#x2F;label&#x2F;title (i.e. accessible name) combination</td>
+                                        <td>landmark-unique</td>
+                                        <td>Best practice</td>
+                                        <td>5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">31</th>
+                                        <td>Links must be distinguishable without relying on color</td>
+                                        <td>link-in-text-block</td>
+                                        <td>WCAG 2 Level A, WCAG 1.4.1</td>
+                                        <td>4</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">32</th>
+                                        <td>Links must have discernible text</td>
+                                        <td>link-name</td>
+                                        <td>WCAG 2 Level A, WCAG 2.4.4, WCAG 4.1.2</td>
+                                        <td>21</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">33</th>
+                                        <td>&lt;ul&gt; and &lt;ol&gt; must only directly contain &lt;li&gt;, &lt;script&gt; or &lt;template&gt; elements</td>
+                                        <td>list</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">34</th>
+                                        <td>&lt;li&gt; elements must be contained in a &lt;ul&gt; or &lt;ol&gt;</td>
+                                        <td>listitem</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                        <td>19</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">35</th>
+                                        <td>Users should be able to zoom and scale the text up to 500%</td>
+                                        <td>meta-viewport-large</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">36</th>
+                                        <td>Zooming and scaling must not be disabled</td>
+                                        <td>meta-viewport</td>
+                                        <td>WCAG 2 Level AA, WCAG 1.4.4</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">37</th>
+                                        <td>Interactive controls must not be nested</td>
+                                        <td>nested-interactive</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">38</th>
+                                        <td>Page should contain a level-one heading</td>
+                                        <td>page-has-heading-one</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">39</th>
+                                        <td>All page content should be contained by landmarks</td>
+                                        <td>region</td>
+                                        <td>Best practice</td>
+                                        <td>194</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="accordionIncomplete">
+                <div class="card">
+                    <div class="card-header" id="headingTwo">
+                        <p class="mb-0">
+                            <button
+                                class="btn btn-link"
+                                data-toggle="collapse"
+                                data-target="#incomplete"
+                                aria-expanded="false"
+                                aria-controls="incomplete"
+                            >
+                                axe returned 3 incomplete checks. Expand
+                                details on click
+                            </button>
+                        </p>
+                    </div>
+                    <div
+                        id="incomplete"
+                        class="collapse"
+                        aria-labelledby="headingTwo"
+                        data-parent="#accordionIncomplete"
+                    >
+                        <div class="card-body">
+                            <p><em>What 'incomplete' axe checks means?</em></p>
+                            <p>
+                                Incomplete results were aborted and require further testing. This
+                                can happen either because of technical restrictions to what the rule
+                                can test, or because a javascript error occurred.
+                            </p>
+                            <p>
+                                <a
+                                    href="https://www.deque.com/axe/core-documentation/api-documentation/#results-object"
+                                    >Visit axe API Documentation</a
+                                >
+                                to learn more.
+                            </p>
+                            <table class="table table-bordered">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 5%">#</th>
+                                        <th style="width: 50%">Description</th>
+                                        <th style="width: 20%">Axe rule ID</th>
+                                        <th style="width: 15%">WCAG</th>
+                                        <th style="width: 10%">Nodes with incomplete check</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th scope="row">1</th>
+                                        <td>Elements must only use permitted ARIA attributes</td>
+                                        <td>aria-prohibited-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">2</th>
+                                        <td>ARIA attributes must conform to valid values</td>
+                                        <td>aria-valid-attr-value</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">3</th>
+                                        <td>Elements must meet minimum color contrast ratio thresholds</td>
+                                        <td>color-contrast</td>
+                                        <td>WCAG 2 Level AA, WCAG 1.4.3</td>
+                                        <td>1</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="accordionInapplicable">
+                <div class="card">
+                    <div class="card-header" id="headingThree">
+                        <p class="mb-0">
+                            <button
+                                class="btn btn-link"
+                                data-toggle="collapse"
+                                data-target="#inapplicable"
+                                aria-expanded="false"
+                                aria-controls="inapplicable"
+                            >
+                                axe returned 50 inapplicable checks.
+                                Expand details on click
+                            </button>
+                        </p>
+                    </div>
+                    <div
+                        id="inapplicable"
+                        class="collapse"
+                        aria-labelledby="headingThree"
+                        data-parent="#accordionInapplicable"
+                    >
+                        <div class="card-body">
+                            <p><em>What 'inapplicable' axe checks means?</em></p>
+                            <p>
+                                The inapplicable array lists all the rules for which no matching
+                                elements were found on the page.
+                            </p>
+                            <p>
+                                <a
+                                    href="https://www.deque.com/axe/core-documentation/api-documentation/#results-object"
+                                    >Visit axe API Documentation</a
+                                >
+                                to learn more.
+                            </p>
+                            <table class="table table-bordered">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 5%">#</th>
+                                        <th style="width: 50%">Description</th>
+                                        <th style="width: 20%">Axe rule ID</th>
+                                        <th style="width: 15%">WCAG</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th scope="row">1</th>
+                                        <td>accesskey attribute value should be unique</td>
+                                        <td>accesskeys</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">2</th>
+                                        <td>Active &lt;area&gt; elements must have alternative text</td>
+                                        <td>area-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 2.4.4, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">3</th>
+                                        <td>ARIA role should be appropriate for the element</td>
+                                        <td>aria-allowed-role</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">4</th>
+                                        <td>aria-braille attributes must have a non-braille equivalent</td>
+                                        <td>aria-braille-equivalent</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">5</th>
+                                        <td>ARIA commands must have an accessible name</td>
+                                        <td>aria-command-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">6</th>
+                                        <td>Deprecated ARIA roles must not be used</td>
+                                        <td>aria-deprecated-role</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">7</th>
+                                        <td>ARIA dialog and alertdialog nodes should have an accessible name</td>
+                                        <td>aria-dialog-name</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">8</th>
+                                        <td>ARIA input fields must have an accessible name</td>
+                                        <td>aria-input-field-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">9</th>
+                                        <td>ARIA meter nodes must have an accessible name</td>
+                                        <td>aria-meter-name</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">10</th>
+                                        <td>ARIA progressbar nodes must have an accessible name</td>
+                                        <td>aria-progressbar-name</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">11</th>
+                                        <td>Required ARIA attributes must be provided</td>
+                                        <td>aria-required-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">12</th>
+                                        <td>Certain ARIA roles must contain particular children</td>
+                                        <td>aria-required-children</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">13</th>
+                                        <td>Certain ARIA roles must be contained by particular parents</td>
+                                        <td>aria-required-parent</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">14</th>
+                                        <td>ARIA roles used must conform to valid values</td>
+                                        <td>aria-roles</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">15</th>
+                                        <td>&quot;role&#x3D;text&quot; should have no focusable descendants</td>
+                                        <td>aria-text</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">16</th>
+                                        <td>ARIA toggle fields must have an accessible name</td>
+                                        <td>aria-toggle-field-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">17</th>
+                                        <td>ARIA tooltip nodes must have an accessible name</td>
+                                        <td>aria-tooltip-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">18</th>
+                                        <td>ARIA treeitem nodes should have an accessible name</td>
+                                        <td>aria-treeitem-name</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">19</th>
+                                        <td>autocomplete attribute must be used correctly</td>
+                                        <td>autocomplete-valid</td>
+                                        <td>WCAG 2.1 Level AA, WCAG 1.3.5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">20</th>
+                                        <td>&lt;blink&gt; elements are deprecated and must not be used</td>
+                                        <td>blink</td>
+                                        <td>WCAG 2 Level A, WCAG 2.2.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">21</th>
+                                        <td>Table header text should not be empty</td>
+                                        <td>empty-table-header</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">22</th>
+                                        <td>Frames with focusable content must not have tabindex&#x3D;-1</td>
+                                        <td>frame-focusable-content</td>
+                                        <td>WCAG 2 Level A, WCAG 2.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">23</th>
+                                        <td>Frames should be tested with axe-core</td>
+                                        <td>frame-tested</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">24</th>
+                                        <td>Frames must have a unique title attribute</td>
+                                        <td>frame-title-unique</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">25</th>
+                                        <td>Frames must have an accessible name</td>
+                                        <td>frame-title</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">26</th>
+                                        <td>HTML elements with lang and xml:lang must have the same base language</td>
+                                        <td>html-xml-lang-mismatch</td>
+                                        <td>WCAG 2 Level A, WCAG 3.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">27</th>
+                                        <td>Input buttons must have discernible text</td>
+                                        <td>input-button-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">28</th>
+                                        <td>Image buttons must have alternative text</td>
+                                        <td>input-image-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">29</th>
+                                        <td>Banner landmark should not be contained in another landmark</td>
+                                        <td>landmark-banner-is-top-level</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">30</th>
+                                        <td>Aside should not be contained in another landmark</td>
+                                        <td>landmark-complementary-is-top-level</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">31</th>
+                                        <td>Document should not have more than one banner landmark</td>
+                                        <td>landmark-no-duplicate-banner</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">32</th>
+                                        <td>&lt;marquee&gt; elements are deprecated and must not be used</td>
+                                        <td>marquee</td>
+                                        <td>WCAG 2 Level A, WCAG 2.2.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">33</th>
+                                        <td>Delayed refresh under 20 hours must not be used</td>
+                                        <td>meta-refresh</td>
+                                        <td>WCAG 2 Level A, WCAG 2.2.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">34</th>
+                                        <td>&lt;object&gt; elements must have alternative text</td>
+                                        <td>object-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">35</th>
+                                        <td>Ensure elements marked as presentational are consistently ignored</td>
+                                        <td>presentation-role-conflict</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">36</th>
+                                        <td>[role&#x3D;&quot;img&quot;] elements must have an alternative text</td>
+                                        <td>role-img-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">37</th>
+                                        <td>scope attribute should be used correctly</td>
+                                        <td>scope-attr-valid</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">38</th>
+                                        <td>Scrollable region must have keyboard access</td>
+                                        <td>scrollable-region-focusable</td>
+                                        <td>WCAG 2 Level A, WCAG 2.1.1, WCAG 2.1.3</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">39</th>
+                                        <td>Select element must have an accessible name</td>
+                                        <td>select-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">40</th>
+                                        <td>Server-side image maps must not be used</td>
+                                        <td>server-side-image-map</td>
+                                        <td>WCAG 2 Level A, WCAG 2.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">41</th>
+                                        <td>The skip-link target should exist and be focusable</td>
+                                        <td>skip-link</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">42</th>
+                                        <td>Summary elements must have discernible text</td>
+                                        <td>summary-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">43</th>
+                                        <td>&lt;svg&gt; elements with an img role must have an alternative text</td>
+                                        <td>svg-img-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">44</th>
+                                        <td>Elements should not have tabindex greater than zero</td>
+                                        <td>tabindex</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">45</th>
+                                        <td>Tables should not have the same summary and caption</td>
+                                        <td>table-duplicate-name</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">46</th>
+                                        <td>Table cells that use the headers attribute must only refer to cells in the same table</td>
+                                        <td>td-headers-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">47</th>
+                                        <td>Table headers in a data table must refer to data cells</td>
+                                        <td>th-has-data-cells</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">48</th>
+                                        <td>lang attribute must have a valid value</td>
+                                        <td>valid-lang</td>
+                                        <td>WCAG 2 Level AA, WCAG 3.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">49</th>
+                                        <td>&lt;video&gt; elements must have captions</td>
+                                        <td>video-caption</td>
+                                        <td>WCAG 2 Level A, WCAG 1.2.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">50</th>
+                                        <td>&lt;video&gt; or &lt;audio&gt; elements must not play automatically</td>
+                                        <td>no-autoplay-audio</td>
+                                        <td>WCAG 2 Level A, WCAG 1.4.2</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="rulesSection">
+                <div class="card">
+                    <div class="card-header" id="ruleSection">
+                        <p class="mb-0">
+                            <button
+                                class="btn btn-link"
+                                data-toggle="collapse"
+                                data-target="#rules"
+                                aria-expanded="false"
+                                aria-controls="inapplicable"
+                            >
+                                axe was running with 0 rules. Expand details on click
+                            </button>
+                        </p>
+                    </div>
+                    <div
+                        id="rules"
+                        class="collapse"
+                        aria-labelledby="ruleSection"
+                        data-parent="#rules"
+                    >
+                        <div class="card-body">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <script>
+            hljs.initHighlightingOnLoad();
+        </script>
+    </main>
+</html>

--- a/e2e/test-results/accessibility-results/Imprint Page Page.html
+++ b/e2e/test-results/accessibility-results/Imprint Page Page.html
@@ -1,0 +1,878 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <!-- Required meta tags -->
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <style>
+            .card-header .btn-link {
+                color: #2557a7;
+            }
+            .violationCard {
+                width: 100%;
+                margin-bottom: 1rem;
+            }
+            .violationCardLine {
+                display: flex;
+                justify-content: space-between;
+                align-items: start;
+                font-weight: 500;
+                line-height: 1.2;
+            }
+            .card-title {
+                font-size: 1.25rem;
+            }
+            .violationCardTitleItem {
+                font-size: 1rem;
+                font-weight: 500;
+            }
+            .card-text {
+                font-size: 0.95rem;
+                font-weight: 300;
+            }
+            .learnMore {
+                margin-bottom: 0.75rem;
+                white-space: nowrap;
+                color: #2557a7;
+            }
+            .card-link {
+                color: #2557a7;
+            }
+            .violationNode {
+                font-size: 0.85rem;
+            }
+            .wrapBreakWord {
+                word-break: break-word;
+            }
+            .summary {
+                font-size: 1rem;
+            }
+            .summarySection {
+                margin: 0.5rem 0;
+            }
+            .hljs {
+                white-space: pre-wrap;
+                width: 100%;
+                background: #f0f0f0;
+            }
+            p {
+                margin-top: 0.3rem;
+            }
+            li {
+                line-height: 1.618;
+            }
+        </style>
+        <!-- Bootstrap CSS -->
+        <link
+            rel="stylesheet"
+            href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
+            integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z"
+            crossorigin="anonymous"
+        />
+        <script
+            src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+            integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+            crossorigin="anonymous"
+        ></script>
+        <script
+            src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"
+            integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
+            crossorigin="anonymous"
+        ></script>
+        <script
+            src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
+            integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+            crossorigin="anonymous"
+        ></script>
+        <link
+            rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/styles/stackoverflow-light.min.css"
+        />
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/highlight.min.js"></script>
+        <title>Axe-core® Accessibility Results</title>
+    </head>
+    <main role="main">
+        <div style="padding: 2rem">
+            <h1>
+                Axe-core® Accessibility Results
+            </h1>
+            <div class="summarySection">
+                <div class="summary">
+                    Page URL:
+                    <a href="http:&#x2F;&#x2F;localhost:3000&#x2F;impressum" target="_blank" class="card-link">http:&#x2F;&#x2F;localhost:3000&#x2F;impressum</a>
+                    <br />
+                </div>
+            </div>
+            <h2>axe-core found <span class="badge badge-success">0</span> violations</h2>
+                <tbody>
+                </tbody>
+            </table>
+            <div id="accordionPasses">
+                <div class="card">
+                    <div class="card-header" id="headingOne">
+                        <p class="mb-0">
+                            <button
+                                class="btn btn-link"
+                                data-toggle="collapse"
+                                data-target="#passes"
+                                aria-expanded="false"
+                                aria-controls="passes"
+                            >
+                                axe returned 36 passed axe
+                                checks. Expand details on
+                                click
+                            </button>
+                        </p>
+                    </div>
+                    <div
+                        id="passes"
+                        class="collapse"
+                        aria-labelledby="headingOne"
+                        data-parent="#accordionPasses"
+                    >
+                        <div class="card-body">
+                            <table class="table table-bordered">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 5%">#</th>
+                                        <th style="width: 40%">Description</th>
+                                        <th style="width: 5%">Axe rule ID</th>
+                                        <th style="width: 15%">WCAG</th>
+                                        <th style="width: 5%">Nodes passed check</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th scope="row">1</th>
+                                        <td>Elements must only use supported ARIA attributes</td>
+                                        <td>aria-allowed-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">2</th>
+                                        <td>ARIA attributes must be used as specified for the element&#39;s role</td>
+                                        <td>aria-conditional-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">3</th>
+                                        <td>aria-hidden&#x3D;&quot;true&quot; must not be present on the document body</td>
+                                        <td>aria-hidden-body</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">4</th>
+                                        <td>ARIA hidden element must not be focusable or contain focusable elements</td>
+                                        <td>aria-hidden-focus</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">5</th>
+                                        <td>Elements must only use permitted ARIA attributes</td>
+                                        <td>aria-prohibited-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">6</th>
+                                        <td>ARIA attributes must conform to valid values</td>
+                                        <td>aria-valid-attr-value</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">7</th>
+                                        <td>ARIA attributes must conform to valid names</td>
+                                        <td>aria-valid-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">8</th>
+                                        <td>Inline text spacing must be adjustable with custom stylesheets</td>
+                                        <td>avoid-inline-spacing</td>
+                                        <td>WCAG 2.1 Level AA, WCAG 1.4.1.2</td>
+                                        <td>2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">9</th>
+                                        <td>Buttons must have discernible text</td>
+                                        <td>button-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">10</th>
+                                        <td>Page must have means to bypass repeated blocks</td>
+                                        <td>bypass</td>
+                                        <td>WCAG 2 Level A, WCAG 2.4.1</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">11</th>
+                                        <td>Elements must meet minimum color contrast ratio thresholds</td>
+                                        <td>color-contrast</td>
+                                        <td>WCAG 2 Level AA, WCAG 1.4.3</td>
+                                        <td>41</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">12</th>
+                                        <td>Documents must have &lt;title&gt; element to aid in navigation</td>
+                                        <td>document-title</td>
+                                        <td>WCAG 2 Level A, WCAG 2.4.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">13</th>
+                                        <td>IDs used in ARIA and labels must be unique</td>
+                                        <td>duplicate-id-aria</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">14</th>
+                                        <td>Headings should not be empty</td>
+                                        <td>empty-heading</td>
+                                        <td>Best practice</td>
+                                        <td>9</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">15</th>
+                                        <td>Form field must not have multiple label elements</td>
+                                        <td>form-field-multiple-labels</td>
+                                        <td>WCAG 2 Level A, WCAG 3.3.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">16</th>
+                                        <td>Heading levels should only increase by one</td>
+                                        <td>heading-order</td>
+                                        <td>Best practice</td>
+                                        <td>9</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">17</th>
+                                        <td>&lt;html&gt; element must have a lang attribute</td>
+                                        <td>html-has-lang</td>
+                                        <td>WCAG 2 Level A, WCAG 3.1.1</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">18</th>
+                                        <td>&lt;html&gt; element must have a valid value for the lang attribute</td>
+                                        <td>html-lang-valid</td>
+                                        <td>WCAG 2 Level A, WCAG 3.1.1</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">19</th>
+                                        <td>Images must have alternative text</td>
+                                        <td>image-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">20</th>
+                                        <td>Alternative text of images should not be repeated as text</td>
+                                        <td>image-redundant-alt</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">21</th>
+                                        <td>Form elements should have a visible label</td>
+                                        <td>label-title-only</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">22</th>
+                                        <td>Form elements must have labels</td>
+                                        <td>label</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">23</th>
+                                        <td>Contentinfo landmark should not be contained in another landmark</td>
+                                        <td>landmark-contentinfo-is-top-level</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">24</th>
+                                        <td>Main landmark should not be contained in another landmark</td>
+                                        <td>landmark-main-is-top-level</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">25</th>
+                                        <td>Document should not have more than one contentinfo landmark</td>
+                                        <td>landmark-no-duplicate-contentinfo</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">26</th>
+                                        <td>Document should not have more than one main landmark</td>
+                                        <td>landmark-no-duplicate-main</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">27</th>
+                                        <td>Document should have one main landmark</td>
+                                        <td>landmark-one-main</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">28</th>
+                                        <td>Landmarks should have a unique role or role&#x2F;label&#x2F;title (i.e. accessible name) combination</td>
+                                        <td>landmark-unique</td>
+                                        <td>Best practice</td>
+                                        <td>5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">29</th>
+                                        <td>Links must have discernible text</td>
+                                        <td>link-name</td>
+                                        <td>WCAG 2 Level A, WCAG 2.4.4, WCAG 4.1.2</td>
+                                        <td>16</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">30</th>
+                                        <td>&lt;ul&gt; and &lt;ol&gt; must only directly contain &lt;li&gt;, &lt;script&gt; or &lt;template&gt; elements</td>
+                                        <td>list</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                        <td>2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">31</th>
+                                        <td>&lt;li&gt; elements must be contained in a &lt;ul&gt; or &lt;ol&gt;</td>
+                                        <td>listitem</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                        <td>11</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">32</th>
+                                        <td>Users should be able to zoom and scale the text up to 500%</td>
+                                        <td>meta-viewport-large</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">33</th>
+                                        <td>Zooming and scaling must not be disabled</td>
+                                        <td>meta-viewport</td>
+                                        <td>WCAG 2 Level AA, WCAG 1.4.4</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">34</th>
+                                        <td>Interactive controls must not be nested</td>
+                                        <td>nested-interactive</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>6</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">35</th>
+                                        <td>Page should contain a level-one heading</td>
+                                        <td>page-has-heading-one</td>
+                                        <td>Best practice</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">36</th>
+                                        <td>All page content should be contained by landmarks</td>
+                                        <td>region</td>
+                                        <td>Best practice</td>
+                                        <td>135</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="accordionIncomplete">
+                <div class="card">
+                    <div class="card-header" id="headingTwo">
+                        <p class="mb-0">
+                            <button
+                                class="btn btn-link"
+                                data-toggle="collapse"
+                                data-target="#incomplete"
+                                aria-expanded="false"
+                                aria-controls="incomplete"
+                            >
+                                axe returned 3 incomplete checks. Expand
+                                details on click
+                            </button>
+                        </p>
+                    </div>
+                    <div
+                        id="incomplete"
+                        class="collapse"
+                        aria-labelledby="headingTwo"
+                        data-parent="#accordionIncomplete"
+                    >
+                        <div class="card-body">
+                            <p><em>What 'incomplete' axe checks means?</em></p>
+                            <p>
+                                Incomplete results were aborted and require further testing. This
+                                can happen either because of technical restrictions to what the rule
+                                can test, or because a javascript error occurred.
+                            </p>
+                            <p>
+                                <a
+                                    href="https://www.deque.com/axe/core-documentation/api-documentation/#results-object"
+                                    >Visit axe API Documentation</a
+                                >
+                                to learn more.
+                            </p>
+                            <table class="table table-bordered">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 5%">#</th>
+                                        <th style="width: 50%">Description</th>
+                                        <th style="width: 20%">Axe rule ID</th>
+                                        <th style="width: 15%">WCAG</th>
+                                        <th style="width: 10%">Nodes with incomplete check</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th scope="row">1</th>
+                                        <td>Elements must only use permitted ARIA attributes</td>
+                                        <td>aria-prohibited-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">2</th>
+                                        <td>ARIA attributes must conform to valid values</td>
+                                        <td>aria-valid-attr-value</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                        <td>1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">3</th>
+                                        <td>Elements must meet minimum color contrast ratio thresholds</td>
+                                        <td>color-contrast</td>
+                                        <td>WCAG 2 Level AA, WCAG 1.4.3</td>
+                                        <td>1</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="accordionInapplicable">
+                <div class="card">
+                    <div class="card-header" id="headingThree">
+                        <p class="mb-0">
+                            <button
+                                class="btn btn-link"
+                                data-toggle="collapse"
+                                data-target="#inapplicable"
+                                aria-expanded="false"
+                                aria-controls="inapplicable"
+                            >
+                                axe returned 53 inapplicable checks.
+                                Expand details on click
+                            </button>
+                        </p>
+                    </div>
+                    <div
+                        id="inapplicable"
+                        class="collapse"
+                        aria-labelledby="headingThree"
+                        data-parent="#accordionInapplicable"
+                    >
+                        <div class="card-body">
+                            <p><em>What 'inapplicable' axe checks means?</em></p>
+                            <p>
+                                The inapplicable array lists all the rules for which no matching
+                                elements were found on the page.
+                            </p>
+                            <p>
+                                <a
+                                    href="https://www.deque.com/axe/core-documentation/api-documentation/#results-object"
+                                    >Visit axe API Documentation</a
+                                >
+                                to learn more.
+                            </p>
+                            <table class="table table-bordered">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 5%">#</th>
+                                        <th style="width: 50%">Description</th>
+                                        <th style="width: 20%">Axe rule ID</th>
+                                        <th style="width: 15%">WCAG</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th scope="row">1</th>
+                                        <td>accesskey attribute value should be unique</td>
+                                        <td>accesskeys</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">2</th>
+                                        <td>Active &lt;area&gt; elements must have alternative text</td>
+                                        <td>area-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 2.4.4, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">3</th>
+                                        <td>ARIA role should be appropriate for the element</td>
+                                        <td>aria-allowed-role</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">4</th>
+                                        <td>aria-braille attributes must have a non-braille equivalent</td>
+                                        <td>aria-braille-equivalent</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">5</th>
+                                        <td>ARIA commands must have an accessible name</td>
+                                        <td>aria-command-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">6</th>
+                                        <td>Deprecated ARIA roles must not be used</td>
+                                        <td>aria-deprecated-role</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">7</th>
+                                        <td>ARIA dialog and alertdialog nodes should have an accessible name</td>
+                                        <td>aria-dialog-name</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">8</th>
+                                        <td>ARIA input fields must have an accessible name</td>
+                                        <td>aria-input-field-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">9</th>
+                                        <td>ARIA meter nodes must have an accessible name</td>
+                                        <td>aria-meter-name</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">10</th>
+                                        <td>ARIA progressbar nodes must have an accessible name</td>
+                                        <td>aria-progressbar-name</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">11</th>
+                                        <td>Required ARIA attributes must be provided</td>
+                                        <td>aria-required-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">12</th>
+                                        <td>Certain ARIA roles must contain particular children</td>
+                                        <td>aria-required-children</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">13</th>
+                                        <td>Certain ARIA roles must be contained by particular parents</td>
+                                        <td>aria-required-parent</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">14</th>
+                                        <td>ARIA roles used must conform to valid values</td>
+                                        <td>aria-roles</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">15</th>
+                                        <td>&quot;role&#x3D;text&quot; should have no focusable descendants</td>
+                                        <td>aria-text</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">16</th>
+                                        <td>ARIA toggle fields must have an accessible name</td>
+                                        <td>aria-toggle-field-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">17</th>
+                                        <td>ARIA tooltip nodes must have an accessible name</td>
+                                        <td>aria-tooltip-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">18</th>
+                                        <td>ARIA treeitem nodes should have an accessible name</td>
+                                        <td>aria-treeitem-name</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">19</th>
+                                        <td>autocomplete attribute must be used correctly</td>
+                                        <td>autocomplete-valid</td>
+                                        <td>WCAG 2.1 Level AA, WCAG 1.3.5</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">20</th>
+                                        <td>&lt;blink&gt; elements are deprecated and must not be used</td>
+                                        <td>blink</td>
+                                        <td>WCAG 2 Level A, WCAG 2.2.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">21</th>
+                                        <td>&lt;dl&gt; elements must only directly contain properly-ordered &lt;dt&gt; and &lt;dd&gt; groups, &lt;script&gt;, &lt;template&gt; or &lt;div&gt; elements</td>
+                                        <td>definition-list</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">22</th>
+                                        <td>&lt;dt&gt; and &lt;dd&gt; elements must be contained by a &lt;dl&gt;</td>
+                                        <td>dlitem</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">23</th>
+                                        <td>Table header text should not be empty</td>
+                                        <td>empty-table-header</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">24</th>
+                                        <td>Frames with focusable content must not have tabindex&#x3D;-1</td>
+                                        <td>frame-focusable-content</td>
+                                        <td>WCAG 2 Level A, WCAG 2.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">25</th>
+                                        <td>Frames should be tested with axe-core</td>
+                                        <td>frame-tested</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">26</th>
+                                        <td>Frames must have a unique title attribute</td>
+                                        <td>frame-title-unique</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">27</th>
+                                        <td>Frames must have an accessible name</td>
+                                        <td>frame-title</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">28</th>
+                                        <td>HTML elements with lang and xml:lang must have the same base language</td>
+                                        <td>html-xml-lang-mismatch</td>
+                                        <td>WCAG 2 Level A, WCAG 3.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">29</th>
+                                        <td>Input buttons must have discernible text</td>
+                                        <td>input-button-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">30</th>
+                                        <td>Image buttons must have alternative text</td>
+                                        <td>input-image-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">31</th>
+                                        <td>Banner landmark should not be contained in another landmark</td>
+                                        <td>landmark-banner-is-top-level</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">32</th>
+                                        <td>Aside should not be contained in another landmark</td>
+                                        <td>landmark-complementary-is-top-level</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">33</th>
+                                        <td>Document should not have more than one banner landmark</td>
+                                        <td>landmark-no-duplicate-banner</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">34</th>
+                                        <td>Links must be distinguishable without relying on color</td>
+                                        <td>link-in-text-block</td>
+                                        <td>WCAG 2 Level A, WCAG 1.4.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">35</th>
+                                        <td>&lt;marquee&gt; elements are deprecated and must not be used</td>
+                                        <td>marquee</td>
+                                        <td>WCAG 2 Level A, WCAG 2.2.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">36</th>
+                                        <td>Delayed refresh under 20 hours must not be used</td>
+                                        <td>meta-refresh</td>
+                                        <td>WCAG 2 Level A, WCAG 2.2.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">37</th>
+                                        <td>&lt;object&gt; elements must have alternative text</td>
+                                        <td>object-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">38</th>
+                                        <td>Ensure elements marked as presentational are consistently ignored</td>
+                                        <td>presentation-role-conflict</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">39</th>
+                                        <td>[role&#x3D;&quot;img&quot;] elements must have an alternative text</td>
+                                        <td>role-img-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">40</th>
+                                        <td>scope attribute should be used correctly</td>
+                                        <td>scope-attr-valid</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">41</th>
+                                        <td>Scrollable region must have keyboard access</td>
+                                        <td>scrollable-region-focusable</td>
+                                        <td>WCAG 2 Level A, WCAG 2.1.1, WCAG 2.1.3</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">42</th>
+                                        <td>Select element must have an accessible name</td>
+                                        <td>select-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">43</th>
+                                        <td>Server-side image maps must not be used</td>
+                                        <td>server-side-image-map</td>
+                                        <td>WCAG 2 Level A, WCAG 2.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">44</th>
+                                        <td>The skip-link target should exist and be focusable</td>
+                                        <td>skip-link</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">45</th>
+                                        <td>Summary elements must have discernible text</td>
+                                        <td>summary-name</td>
+                                        <td>WCAG 2 Level A, WCAG 4.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">46</th>
+                                        <td>&lt;svg&gt; elements with an img role must have an alternative text</td>
+                                        <td>svg-img-alt</td>
+                                        <td>WCAG 2 Level A, WCAG 1.1.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">47</th>
+                                        <td>Elements should not have tabindex greater than zero</td>
+                                        <td>tabindex</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">48</th>
+                                        <td>Tables should not have the same summary and caption</td>
+                                        <td>table-duplicate-name</td>
+                                        <td>Best practice</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">49</th>
+                                        <td>Table cells that use the headers attribute must only refer to cells in the same table</td>
+                                        <td>td-headers-attr</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">50</th>
+                                        <td>Table headers in a data table must refer to data cells</td>
+                                        <td>th-has-data-cells</td>
+                                        <td>WCAG 2 Level A, WCAG 1.3.1</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">51</th>
+                                        <td>lang attribute must have a valid value</td>
+                                        <td>valid-lang</td>
+                                        <td>WCAG 2 Level AA, WCAG 3.1.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">52</th>
+                                        <td>&lt;video&gt; elements must have captions</td>
+                                        <td>video-caption</td>
+                                        <td>WCAG 2 Level A, WCAG 1.2.2</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">53</th>
+                                        <td>&lt;video&gt; or &lt;audio&gt; elements must not play automatically</td>
+                                        <td>no-autoplay-audio</td>
+                                        <td>WCAG 2 Level A, WCAG 1.4.2</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="rulesSection">
+                <div class="card">
+                    <div class="card-header" id="ruleSection">
+                        <p class="mb-0">
+                            <button
+                                class="btn btn-link"
+                                data-toggle="collapse"
+                                data-target="#rules"
+                                aria-expanded="false"
+                                aria-controls="inapplicable"
+                            >
+                                axe was running with 0 rules. Expand details on click
+                            </button>
+                        </p>
+                    </div>
+                    <div
+                        id="rules"
+                        class="collapse"
+                        aria-labelledby="ruleSection"
+                        data-parent="#rules"
+                    >
+                        <div class="card-body">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <script>
+            hljs.initHighlightingOnLoad();
+        </script>
+    </main>
+</html>

--- a/frontend/src/__snapshots__/error.unit.spec.ts.snap
+++ b/frontend/src/__snapshots__/error.unit.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`error page > shows a generic message for internal server errors (500) 1`] = `"Fehlerseite Es gab leider einen Fehler  Probieren Sie es zu einem späteren Moment noch einmal.Wir haben den Fehler dokumentiert und an unsere Entwickler:innen weitergeleitet."`;
+exports[`error page > shows a generic message for internal server errors (500) 1`] = `"Es gab leider einen Fehler  Probieren Sie es zu einem späteren Moment noch einmal.Wir haben den Fehler dokumentiert und an unsere Entwickler:innen weitergeleitet."`;
 
-exports[`error page > shows a more generic message for other errors 1`] = `"Fehlerseite Es gab leider einen Fehler  Ein unbekannter Fehler ist aufgetreten: 418"`;
+exports[`error page > shows a more generic message for other errors 1`] = `"Es gab leider einen Fehler  Ein unbekannter Fehler ist aufgetreten: 418"`;
 
-exports[`error page > shows a specific message for Not Found errors (404) 1`] = `"Fehlerseite Diese Seite existiert nicht  Überprüfen Sie den eingegebenen Link"`;
+exports[`error page > shows a specific message for Not Found errors (404) 1`] = `"Diese Seite existiert nicht  Überprüfen Sie den eingegebenen Link"`;

--- a/frontend/src/components/Search/Result/Caselaw/CaselawSearchResult.vue
+++ b/frontend/src/components/Search/Result/Caselaw/CaselawSearchResult.vue
@@ -181,7 +181,10 @@ function trackResultClick(url: string) {
           external
           @click="trackResultClick(`${metadata.url}#${section.id}`)"
         >
-          {{ section.title }}:</NuxtLink
+          <div role="heading" aria-level="3">
+            {{ section.title }}
+          </div>
+          : </NuxtLink
         >{{ " " }}
         <span
           data-testid="highlighted-field"

--- a/frontend/src/components/Search/Result/Norms/NormSearchResult.unit.spec.ts
+++ b/frontend/src/components/Search/Result/Norms/NormSearchResult.unit.spec.ts
@@ -220,7 +220,7 @@ describe("NormSearchResult.vue", () => {
     const titleContent = wrapper.find("a > div");
     expect(titleContent.element.innerHTML).toBe(expectedSanitized);
 
-    const contentItems = wrapper.findAll('[data-testid="highlights"] a span');
+    const contentItems = wrapper.findAll('[data-testid="highlights"] a div');
     expect(contentItems.length).toBe(1);
     expect(contentItems[0].element.innerHTML).toBe(expectedSanitized);
   });

--- a/frontend/src/components/Search/Result/Norms/NormSearchResult.vue
+++ b/frontend/src/components/Search/Result/Norms/NormSearchResult.vue
@@ -93,7 +93,11 @@ function openResult(url: string) {
             :to="`${link}#${highlight.location || ''}`"
             @click="openResult(`${link}#${highlight.location || ''}`)"
           >
-            <span v-html="sanitizeSearchResult(highlight.name)" />
+            <div
+              role="heading"
+              aria-level="3"
+              v-html="sanitizeSearchResult(highlight.name)"
+            />
           </NuxtLink>
         </div>
         <div

--- a/frontend/src/components/Search/SimpleSearch/SimpleSearch.vue
+++ b/frontend/src/components/Search/SimpleSearch/SimpleSearch.vue
@@ -100,7 +100,7 @@ useHead({ title });
 
 <template>
   <div class="pb-24">
-    <div class="ris-heading2-regular inline-block font-semibold">Suche</div>
+    <h1 class="ris-heading2-regular inline-block font-semibold">Suche</h1>
   </div>
   <SimpleSearchInput
     :model-value="values.query.value"
@@ -121,8 +121,6 @@ useHead({ title });
       <DateRangeFilter v-if="documentKind === DocumentKind.CaseLaw" />
     </fieldset>
     <div id="main" class="w-full flex-col justify-end gap-8 lg:w-9/12">
-      <h1 class="sr-only">Suchergebnisse</h1>
-
       <Pagination
         :is-loading="isLoading"
         navigation-position="bottom"

--- a/frontend/src/error.vue
+++ b/frontend/src/error.vue
@@ -42,11 +42,10 @@ useHead({ title: pageTitle.value });
 <template>
   <NuxtLayout>
     <div class="container pt-48 pb-24">
-      <h1 class="sr-only">Fehlerseite</h1>
       <template v-if="isNotFoundError">
-        <h2 class="ris-heading2-regular inline-block font-semibold">
+        <h1 class="ris-heading2-regular inline-block font-semibold">
           Diese Seite existiert nicht
-        </h2>
+        </h1>
         <p class="ris-body1-regular mt-8">
           Überprüfen Sie den eingegebenen Link<ClientOnly
             >: {{ locationClientOnly }}</ClientOnly
@@ -64,15 +63,15 @@ useHead({ title: pageTitle.value });
       <template v-else-if="isTokenRefreshError">
         <div class="flex items-center gap-24">
           <LoadingSpinner />
-          <h2 class="ris-heading2-regular inline-block">
+          <h1 class="ris-heading2-regular inline-block">
             Sie werden angemeldet…
-          </h2>
+          </h1>
         </div>
       </template>
       <template v-else>
-        <h2 class="ris-heading2-regular inline-block font-semibold">
+        <h1 class="ris-heading2-regular inline-block font-semibold">
           Es gab leider einen Fehler
-        </h2>
+        </h1>
         <p v-if="isInternalServerError" class="ris-body1-regular mt-24">
           Probieren Sie es zu einem späteren Moment noch einmal.<br />Wir haben
           den Fehler dokumentiert und an unsere Entwickler:innen weitergeleitet.

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8067,24 +8067,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001669":
-  version: 1.0.30001686
-  resolution: "caniuse-lite@npm:1.0.30001686"
-  checksum: 10c0/41748e81c17c1a6a0fd6e515c93c8620004171fe6706027e45f837fde71e97173e85141b0dc11e07d53b4782f3741a6651cb0f7d395cc1c1860892355eabdfa2
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001688":
-  version: 1.0.30001707
-  resolution: "caniuse-lite@npm:1.0.30001707"
-  checksum: 10c0/a1beaf84bad4f6617bbc5616d6bc0c9cab73e73f7e9e09b6466af5195b1bc393e0f6f19643d7a1c88bd3f4bfa122d7bea81cf6225ec3ade57d5b1dd3478c1a1b
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001702, caniuse-lite@npm:^1.0.30001718":
-  version: 1.0.30001722
-  resolution: "caniuse-lite@npm:1.0.30001722"
-  checksum: 10c0/a1e344c392e0b138f0b215525108877d725665217a5e8e7504897e30379a5a9b858bc44799ccc0e19f4a64bf1e05c15b4a58eb1c9032293f894aa24e8d9f470f
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001669, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702, caniuse-lite@npm:^1.0.30001718":
+  version: 1.0.30001743
+  resolution: "caniuse-lite@npm:1.0.30001743"
+  checksum: 10c0/1bd730ca10d881a1ca9f55ce864d34c3b18501718c03976e0d3419f4694b715159e13fdef6d58ad47b6d2445d315940f3a01266658876828c820a3331aac021d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR implements the following changes to the portal:

- Search Heading: remove hidden h1 (currently only visible to screen reader), Headline „Suche” will be h1 , keep existing styling
- Search Results: Norm Search Teaser, Heading gets defined as h2 (equal to other teaser results), Heading Paragraph/Tenor/Orientierungssatz should be shown on heading menu of screen reader
- Feedback Section: h3 turns into h2, get’s styled as h2
- Page 404,500: Heading gets defined has h1, keep existing styling
- Page Open Source : heading get’s defined as h1, feedback heading is h2
- Page Kontakt: heading get’s defined as h1, feedback heading is h2