### PR TITLE
inject caselaw ldml mapper

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/CaseLawLdmlToOpenSearchMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/CaseLawLdmlToOpenSearchMapper.java
@@ -26,13 +26,12 @@ import java.io.StringReader;
 import java.time.Instant;
 import javax.xml.transform.stream.StreamSource;
 import org.eclipse.persistence.exceptions.DescriptorException;
+import org.springframework.stereotype.Service;
 
+@Service
 public class CaseLawLdmlToOpenSearchMapper {
 
-  private CaseLawLdmlToOpenSearchMapper() {}
-
-  public static CaseLawDocumentationUnit mapToEntity(CaseLawLdml caseLawLdml)
-      throws ValidationException {
+  public CaseLawDocumentationUnit mapToEntity(CaseLawLdml caseLawLdml) throws ValidationException {
     validateNotNull(caseLawLdml.getJudgment(), "Judgment missing");
     Judgment judgment = caseLawLdml.getJudgment();
     validateNotNull(judgment.getMeta(), "Meta missing");
@@ -141,11 +140,11 @@ public class CaseLawLdmlToOpenSearchMapper {
     return MappingUtils.sanitizeHtmlFromString(html.toHtmlString());
   }
 
-  public static CaseLawDocumentationUnit fromString(String ldmlFile) {
+  public CaseLawDocumentationUnit fromString(String ldmlFile) {
     try {
       StreamSource ldmlStreamSource = new StreamSource(new StringReader(ldmlFile));
       CaseLawLdml ldml = JAXB.unmarshal(ldmlStreamSource, CaseLawLdml.class);
-      return CaseLawLdmlToOpenSearchMapper.mapToEntity(ldml);
+      return mapToEntity(ldml);
     } catch (DescriptorException | DataBindingException | ValidationException e) {
       throw new OpenSearchMapperException("unable to parse file to DocumentationUnit", e);
     }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexCaselawService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexCaselawService.java
@@ -15,10 +15,16 @@ public class IndexCaselawService extends BaseIndexService<CaseLawDocumentationUn
 
   private final CaseLawRepository repository;
 
+  private final CaseLawLdmlToOpenSearchMapper marshaller;
+
   @Autowired
-  public IndexCaselawService(CaseLawBucket bucket, CaseLawRepository repository) {
+  public IndexCaselawService(
+      CaseLawBucket bucket,
+      CaseLawRepository repository,
+      CaseLawLdmlToOpenSearchMapper marshaller) {
     super(bucket);
     this.repository = repository;
+    this.marshaller = marshaller;
   }
 
   @Override
@@ -35,7 +41,7 @@ public class IndexCaselawService extends BaseIndexService<CaseLawDocumentationUn
   protected Optional<CaseLawDocumentationUnit> mapFileToEntity(
       String filename, String fileContent) {
     try {
-      return Optional.of(CaseLawLdmlToOpenSearchMapper.fromString(fileContent));
+      return Optional.of(marshaller.fromString(fileContent));
     } catch (OpenSearchMapperException e) {
       logger.error("unable to parse file {}", filename, e);
       return Optional.empty();

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/importer/caselaw/CaseLawImporterTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/importer/caselaw/CaseLawImporterTest.java
@@ -1,17 +1,16 @@
 package de.bund.digitalservice.ris.search.unit.importer.caselaw;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
+import de.bund.digitalservice.ris.search.mapper.CaseLawLdmlToOpenSearchMapper;
+import de.bund.digitalservice.ris.search.models.opensearch.CaseLawDocumentationUnit;
 import de.bund.digitalservice.ris.search.repository.objectstorage.CaseLawBucket;
 import de.bund.digitalservice.ris.search.repository.opensearch.CaseLawRepository;
 import de.bund.digitalservice.ris.search.service.IndexCaselawService;
-import de.bund.digitalservice.ris.search.utils.CaseLawLdmlTemplateUtils;
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,28 +22,29 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class CaseLawImporterTest {
-  private String testCaseLawLdml;
   private CaseLawRepository caseLawRepositoryMock;
   private CaseLawBucket caseLawBucket;
-  private final CaseLawLdmlTemplateUtils caseLawLdmlTemplateUtils = new CaseLawLdmlTemplateUtils();
+  private CaseLawLdmlToOpenSearchMapper marshaller;
 
   @BeforeEach
-  void beforeEach() throws IOException {
-    testCaseLawLdml = caseLawLdmlTemplateUtils.getXmlFromTemplate(null);
+  void beforeEach() {
     caseLawRepositoryMock = Mockito.mock(CaseLawRepository.class);
     caseLawBucket = Mockito.mock(CaseLawBucket.class);
+    marshaller = Mockito.mock(CaseLawLdmlToOpenSearchMapper.class);
   }
 
   @Test
   @DisplayName("Import one caselaw ldml")
   void canImportLdml() throws ObjectStoreServiceException {
     IndexCaselawService indexCaselawService =
-        new IndexCaselawService(caseLawBucket, caseLawRepositoryMock);
+        new IndexCaselawService(caseLawBucket, caseLawRepositoryMock, marshaller);
     Changelog mockChangelog = new Changelog();
     mockChangelog.setChangeAll(true);
     when(caseLawBucket.getAllKeys()).thenReturn(List.of("mockFile.xml"));
-    when(caseLawBucket.getFileAsString("mockFile.xml")).thenReturn(Optional.of(testCaseLawLdml));
+    when(caseLawBucket.getFileAsString("mockFile.xml")).thenReturn(Optional.of("content"));
+    CaseLawDocumentationUnit unit = CaseLawDocumentationUnit.builder().id("id").build();
+    when(marshaller.fromString("content")).thenReturn(unit);
     indexCaselawService.indexChangelog(mockChangelog);
-    verify(caseLawRepositoryMock, atLeastOnce()).save(any());
+    verify(caseLawRepositoryMock, atLeastOnce()).save(unit);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/CaseLawLdmlToOpenSearchMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/CaseLawLdmlToOpenSearchMapperTest.java
@@ -14,6 +14,7 @@ class CaseLawLdmlToOpenSearchMapperTest {
 
   private String testCaseLawLdml;
   private final CaseLawLdmlTemplateUtils caseLawLdmlTemplateUtils = new CaseLawLdmlTemplateUtils();
+  private final CaseLawLdmlToOpenSearchMapper mapper = new CaseLawLdmlToOpenSearchMapper();
 
   @BeforeEach
   void beforeEach() throws IOException {
@@ -22,7 +23,7 @@ class CaseLawLdmlToOpenSearchMapperTest {
 
   @Test
   void shouldMapToCaseLawDocumentationUnitCorrectly() {
-    CaseLawDocumentationUnit caseLaw = CaseLawLdmlToOpenSearchMapper.fromString(testCaseLawLdml);
+    CaseLawDocumentationUnit caseLaw = mapper.fromString(testCaseLawLdml);
 
     assertThat(caseLaw.id()).isEqualTo("testDocNumber");
     assertThat(caseLaw.documentationOffice()).isEqualTo("documentationOffice");

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexCaseLawServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexCaseLawServiceTest.java
@@ -7,7 +7,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
+import de.bund.digitalservice.ris.search.exception.OpenSearchMapperException;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
+import de.bund.digitalservice.ris.search.mapper.CaseLawLdmlToOpenSearchMapper;
+import de.bund.digitalservice.ris.search.models.opensearch.CaseLawDocumentationUnit;
 import de.bund.digitalservice.ris.search.repository.objectstorage.CaseLawBucket;
 import de.bund.digitalservice.ris.search.repository.opensearch.CaseLawRepository;
 import de.bund.digitalservice.ris.search.service.IndexCaselawService;
@@ -31,161 +34,23 @@ class IndexCaseLawServiceTest {
 
   @Mock CaseLawBucket bucket;
   @Mock CaseLawRepository repo;
-
-  String caseLawContent =
-      """
-          <?xml version="1.0" encoding="utf-8"?>
-          <akn:akomaNtoso xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0/WD17"
-                          xmlns:ris="http://example.com/0.1/"
-                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                          xsi:schemaLocation="http://docs.oasis-open.org/legaldocml/ns/akn/3.0/WD17 https://docs.oasis-open.org/legaldocml/akn-core/v1.0/csprd02/part2-specs/schemas/akomantoso30.xsd">
-             <akn:judgment name="attributsemantik-noch-undefiniert">
-                <akn:meta>
-                   <akn:identification source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRWork>
-                         <akn:FRBRthis value="TEST80020093"/>
-                         <akn:FRBRuri value="TEST80020093"/>
-                         <akn:FRBRalias name="uebergreifende-id" value="19c1545d-4c41-4765-be23-dc71ec0d0a90"/>
-                         <akn:FRBRdate date="2008-09-04" name="entscheidungsdatum"/>
-                         <akn:FRBRauthor href="attributsemantik-noch-undefiniert"/>
-                         <akn:FRBRcountry value="de"/>
-                      </akn:FRBRWork>
-                      <akn:FRBRExpression>
-                         <akn:FRBRthis value="TEST80020093/dokument"/>
-                         <akn:FRBRuri value="TEST80020093/dokument"/>
-                         <akn:FRBRdate date="2008-09-04" name="entscheidungsdatum"/>
-                         <akn:FRBRauthor href="attributsemantik-noch-undefiniert"/>
-                         <akn:FRBRlanguage language="deu"/>
-                      </akn:FRBRExpression>
-                      <akn:FRBRManifestation>
-                         <akn:FRBRthis value="TEST80020093/dokument.xml"/>
-                         <akn:FRBRuri value="TEST80020093/dokument.xml"/>
-                         <akn:FRBRdate date="2008-09-04" name="entscheidungsdatum"/>
-                         <akn:FRBRauthor href="attributsemantik-noch-undefiniert"/>
-                      </akn:FRBRManifestation>
-                   </akn:identification>
-                   <akn:classification source="attributsemantik-noch-undefiniert">
-                      <akn:keyword dictionary="attributsemantik-noch-undefiniert"
-                                   showAs="attributsemantik-noch-undefiniert"
-                                   value="Beschwerdeverfahren"/>
-                      <akn:keyword dictionary="attributsemantik-noch-undefiniert"
-                                   showAs="attributsemantik-noch-undefiniert"
-                                   value="bedürftige Partei"/>
-                      <akn:keyword dictionary="attributsemantik-noch-undefiniert"
-                                   showAs="attributsemantik-noch-undefiniert"
-                                   value="wesentliche Änderung"/>
-                      <akn:keyword dictionary="attributsemantik-noch-undefiniert"
-                                   showAs="attributsemantik-noch-undefiniert"
-                                   value="Änderung"/>
-                      <akn:keyword dictionary="attributsemantik-noch-undefiniert"
-                                   showAs="attributsemantik-noch-undefiniert"
-                                   value="Erklärungspflicht"/>
-                      <akn:keyword dictionary="attributsemantik-noch-undefiniert"
-                                   showAs="attributsemantik-noch-undefiniert"
-                                   value="Prozesskostenhilfe"/>
-                      <akn:keyword dictionary="attributsemantik-noch-undefiniert"
-                                   showAs="attributsemantik-noch-undefiniert"
-                                   value="Aufhebung"/>
-                      <akn:keyword dictionary="attributsemantik-noch-undefiniert"
-                                   showAs="attributsemantik-noch-undefiniert"
-                                   value="Erklärung"/>
-                      <akn:keyword dictionary="attributsemantik-noch-undefiniert"
-                                   showAs="attributsemantik-noch-undefiniert"
-                                   value="Gehaltsabrechnung"/>
-                      <akn:keyword dictionary="attributsemantik-noch-undefiniert"
-                                   showAs="attributsemantik-noch-undefiniert"
-                                   value="persönliche und wirtschaftliche Verhältnisse"/>
-                   </akn:classification>
-                   <akn:proprietary source="attributsemantik-noch-undefiniert">
-                      <ris:meta>
-                         <ris:previousDecisions>
-                            <ris:previousDecision date="2008-04-08">
-                               <ris:fileNumber>8 Ca 1758/05</ris:fileNumber>
-                               <ris:courtType>ArbG</ris:courtType>
-                            </ris:previousDecision>
-                         </ris:previousDecisions>
-                         <ris:fileNumbers>
-                            <ris:fileNumber>3 Ta 156/08</ris:fileNumber>
-                         </ris:fileNumbers>
-                         <ris:documentType>Beschluss</ris:documentType>
-                         <ris:courtLocation>Mainz</ris:courtLocation>
-                         <ris:courtType>LArbG</ris:courtType>
-                         <ris:legalEffect>JA</ris:legalEffect>
-                         <ris:fieldOfLaws>
-                            <ris:fieldOfLaw>Arbeitsrecht</ris:fieldOfLaw>
-                            <ris:fieldOfLaw>Aufhebung der Bewilligung</ris:fieldOfLaw>
-                            <ris:fieldOfLaw>Bewilligung, Wirkungen, Beiordnung eines Rechtsanwalts</ris:fieldOfLaw>
-                            <ris:fieldOfLaw>Bewilligungsvoraussetzungen</ris:fieldOfLaw>
-                         </ris:fieldOfLaws>
-                         <ris:judicialBody>3. Kammer</ris:judicialBody>
-                         <ris:publicationStatus>PUBLISHED</ris:publicationStatus>
-                         <ris:error>false</ris:error>
-                         <ris:documentationOffice>BAG</ris:documentationOffice>
-                         <ris:procedures>
-                            <ris:procedure>SELECT081105</ris:procedure>
-                         </ris:procedures>
-                      </ris:meta>
-                   </akn:proprietary>
-                </akn:meta>
-                <akn:header>
-                   <akn:p>(Testheader)</akn:p>
-                </akn:header>
-                <akn:judgmentBody>
-                   <akn:introduction>
-                      <akn:block name="Orientierungssatz">
-                         <akn:embeddedStructure>
-                            <akn:p>An die Erfüllung der Erklärungspflicht im Rahmen des § 120 Abs. 4 S. 2 ZPO (- ist eine Änderung der Verhältnisse eingetreten? -) dürfen keine zu strengen Anforderungen gestellt werden.</akn:p>
-                            <akn:p>
-                      Die (bedürftige) kann Partei die erforderliche Erklärung auch noch im Beschwerdeverfahren abgeben bzw. eine bereits abgegebene Erklärung ergänzen und belegen.
-                      <akn:a class="border-number-link" href="#border-number-link-7">7</akn:a>
-                            </akn:p>
-                         </akn:embeddedStructure>
-                      </akn:block>
-                      <akn:block name="Tenor">
-                         <akn:embeddedStructure>
-                            <akn:p>1. Tenor</akn:p>
-                            <akn:p>2.Tenor</akn:p>
-                         </akn:embeddedStructure>
-                      </akn:block>
-                   </akn:introduction>
-                   <akn:decision>
-                      <akn:block name="Gründe">
-                         <akn:embeddedStructure>
-                            <akn:p>
-                               <akn:b>I.</akn:b>
-                            </akn:p>
-                            <akn:hcontainer name="randnummer">
-                               <akn:num>1</akn:num>
-                               <akn:content>
-                                  <akn:p>Content 1</akn:p>
-                               </akn:content>
-                            </akn:hcontainer>
-                            <akn:hcontainer name="randnummer">
-                               <akn:num>2</akn:num>
-                               <akn:content>
-                                  <akn:p>Content 2</akn:p>
-                               </akn:content>
-                            </akn:hcontainer>
-                         </akn:embeddedStructure>
-                      </akn:block>
-                   </akn:decision>
-                </akn:judgmentBody>
-             </akn:judgment>
-          </akn:akomaNtoso>
-          """;
+  @Mock CaseLawLdmlToOpenSearchMapper marshaller;
 
   @BeforeEach()
   void setup() {
-    this.service = new IndexCaselawService(bucket, repo);
+    this.service = new IndexCaselawService(bucket, repo, marshaller);
   }
+
+  CaseLawDocumentationUnit testUnit = CaseLawDocumentationUnit.builder().id("TEST80020093").build();
 
   @Test
   void reindexAllIgnoresInvalidFiles() throws ObjectStoreServiceException {
-    String testContent = caseLawContent;
-
     when(this.bucket.getAllKeys()).thenReturn(List.of("file1.xml", "file2.xml"));
-    when(this.bucket.getFileAsString("file1.xml")).thenReturn(Optional.of(testContent));
+    when(this.bucket.getFileAsString("file1.xml")).thenReturn(Optional.of("content"));
+    when(this.marshaller.fromString("content")).thenReturn(testUnit);
     when(this.bucket.getFileAsString("file2.xml")).thenReturn(Optional.of("this will not parse"));
+    when(this.marshaller.fromString("this will not parse"))
+        .thenThrow(OpenSearchMapperException.class);
 
     String startingTimestamp =
         ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
@@ -203,9 +68,8 @@ class IndexCaseLawServiceTest {
 
   @Test
   void itCanReindexFromOneSpecificChangelog() throws ObjectStoreServiceException {
-    String testContent = caseLawContent;
-
-    when(this.bucket.getFileAsString("TEST080020093.xml")).thenReturn(Optional.of(testContent));
+    when(this.bucket.getFileAsString("TEST080020093.xml")).thenReturn(Optional.of("content"));
+    when(marshaller.fromString("content")).thenReturn(testUnit);
 
     Changelog changelog = new Changelog();
     changelog.setChanged(Sets.newHashSet(List.of("TEST080020093.xml")));
@@ -222,10 +86,10 @@ class IndexCaseLawServiceTest {
 
   @Test
   void doesNotIndexNoneXmlFilesListedInChangelog() throws ObjectStoreServiceException {
-    String testContent = caseLawContent;
-
     when(this.bucket.getFileAsString("TEST080020093/TEST080020093.xml"))
-        .thenReturn(Optional.of(testContent));
+        .thenReturn(Optional.of("content"));
+
+    when(marshaller.fromString("content")).thenReturn(testUnit);
 
     Changelog changelog = new Changelog();
     changelog.setChanged(


### PR DESCRIPTION
inject the opensearch mapper to be able to mock the fromString method to not rely on file operations for unit tests