### PR TITLE
RISDEV-8606 Fix facicon setup

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -25,12 +25,47 @@ export default defineNuxtConfig({
           content:
             "Gesetze & Verordnungen, Gerichtsentscheidungen und Verwaltungsvorschriften",
         },
+        { name: "theme-color", content: "#ffffff" },
+        { name: "msapplication-TileColor", content: "#ffffff" },
       ],
       htmlAttrs: {
         lang: "de",
       },
       charset: "utf-8",
       viewport: "width=device-width, initial-scale=1",
+      link: [
+        { rel: "icon", type: "image/x-icon", href: "/favicon.ico" },
+        {
+          rel: "icon",
+          type: "image/png",
+          sizes: "16x16",
+          href: "/favicon-16x16.png",
+        },
+        {
+          rel: "icon",
+          type: "image/png",
+          sizes: "32x32",
+          href: "/favicon-32x32.png",
+        },
+        {
+          rel: "apple-touch-icon",
+          sizes: "180x180",
+          href: "/apple-touch-icon.png",
+        },
+        {
+          rel: "icon",
+          type: "image/png",
+          sizes: "192x192",
+          href: "/android-chrome-192x192.png",
+        },
+        {
+          rel: "icon",
+          type: "image/png",
+          sizes: "512x512",
+          href: "/android-chrome-512x512.png",
+        },
+        { rel: "manifest", href: "/site.webmanifest" },
+      ],
     },
   },
   srcDir: "src/",

--- a/frontend/src/public/site.webmanifest
+++ b/frontend/src/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "",
-  "short_name": "",
+  "name": "Rechtsinformationen des Bundes",
+  "short_name": "RIS",
   "icons": [
     {
       "src": "/android-chrome-192x192.png",


### PR DESCRIPTION
This PR implements changes to the nuxt config to include links to the manifest and the favicon different sizes per device.
It also updates information in the site.webmanifest file about the project.