### PR TITLE
Literature backend API and service

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/LiteratureController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/LiteratureController.java
@@ -1,0 +1,182 @@
+package de.bund.digitalservice.ris.search.controller.api;
+
+import de.bund.digitalservice.ris.search.config.ApiConfig;
+import de.bund.digitalservice.ris.search.exception.CustomValidationException;
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
+import de.bund.digitalservice.ris.search.mapper.LiteratureSchemaMapper;
+import de.bund.digitalservice.ris.search.mapper.LiteratureSearchSchemaMapper;
+import de.bund.digitalservice.ris.search.mapper.SortParamsConverter;
+import de.bund.digitalservice.ris.search.models.api.parameters.LiteratureSearchParams;
+import de.bund.digitalservice.ris.search.models.api.parameters.LiteratureSortParam;
+import de.bund.digitalservice.ris.search.models.api.parameters.PaginationParams;
+import de.bund.digitalservice.ris.search.models.api.parameters.ResourceReferenceMode;
+import de.bund.digitalservice.ris.search.models.api.parameters.UniversalSearchParams;
+import de.bund.digitalservice.ris.search.models.opensearch.Literature;
+import de.bund.digitalservice.ris.search.schema.CollectionSchema;
+import de.bund.digitalservice.ris.search.schema.LiteratureSchema;
+import de.bund.digitalservice.ris.search.schema.LiteratureSearchSchema;
+import de.bund.digitalservice.ris.search.schema.SearchMemberSchema;
+import de.bund.digitalservice.ris.search.service.LiteratureService;
+import de.bund.digitalservice.ris.search.service.XsltTransformerService;
+import de.bund.digitalservice.ris.search.utils.LuceneQueryTools;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Optional;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
+import org.springframework.data.elasticsearch.core.SearchPage;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Literature")
+@RestController
+@Profile({"default", "staging", "uat", "test", "prototype"})
+public class LiteratureController {
+
+  private final LiteratureService literatureService;
+  private final XsltTransformerService xsltTransformerService;
+
+  @Autowired
+  public LiteratureController(
+      LiteratureService literatureService, XsltTransformerService xsltTransformerService) {
+    this.literatureService = literatureService;
+    this.xsltTransformerService = xsltTransformerService;
+  }
+
+  @GetMapping(
+      path = ApiConfig.Paths.LITERATURE + "/{documentNumber}",
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(
+      summary = "Literature metadata",
+      description = "The endpoint returns the metadata of a single literature from our database.")
+  @ApiResponse(responseCode = "200")
+  @ApiResponse(responseCode = "404", content = @Content)
+  public ResponseEntity<LiteratureSchema> getLiteratureMetadata(
+      @Parameter(example = "STRE201770751") @PathVariable String documentNumber) {
+    List<Literature> result = literatureService.getByDocumentNumber(documentNumber);
+    if (result.isEmpty()) {
+      return ResponseEntity.notFound().build();
+    }
+    Literature unit = result.getFirst();
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(LiteratureSchemaMapper.fromDomain(unit));
+  }
+
+  @GetMapping(
+      path = ApiConfig.Paths.LITERATURE + "/{documentNumber}.html",
+      produces = MediaType.TEXT_HTML_VALUE)
+  @Operation(
+      summary = "Literature HTML",
+      description = "Renders and returns a literature item as HTML.")
+  @ApiResponse(responseCode = "200")
+  @ApiResponse(responseCode = "404", content = @Content)
+  public ResponseEntity<String> getLiteratureAsHtml(
+      @Parameter(example = "BJLU075748788") @PathVariable String documentNumber,
+      @RequestHeader(
+              name = ApiConfig.Headers.GET_RESOURCES_VIA,
+              required = false,
+              defaultValue = ResourceReferenceMode.DEFAULT_VALUE)
+          @Parameter(
+              description =
+                  "Used to select a different prefix for referenced resources, like images. Selecting 'PROXY' will prepend `/api`. Otherwise, the API base URL will be used.")
+          ResourceReferenceMode resourceReferenceMode)
+      throws ObjectStoreServiceException {
+    final String resourcePath = getResourceBasePath(resourceReferenceMode, documentNumber);
+    Optional<byte[]> bytes = literatureService.getFileByDocumentNumber(documentNumber);
+
+    if (bytes.isPresent()) {
+      String html = xsltTransformerService.transformCaseLaw(bytes.get(), resourcePath);
+      return ResponseEntity.ok(html);
+    } else {
+      return ResponseEntity.notFound().build();
+    }
+  }
+
+  @GetMapping(
+      path = ApiConfig.Paths.LITERATURE + "/{documentNumber}.xml",
+      produces = MediaType.APPLICATION_XML_VALUE)
+  @Operation(
+      summary = "Decision XML",
+      description =
+          "Returns a literature item as XML. This content is used as a source for the HTML endpoint.")
+  @ApiResponse(responseCode = "200")
+  @ApiResponse(responseCode = "404", content = @Content(schema = @Schema()))
+  public ResponseEntity<byte[]> getLiteratureAsXml(
+      @Parameter(example = "BJLU075748788") @PathVariable String documentNumber)
+      throws ObjectStoreServiceException {
+
+    Optional<byte[]> bytes = literatureService.getFileByDocumentNumber(documentNumber);
+    return bytes.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+  }
+
+  /**
+   * Search for literature in the OpenSearch index with filters. For more information on the
+   * parameters, refer to the OpenAPI documentation.
+   *
+   * @param literatureSearchParams Parameters to search with for literature.
+   * @param universalSearchParams Parameters to search with for all document types.
+   * @param paginationParams The number of entities and page index to request.
+   * @param sortParams The sorting parameters
+   * @return The search results
+   */
+  @GetMapping(path = ApiConfig.Paths.LITERATURE, produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(
+      summary = "List and search literature",
+      description =
+          "The endpoint returns a list of literature from our database. The list is paginated and can be filtered and sorted.")
+  @ApiResponse(responseCode = "200", description = "Success")
+  @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content)
+  public ResponseEntity<CollectionSchema<SearchMemberSchema<LiteratureSearchSchema>>>
+      searchAndFilter(
+          @ParameterObject() LiteratureSearchParams literatureSearchParams,
+          @ParameterObject UniversalSearchParams universalSearchParams,
+          @ParameterObject() @Valid PaginationParams paginationParams,
+          @ParameterObject @Valid LiteratureSortParam sortParams)
+          throws CustomValidationException {
+
+    var pageRequest = PageRequest.of(paginationParams.getPageIndex(), paginationParams.getSize());
+
+    var sortedPageRequest =
+        pageRequest.withSort(SortParamsConverter.buildSort(sortParams.getSort()));
+
+    try {
+      SearchPage<Literature> page =
+          literatureService.searchAndFilterLiterature(
+              universalSearchParams, literatureSearchParams, sortedPageRequest);
+      return ResponseEntity.ok()
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(LiteratureSearchSchemaMapper.fromSearchPage(page));
+    } catch (UncategorizedElasticsearchException e) {
+      LuceneQueryTools.checkForInvalidQuery(e);
+      throw e;
+    }
+  }
+
+  /**
+   * Controls how resources like images will be referenced. For example, they might be accessed
+   * through an API endpoint in local development, but served via a CDN in production.
+   *
+   * @param mode Controls which static prefix will be returned.
+   * @return The prefix to use when returning references to resources.
+   */
+  private String getResourceBasePath(ResourceReferenceMode mode, String documentNumber) {
+    return switch (mode) {
+      case API -> ApiConfig.Paths.LITERATURE + "/" + documentNumber + "/";
+      case PROXY -> "/api" + ApiConfig.Paths.LITERATURE + "/" + documentNumber + "/";
+    };
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureLdmlToOpenSearchMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureLdmlToOpenSearchMapper.java
@@ -17,11 +17,13 @@ import de.bund.digitalservice.ris.search.models.ldml.literature.Proprietary;
 import de.bund.digitalservice.ris.search.models.ldml.literature.References;
 import de.bund.digitalservice.ris.search.models.ldml.literature.TlcPerson;
 import de.bund.digitalservice.ris.search.models.opensearch.Literature;
+import de.bund.digitalservice.ris.search.utils.DateUtils;
 import jakarta.xml.bind.DataBindingException;
 import jakarta.xml.bind.JAXB;
 import jakarta.xml.bind.ValidationException;
 import java.io.StringReader;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -55,6 +57,7 @@ public class LiteratureLdmlToOpenSearchMapper {
         Literature.builder()
             .id(documentNumber)
             .documentNumber(documentNumber)
+            .recordingDate(extractRecordingDate(literatureLdml))
             .yearsOfPublication(extractYearsOfPublication(literatureLdml))
             .documentTypes(extractDocumentTypes(literatureLdml))
             .dependentReferences(extractDependentReferences(literatureLdml))
@@ -90,6 +93,16 @@ public class LiteratureLdmlToOpenSearchMapper {
     }
 
     return documentNumber;
+  }
+
+  private static LocalDate extractRecordingDate(LiteratureLdml literatureLdml) {
+    FrbrWork frbrWork = literatureLdml.getDoc().getMeta().getIdentification().getFrbrWork();
+    if (frbrWork == null
+        || frbrWork.getFrbrDate() == null
+        || frbrWork.getFrbrDate().getDate() == null) {
+      return null;
+    }
+    return DateUtils.nullSafeParseyyyyMMdd(frbrWork.getFrbrDate().getDate());
   }
 
   private static List<String> extractYearsOfPublication(LiteratureLdml literatureLdml) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureSearchSchemaMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureSearchSchemaMapper.java
@@ -1,0 +1,92 @@
+package de.bund.digitalservice.ris.search.mapper;
+
+import de.bund.digitalservice.ris.search.config.ApiConfig;
+import de.bund.digitalservice.ris.search.models.opensearch.Literature;
+import de.bund.digitalservice.ris.search.schema.CollectionSchema;
+import de.bund.digitalservice.ris.search.schema.LiteratureSearchSchema;
+import de.bund.digitalservice.ris.search.schema.PartialCollectionViewSchema;
+import de.bund.digitalservice.ris.search.schema.SearchMemberSchema;
+import de.bund.digitalservice.ris.search.schema.TextMatchSchema;
+import de.bund.digitalservice.ris.search.utils.PageUtils;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchPage;
+
+public class LiteratureSearchSchemaMapper {
+  private LiteratureSearchSchemaMapper() {}
+
+  public static <T> SearchMemberSchema<LiteratureSearchSchema> fromSearchHit(
+      SearchHit<T> searchHit) {
+    Literature document = (Literature) searchHit.getContent();
+    List<TextMatchSchema> textMatches =
+        searchHit.getHighlightFields().entrySet().stream()
+            .flatMap(
+                textMatch ->
+                    textMatch.getValue().stream()
+                        .map(
+                            valueMatch ->
+                                TextMatchSchema.builder()
+                                    .name(getTextMatchKey(textMatch))
+                                    .text(valueMatch)
+                                    .build()))
+            .toList();
+
+    return SearchMemberSchema.<LiteratureSearchSchema>builder()
+        .item(fromDomain(document))
+        .textMatches(textMatches)
+        .build();
+  }
+
+  /**
+   * Case-convert text match keys (field names) to match the result schema.
+   *
+   * @param textMatch The text match to take the name from.
+   * @return A normalized key
+   */
+  private static String getTextMatchKey(Map.Entry<String, List<String>> textMatch) {
+    final String key = textMatch.getKey();
+    if (key.endsWith(".text")) {
+      return PageUtils.snakeCaseToCamelCase(StringUtils.removeEnd(key, ".text"));
+    }
+    return PageUtils.snakeCaseToCamelCase(key);
+  }
+
+  public static LiteratureSearchSchema fromDomain(Literature doc) {
+    String entityURI = ApiConfig.Paths.LITERATURE + "/" + doc.documentNumber();
+    return LiteratureSearchSchema.builder()
+        .id(entityURI)
+        .inLanguage("de")
+        .documentNumber(doc.documentNumber())
+        .recordingDate(doc.recordingDate())
+        .yearsOfPublication(doc.yearsOfPublication())
+        .documentTypes(doc.documentTypes())
+        .dependentReferences(doc.dependentReferences())
+        .independentReferences(doc.independentReferences())
+        .headline(doc.mainTitle())
+        .alternativeTitle(doc.documentaryTitle())
+        .authors(doc.authors())
+        .collaborators(doc.collaborators())
+        .shortReport(doc.shortReport())
+        .outline(doc.outline())
+        .build();
+  }
+
+  public static <T> CollectionSchema<SearchMemberSchema<LiteratureSearchSchema>> fromSearchPage(
+      final SearchPage<T> page) {
+    String collectionBasePath = ApiConfig.Paths.LITERATURE;
+    PartialCollectionViewSchema view =
+        PartialCollectionViewMapper.fromPage(collectionBasePath, page);
+
+    String id =
+        String.format("%s?page=%d&size=%d", collectionBasePath, page.getNumber(), page.getSize());
+
+    return CollectionSchema.<SearchMemberSchema<LiteratureSearchSchema>>builder()
+        .id(id)
+        .totalItems(page.getTotalElements())
+        .member(page.stream().map(LiteratureSearchSchemaMapper::fromSearchHit).toList())
+        .view(view)
+        .build();
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/MappingDefinitions.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/MappingDefinitions.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.search.mapper;
 
 import de.bund.digitalservice.ris.search.models.opensearch.CaseLawDocumentationUnit;
+import de.bund.digitalservice.ris.search.models.opensearch.Literature;
 import de.bund.digitalservice.ris.search.models.opensearch.Norm;
 import java.util.HashMap;
 import java.util.Map;
@@ -10,14 +11,35 @@ public class MappingDefinitions {
 
   protected static final Map<String, String> caseLawOpenSearchToSchemaMap;
   protected static final Map<String, String> normsOpenSearchToSchemaMap;
+  protected static final Map<String, String> literatureOpenSearchToSchemaMap;
 
   protected static final Map<String, String> caseLawSchemaToOpenSearchMap;
 
   protected static final Map<String, String> normsSchemaToOpenSearchMap;
 
+  protected static final Map<String, String> literatureSchemaToOpenSearchMap;
+
   protected static final Map<String, String> schemaToOpenSearchMap;
 
+  private static final String DATUM_FIELD = "DATUM";
+
   static {
+    literatureOpenSearchToSchemaMap =
+        Map.ofEntries(
+            Map.entry(Literature.Fields.DOCUMENT_NUMBER, "documentNumber"),
+            Map.entry(Literature.Fields.RECORDING_DATE, "recordingDate"),
+            Map.entry(Literature.Fields.YEARS_OF_PUBLICATION, "yearsOfPublication"),
+            Map.entry(Literature.Fields.DEPENDENT_REFERENCES, "dependentReferences"),
+            Map.entry(Literature.Fields.INDEPENDENT_REFERENCES, "independentReferences"),
+            Map.entry(Literature.Fields.MAIN_TITLE, "mainTitle"),
+            Map.entry(Literature.Fields.DOCUMENTARY_TITLE, "documentaryTitle"),
+            Map.entry(Literature.Fields.AUTHORS, "authors"),
+            Map.entry(Literature.Fields.COLLABORATORS, "collaborators"),
+            Map.entry(Literature.Fields.SHORT_REPORT, "shortReport"),
+            Map.entry(Literature.Fields.OUTLINE, "outline"),
+            Map.entry(Literature.Fields.INDEXED_AT, "indexedAt"),
+            Map.entry(DATUM_FIELD, "date") // alias shared with caseLaw/norms
+            );
     normsOpenSearchToSchemaMap =
         Map.ofEntries(
             Map.entry(Norm.Fields.WORK_ELI_KEYWORD, "legislationIdentifier"),
@@ -26,7 +48,7 @@ public class MappingDefinitions {
             Map.entry(Norm.Fields.OFFICIAL_ABBREVIATION, "abbreviation"),
             Map.entry(Norm.Fields.NORMS_DATE, "legislationDate"),
             Map.entry(Norm.Fields.ENTRY_INTO_FORCE_DATE, "temporalCoverageFrom"),
-            Map.entry("DATUM", "date") // alias shared with caseLaw
+            Map.entry(DATUM_FIELD, "date") // alias shared with caseLaw
             );
     caseLawOpenSearchToSchemaMap =
         Map.ofEntries(
@@ -62,7 +84,7 @@ public class MappingDefinitions {
             Map.entry(CaseLawDocumentationUnit.Fields.PROCEDURES, "procedures"),
             Map.entry(CaseLawDocumentationUnit.Fields.LEGAL_EFFECT, "legalEffect"),
             Map.entry(CaseLawDocumentationUnit.Fields.INDEXED_AT, "indexedAt"),
-            Map.entry("DATUM", "date") // alias shared with norms
+            Map.entry(DATUM_FIELD, "date") // alias shared with norms
             );
     schemaToOpenSearchMap = new HashMap<>();
 
@@ -73,8 +95,13 @@ public class MappingDefinitions {
     normsSchemaToOpenSearchMap = new HashMap<>();
     normsOpenSearchToSchemaMap.forEach((key, value) -> normsSchemaToOpenSearchMap.put(value, key));
 
+    literatureSchemaToOpenSearchMap = new HashMap<>();
+    literatureOpenSearchToSchemaMap.forEach(
+        (key, value) -> literatureSchemaToOpenSearchMap.put(value, key));
+
     schemaToOpenSearchMap.putAll(caseLawSchemaToOpenSearchMap);
     schemaToOpenSearchMap.putAll(normsSchemaToOpenSearchMap);
+    schemaToOpenSearchMap.putAll(literatureSchemaToOpenSearchMap);
   }
 
   public static String getOpenSearchName(String nameInSchema, ResolutionMode mode) {
@@ -82,12 +109,14 @@ public class MappingDefinitions {
       case ALL -> schemaToOpenSearchMap.get(nameInSchema);
       case NORMS -> normsSchemaToOpenSearchMap.get(nameInSchema);
       case CASE_LAW -> caseLawSchemaToOpenSearchMap.get(nameInSchema);
+      case LITERATURE -> literatureSchemaToOpenSearchMap.get(nameInSchema);
     };
   }
 
   public enum ResolutionMode {
     ALL,
     NORMS,
-    CASE_LAW
+    CASE_LAW,
+    LITERATURE
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/api/parameters/LiteratureSearchParams.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/api/parameters/LiteratureSearchParams.java
@@ -1,0 +1,20 @@
+package de.bund.digitalservice.ris.search.models.api.parameters;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LiteratureSearchParams {
+
+  @Schema String documentNumber;
+
+  @Schema String[] yearOfPublication;
+
+  @Schema String[] documentType;
+
+  @Schema String[] author;
+
+  @Schema String[] collaborator;
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/api/parameters/LiteratureSortParam.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/api/parameters/LiteratureSortParam.java
@@ -1,0 +1,17 @@
+package de.bund.digitalservice.ris.search.models.api.parameters;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+import org.jetbrains.annotations.Nullable;
+
+@Data
+public class LiteratureSortParam {
+  @Schema(
+      description =
+          "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date and documentNumber and not setting the sort field (sort by relevance descending)."
+              + "Add a leading - to set the order to descending (-date)")
+  @Pattern(regexp = "^-?(|default|date|DATUM|documentNumber)$")
+  @Nullable
+  String sort = null;
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/ldml/literature/FrbrDate.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/ldml/literature/FrbrDate.java
@@ -1,0 +1,16 @@
+package de.bund.digitalservice.ris.search.models.ldml.literature;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class FrbrDate {
+  @XmlAttribute private String date;
+  @XmlAttribute private String name = "erfassungsdatum";
+
+  public FrbrDate(String date) {
+    this.date = date;
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/ldml/literature/FrbrWork.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/ldml/literature/FrbrWork.java
@@ -10,6 +10,9 @@ public class FrbrWork {
   @XmlElement(name = "FRBRalias", namespace = LiteratureNamespaces.AKN_NS)
   private List<FrbrNameValueElement> frbrAliasList;
 
+  @XmlElement(name = "FRBRdate", namespace = LiteratureNamespaces.AKN_NS)
+  private FrbrDate frbrDate;
+
   @XmlElement(name = "FRBRauthor", namespace = LiteratureNamespaces.AKN_NS)
   private List<FrbrAuthor> frbrAuthors;
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/Literature.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/Literature.java
@@ -2,12 +2,15 @@ package de.bund.digitalservice.ris.search.models.opensearch;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.ElementCollection;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 import org.opensearch.common.Nullable;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.annotations.Setting;
 
@@ -19,6 +22,8 @@ import org.springframework.data.elasticsearch.annotations.Setting;
 public record Literature(
     @Id @Field(name = Fields.ID) String id,
     @Field(name = Fields.DOCUMENT_NUMBER) String documentNumber,
+    @Field(name = Fields.RECORDING_DATE, type = FieldType.Date, format = DateFormat.date)
+        LocalDate recordingDate,
     @ElementCollection @Field(name = Fields.YEARS_OF_PUBLICATION) List<String> yearsOfPublication,
     @ElementCollection @Field(name = Fields.DOCUMENT_TYPES) List<String> documentTypes,
     @ElementCollection @Field(name = Fields.DEPENDENT_REFERENCES) List<String> dependentReferences,
@@ -37,6 +42,7 @@ public record Literature(
 
     public static final String ID = "id";
     public static final String DOCUMENT_NUMBER = "document_number";
+    public static final String RECORDING_DATE = "recording_date";
     public static final String YEARS_OF_PUBLICATION = "years_of_publication";
     public static final String DOCUMENT_TYPES = "document_types";
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/LiteratureRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/LiteratureRepository.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.search.repository.opensearch;
 
 import de.bund.digitalservice.ris.search.models.opensearch.Literature;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
@@ -11,4 +12,6 @@ public interface LiteratureRepository extends ElasticsearchRepository<Literature
   void deleteByIndexedAtIsNull();
 
   void deleteAllById(@NotNull Iterable<? extends String> ids);
+
+  List<Literature> findByDocumentNumber(String documentNumber);
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/AbstractDocumentSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/AbstractDocumentSchema.java
@@ -1,4 +1,4 @@
 package de.bund.digitalservice.ris.search.schema;
 
 public sealed interface AbstractDocumentSchema
-    permits CaseLawSearchSchema, LegislationWorkSearchSchema {}
+    permits CaseLawSearchSchema, LegislationWorkSearchSchema, LiteratureSearchSchema {}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/LiteratureSearchSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/LiteratureSearchSchema.java
@@ -1,0 +1,39 @@
+package de.bund.digitalservice.ris.search.schema;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldId;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldResource;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldType;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import org.jetbrains.annotations.Nullable;
+
+@Builder
+@JsonldResource
+@JsonldType("Literature")
+public record LiteratureSearchSchema(
+    @Schema(example = "KALU000000000") @JsonldId String id,
+    @Schema(example = "de") String inLanguage,
+    @Schema(description = "Dokumentnummer", example = "KALU000000000") String documentNumber,
+    @Schema(
+            example = "2003-12-15",
+            description = "The date on which the literature piece was recorded.")
+        LocalDate recordingDate,
+    @Schema(description = "Veröffentlichungsjahre", example = "[2014, 2024-09]")
+        List<String> yearsOfPublication,
+    @Schema(description = "Dokumenttypen", example = "[Auf]") List<String> documentTypes,
+    @Schema(description = "Unselbstständige Fundstellen", example = "[BUV, 1982, 123-123]")
+        List<String> dependentReferences,
+    @Schema(
+            description = "Selbstständige Fundstellen",
+            example = "[50 Jahre Betriebs-Berater, 1987, 123-456]")
+        List<String> independentReferences,
+    @Schema(description = "Haupttitel") String headline,
+    @Schema(description = "Dokumentarischer Titel") String alternativeTitle,
+    @Schema(description = "Authoren", example = "[Musterfrau, Sabine]") List<String> authors,
+    @Schema(description = "Mitarbeiter", example = "[Mustermann, Max]") List<String> collaborators,
+    @Schema(description = "Kurzrefarat") String shortReport,
+    @Schema(description = "Gliederung") String outline,
+    @Nullable List<LiteratureEncodingSchema> encoding)
+    implements AbstractDocumentSchema {}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/helper/FetchSourceFilterDefinitions.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/helper/FetchSourceFilterDefinitions.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.search.service.helper;
 
 import de.bund.digitalservice.ris.search.models.opensearch.CaseLawDocumentationUnit;
+import de.bund.digitalservice.ris.search.models.opensearch.Literature;
 import de.bund.digitalservice.ris.search.models.opensearch.Norm;
 import java.util.List;
 import java.util.stream.Stream;
@@ -26,6 +27,9 @@ public class FetchSourceFilterDefinitions {
           Norm.Fields.ARTICLE_TEXTS,
           Norm.Fields.ARTICLES,
           Norm.Fields.TABLE_OF_CONTENTS);
+
+  public static final List<String> LITERATURE_FETCH_EXCLUDED_FIELDS =
+      List.of(Literature.Fields.OUTLINE, Literature.Fields.SHORT_REPORT);
 
   public static List<String> getDocumentExcludedFields() {
     return Stream.concat(

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/helper/LiteratureQueryBuilder.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/helper/LiteratureQueryBuilder.java
@@ -1,0 +1,62 @@
+package de.bund.digitalservice.ris.search.service.helper;
+
+import static org.opensearch.index.query.QueryBuilders.matchQuery;
+
+import de.bund.digitalservice.ris.search.models.api.parameters.LiteratureSearchParams;
+import de.bund.digitalservice.ris.search.models.opensearch.Literature;
+import java.util.Arrays;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.Operator;
+import org.opensearch.index.query.QueryBuilders;
+
+/** Helper class to build OpenSearch queries for Literature entities. */
+public class LiteratureQueryBuilder {
+
+  private LiteratureQueryBuilder() {}
+
+  /**
+   * Adds filters to the given query based on the provided search parameters.
+   *
+   * @param params the search parameters (may be null)
+   * @param query the main BoolQueryBuilder to which filters will be added
+   */
+  public static void addLiteratureFilters(LiteratureSearchParams params, BoolQueryBuilder query) {
+    if (params == null) {
+      return;
+    }
+
+    if (params.getDocumentNumber() != null) {
+      query.must(
+          matchQuery(Literature.Fields.DOCUMENT_NUMBER, params.getDocumentNumber())
+              .operator(Operator.AND));
+    }
+
+    // Array fields
+    addArrayFilter(query, Literature.Fields.YEARS_OF_PUBLICATION, params.getYearOfPublication());
+    addArrayFilter(query, Literature.Fields.DOCUMENT_TYPES, params.getDocumentType());
+    addArrayFilter(query, Literature.Fields.AUTHORS, params.getAuthor());
+    addArrayFilter(query, Literature.Fields.COLLABORATORS, params.getCollaborator());
+  }
+
+  /**
+   * Adds a filter to the main query for an array of values.
+   *
+   * <p>Each element in the array is added as a {@code matchQuery} on the field, wrapped in a {@code
+   * boolQuery} with {@code should} clauses. The main query will require at least one of the values
+   * to match.
+   *
+   * @param query the main BoolQueryBuilder to which the filter will be added
+   * @param field the name of the field in the OpenSearch index
+   * @param values an array of values to filter by; if null or empty, no filter is added
+   */
+  private static void addArrayFilter(BoolQueryBuilder query, String field, String[] values) {
+    if (values == null || values.length == 0) return;
+
+    var boolQuery = QueryBuilders.boolQuery().minimumShouldMatch(1);
+    Arrays.stream(values)
+        .map(value -> QueryBuilders.matchQuery(field, value).operator(Operator.AND))
+        .forEach(boolQuery::should);
+
+    query.must(boolQuery);
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/RisHighlightBuilder.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/RisHighlightBuilder.java
@@ -4,6 +4,7 @@ import static org.opensearch.search.fetch.subphase.highlight.HighlightBuilder.Bo
 import static org.opensearch.search.fetch.subphase.highlight.HighlightBuilder.Field;
 
 import de.bund.digitalservice.ris.search.models.opensearch.CaseLawDocumentationUnit;
+import de.bund.digitalservice.ris.search.models.opensearch.Literature;
 import de.bund.digitalservice.ris.search.models.opensearch.Norm;
 import java.util.List;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
@@ -70,11 +71,19 @@ public final class RisHighlightBuilder {
     return builder;
   }
 
+  private static HighlightBuilder addLiteratureFields(HighlightBuilder builder) {
+    return builder.field(Literature.Fields.MAIN_TITLE);
+  }
+
   public static HighlightBuilder getNormsHighlighter() {
     return addNormsFields(baseHighlighter());
   }
 
   public static HighlightBuilder getCaseLawHighlighter() {
     return addCaseLawFields(baseHighlighter());
+  }
+
+  public static HighlightBuilder getLiteratureHighlighter() {
+    return addLiteratureFields(baseHighlighter());
   }
 }

--- a/backend/src/main/resources/openSearch/literature_mappings.json
+++ b/backend/src/main/resources/openSearch/literature_mappings.json
@@ -4,6 +4,13 @@
       "type": "text",
       "analyzer": "custom_german_analyzer"
     },
+    "DATUM": {
+      "type": "alias",
+      "path": "recording_date"
+    },
+    "recording_date": {
+      "type": "date"
+    },
     "years_of_publication": {
       "type": "text",
       "analyzer": "custom_german_analyzer"

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/config/ContainersIntegrationBase.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/config/ContainersIntegrationBase.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.search.integration.config;
 
 import de.bund.digitalservice.ris.search.models.opensearch.CaseLawDocumentationUnit;
+import de.bund.digitalservice.ris.search.models.opensearch.Literature;
 import de.bund.digitalservice.ris.search.models.opensearch.Norm;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -46,6 +47,8 @@ public class ContainersIntegrationBase {
     openSearchRestTemplate.indexOps(CaseLawDocumentationUnit.class).refresh();
     openSearchRestTemplate.indexOps(Norm.class).create();
     openSearchRestTemplate.indexOps(Norm.class).refresh();
+    openSearchRestTemplate.indexOps(Literature.class).create();
+    openSearchRestTemplate.indexOps(Literature.class).refresh();
 
     // recreate documents alias
     openSearchRestTemplate
@@ -54,7 +57,7 @@ public class ContainersIntegrationBase {
             new AliasActions(
                 new AliasAction.Add(
                     AliasActionParameters.builder()
-                        .withIndices("caselaws", "norms")
+                        .withIndices("caselaws", "norms", "literature")
                         .withAliases("documents")
                         .build())));
   }
@@ -76,5 +79,16 @@ public class ContainersIntegrationBase {
 
     Document mappingDocumentNorms = Document.parse(mappingJsonNorms);
     openSearchRestTemplate.indexOps(IndexCoordinates.of("norms")).putMapping(mappingDocumentNorms);
+
+    // literature mapping
+    ClassPathResource resourceLiterature =
+        new ClassPathResource("/openSearch/literature_mappings.json");
+    InputStreamReader readerLiterature = new InputStreamReader(resourceLiterature.getInputStream());
+    String mappingJsonLiterature = FileCopyUtils.copyToString(readerLiterature);
+
+    Document mappingDocumentLiterature = Document.parse(mappingJsonLiterature);
+    openSearchRestTemplate
+        .indexOps(IndexCoordinates.of("literature"))
+        .putMapping(mappingDocumentLiterature);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/LiteratureControllerApiTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/LiteratureControllerApiTest.java
@@ -1,0 +1,347 @@
+package de.bund.digitalservice.ris.search.integration.controller.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.startsWithIgnoringCase;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.c4_soft.springaddons.security.oauth2.test.annotations.WithJwt;
+import de.bund.digitalservice.ris.search.config.ApiConfig;
+import de.bund.digitalservice.ris.search.integration.config.ContainersIntegrationBase;
+import de.bund.digitalservice.ris.search.integration.controller.api.testData.LiteratureTestData;
+import de.bund.digitalservice.ris.search.repository.opensearch.LiteratureRepository;
+import java.io.IOException;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Tag("integration")
+@WithJwt("jwtTokens/ValidAccessToken.json")
+class LiteratureControllerApiTest extends ContainersIntegrationBase {
+
+  @Autowired private LiteratureRepository literatureRepository;
+  @Autowired private MockMvc mockMvc;
+
+  private final String documentNumberPersistedInTest = "KALU000000002";
+  private final String documentNumberPresentInBucket = "literatureLdml-1";
+
+  @BeforeEach
+  void setUpSearchControllerApiTest() throws IOException {
+    assertTrue(openSearchContainer.isRunning());
+
+    super.recreateIndex();
+    super.updateMapping();
+
+    literatureRepository.saveAll(LiteratureTestData.allDocuments);
+  }
+
+  @Test
+  @DisplayName("Should return literature when using api endpoint with document number")
+  void shouldReturnSingleLiteratureJson() throws Exception {
+
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE + "/" + documentNumberPersistedInTest)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpectAll(
+            status().isOk(),
+            jsonPath("$.documentNumber", Matchers.is(documentNumberPersistedInTest)),
+            jsonPath("$.yearsOfPublication", Matchers.containsInAnyOrder("1999", "2000", "2001")),
+            jsonPath("$.documentTypes", Matchers.containsInAnyOrder("Kommentar", "Aufsatz")),
+            jsonPath("$.dependentReferences", Matchers.contains("NJW, 2000, 456-789")),
+            jsonPath(
+                "$.independentReferences",
+                Matchers.contains("Festschrift für Müller, 2001, 12-34")),
+            jsonPath("$.headline", Matchers.is("Zivilprozessrecht im Wandel")),
+            jsonPath("$.alternativeTitle", Matchers.is("Dokumentation ZPO")),
+            jsonPath("$.authors", Matchers.containsInAnyOrder("Schmidt, Hans", "Becker, Anna")),
+            jsonPath("$.collaborators", Matchers.contains("Meier, Karl")),
+            jsonPath(
+                "$.shortReport",
+                Matchers.is("Ein Überblick über die Entwicklung der Rechtsprechung")),
+            jsonPath(
+                "$.outline", Matchers.is("Teil A: Einführung; Teil B: Praxisfälle; Teil C: Fazit")),
+            jsonPath(
+                "$.encoding[*]['@id']",
+                containsInAnyOrder(
+                    "/v1/literature/" + documentNumberPersistedInTest + "/html",
+                    "/v1/literature/" + documentNumberPersistedInTest + "/xml",
+                    "/v1/literature/" + documentNumberPersistedInTest + "/zip")),
+            jsonPath(
+                "$.encoding[*].contentUrl",
+                containsInAnyOrder(
+                    "/v1/literature/" + documentNumberPersistedInTest + ".html",
+                    "/v1/literature/" + documentNumberPersistedInTest + ".xml",
+                    "/v1/literature/" + documentNumberPersistedInTest + ".zip")));
+  }
+
+  @Test
+  @DisplayName("Should return not found when using document number is not found")
+  void shouldReturnNotFound() throws Exception {
+
+    mockMvc
+        .perform(get(ApiConfig.Paths.LITERATURE + "/TEST").contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("XML Endpoint Should return error xml when literature not in bucket")
+  void shouldReturnNotFoundIfXMLNotPresent() throws Exception {
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE + "/NOT_PRESENT_IN_BUCKET.xml")
+                .contentType(MediaType.APPLICATION_XML))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("Should return XML version of a literature item")
+  void literatureXMLEndpoint() throws Exception {
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE + "/" + this.documentNumberPresentInBucket + ".xml")
+                .contentType(MediaType.APPLICATION_XML))
+        .andExpectAll(
+            status().isOk(),
+            content()
+                .string(
+                    startsWithIgnoringCase(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>")),
+            content().contentType("application/xml"));
+  }
+
+  @Test
+  @DisplayName("Html Endpoint Should return error html when literature not in bucket")
+  void shouldReturnNotFoundIfHTMLNotPresent() throws Exception {
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE + "/NOT_PRESENT_IN_BUCKET.html")
+                .contentType(MediaType.TEXT_HTML))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("Should return HTML version of literature item")
+  void shouldReturnSingleLiteratureHtml() throws Exception {
+
+    String responseContent =
+        mockMvc
+            .perform(
+                get(ApiConfig.Paths.LITERATURE + "/" + this.documentNumberPresentInBucket + ".html")
+                    .contentType(MediaType.TEXT_HTML))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    assertThat(responseContent, containsString("Literatur Test Dokument"));
+    assertThat(responseContent, containsString("1. Dies ist ein literature"));
+    assertThat(responseContent, containsString("Außerdem gib es noch"));
+  }
+
+  @Test
+  @DisplayName("Should return correct item when searching with searchTerm")
+  void shouldReturnLiteratureItemWhenUsingSearchTerm() throws Exception {
+    final String searchTerm = "Handelsrecht";
+
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE + String.format("?searchTerm=%s", searchTerm))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.member", hasSize(1)))
+        .andExpect(jsonPath("$.member[0]['item'].documentNumber", Matchers.is("KALU000000001")))
+        .andExpect(jsonPath("$.member[0]['item'].recordingDate", Matchers.is("2013-01-01")))
+        .andExpect(
+            jsonPath(
+                "$.member[0]['item'].yearsOfPublication",
+                Matchers.containsInAnyOrder("2014", "2024")))
+        .andExpect(jsonPath("$.member[0]['item'].documentTypes", Matchers.contains("Auf")))
+        .andExpect(
+            jsonPath(
+                "$.member[0]['item'].dependentReferences", Matchers.contains("BUV, 1982, 123-123")))
+        .andExpect(
+            jsonPath(
+                "$.member[0]['item'].independentReferences",
+                Matchers.contains("50 Jahre Betriebs-Berater, 1987, 123-456")))
+        .andExpect(
+            jsonPath("$.member[0]['item'].headline", Matchers.is("Einführung in das Handelsrecht")))
+        .andExpect(
+            jsonPath(
+                "$.member[0]['item'].alternativeTitle", Matchers.is("Dokumentation Handelsrecht")))
+        .andExpect(jsonPath("$.member[0]['item'].authors", Matchers.contains("Musterfrau, Sabine")))
+        .andExpect(
+            jsonPath("$.member[0]['item'].collaborators", Matchers.contains("Mustermann, Max")))
+        .andExpect(
+            jsonPath(
+                "$.member[0]['item'].shortReport",
+                Matchers.nullValue())) // excluded from search results
+        .andExpect(
+            jsonPath(
+                "$.member[0]['item'].outline",
+                Matchers.nullValue())) // excluded from search results
+        .andExpect(jsonPath("$.member[0]['textMatches'][*]['name']", Matchers.hasItem("mainTitle")))
+        .andExpect(
+            jsonPath(
+                "$.member[0]['textMatches'][*]['text']",
+                Matchers.hasItem("Einführung in das <mark>%s</mark>".formatted(searchTerm))));
+  }
+
+  @Test
+  @DisplayName("Search by document number")
+  void shouldReturnItemWhenSearchingByDocumentNumber() throws Exception {
+    final String documentNumber = "KALU000000002";
+
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE + "?documentNumber=" + documentNumber)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.member", hasSize(1)))
+        .andExpect(jsonPath("$.member[0].item.documentNumber", Matchers.is(documentNumber)));
+  }
+
+  @Test
+  @DisplayName("Search by year of publication")
+  void shouldReturnItemWhenSearchingByYearOfPublication() throws Exception {
+    final String year = "2020";
+
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE + "?yearOfPublication=" + year)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.member", hasSize(1)))
+        .andExpect(jsonPath("$.member[0].item.documentNumber", Matchers.is("KALU000000003")));
+  }
+
+  @Test
+  @DisplayName("Search by document type")
+  void shouldReturnItemWhenSearchingByDocumentType() throws Exception {
+    final String documentType = "Buch";
+
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE + "?documentType=" + documentType)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.member", hasSize(1)))
+        .andExpect(jsonPath("$.member[0].item.documentNumber", Matchers.is("KALU000000003")));
+  }
+
+  @Test
+  @DisplayName("Search by author")
+  void shouldReturnItemWhenSearchingByAuthor() throws Exception {
+    final String author = "Hoffmann, Clara";
+
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE + "?author=" + author)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.member", hasSize(1)))
+        .andExpect(jsonPath("$.member[0].item.documentNumber", Matchers.is("KALU000000003")));
+  }
+
+  @DisplayName("Search by collaborator")
+  void shouldReturnItemWhenSearchingByCollaborator() throws Exception {
+    final String collaborator = "Mustermann, Max";
+
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE + "?collaborator=" + collaborator)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.member", hasSize(1)))
+        .andExpect(jsonPath("$.member[0].item.documentNumber", Matchers.is("KALU000000001")));
+  }
+
+  @Test
+  @DisplayName("Search by multiple document types")
+  void shouldReturnItemsWhenSearchingByMultipleDocumentTypes() throws Exception {
+    final String types = "Auf,Buch";
+
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE + "?documentType=" + types)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.member", hasSize(2)))
+        .andExpect(
+            jsonPath(
+                "$.member[*].item.documentNumber",
+                Matchers.containsInAnyOrder("KALU000000001", "KALU000000003")));
+  }
+
+  @Test
+  @DisplayName("Search by multiple authors")
+  void shouldReturnItemsWhenSearchingByMultipleAuthors() throws Exception {
+    final String authors = "Hoffmann, Clara,Schmidt, Hans";
+
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE + "?author=" + authors)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.member", hasSize(2)))
+        .andExpect(
+            jsonPath(
+                "$.member[*].item.documentNumber",
+                Matchers.containsInAnyOrder("KALU000000002", "KALU000000003")));
+  }
+
+  @Test
+  @DisplayName("Search by document type and year of publication")
+  void shouldReturnItemWhenSearchingByTypeAndYear() throws Exception {
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE + "?documentType=Buch&yearOfPublication=2020")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.member", hasSize(1)))
+        .andExpect(jsonPath("$.member[0].item.documentNumber", Matchers.is("KALU000000003")));
+  }
+
+  @Test
+  @DisplayName("Search by author and collaborator")
+  void shouldReturnItemWhenSearchingByAuthorAndCollaborator() throws Exception {
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE
+                    + "?author=Musterfrau, Sabine&collaborator=Mustermann, Max")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.member", hasSize(1)))
+        .andExpect(jsonPath("$.member[0].item.documentNumber", Matchers.is("KALU000000001")));
+  }
+
+  @Test
+  @DisplayName("Search by multiple parameters with multiple values")
+  void shouldReturnItemsWhenSearchingByMultipleParamsAndValues() throws Exception {
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LITERATURE
+                    + "?documentType=Kommentar,Auf&author=Schmidt, Hans,Hoffmann, Clara")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.member", hasSize(1)))
+        .andExpect(
+            jsonPath(
+                "$.member[*].item.documentNumber", Matchers.containsInAnyOrder("KALU000000002")));
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/testData/LiteratureTestData.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/testData/LiteratureTestData.java
@@ -1,0 +1,64 @@
+package de.bund.digitalservice.ris.search.integration.controller.api.testData;
+
+import de.bund.digitalservice.ris.search.models.opensearch.Literature;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LiteratureTestData {
+
+  public static final List<Literature> allDocuments = new ArrayList<>();
+
+  static {
+    allDocuments.add(
+        Literature.builder()
+            .id("lit-1")
+            .documentNumber("KALU000000001")
+            .recordingDate(LocalDate.parse("2013-01-01"))
+            .yearsOfPublication(List.of("2014", "2024"))
+            .documentTypes(List.of("Auf"))
+            .dependentReferences(List.of("BUV, 1982, 123-123"))
+            .independentReferences(List.of("50 Jahre Betriebs-Berater, 1987, 123-456"))
+            .mainTitle("Einführung in das Handelsrecht")
+            .documentaryTitle("Dokumentation Handelsrecht")
+            .authors(List.of("Musterfrau, Sabine"))
+            .collaborators(List.of("Mustermann, Max"))
+            .shortReport("Kurzer Bericht über die Entwicklung des Handelsrechts")
+            .outline("Kapitel 1: Grundlagen; Kapitel 2: Beispiele")
+            .build());
+
+    allDocuments.add(
+        Literature.builder()
+            .id("lit-2")
+            .documentNumber("KALU000000002")
+            .recordingDate(LocalDate.parse("1998-01-01"))
+            .yearsOfPublication(List.of("1999", "2000", "2001"))
+            .documentTypes(List.of("Kommentar", "Aufsatz"))
+            .dependentReferences(List.of("NJW, 2000, 456-789"))
+            .independentReferences(List.of("Festschrift für Müller, 2001, 12-34"))
+            .mainTitle("Zivilprozessrecht im Wandel")
+            .documentaryTitle("Dokumentation ZPO")
+            .authors(List.of("Schmidt, Hans", "Becker, Anna"))
+            .collaborators(List.of("Meier, Karl"))
+            .shortReport("Ein Überblick über die Entwicklung der Rechtsprechung")
+            .outline("Teil A: Einführung; Teil B: Praxisfälle; Teil C: Fazit")
+            .build());
+
+    allDocuments.add(
+        Literature.builder()
+            .id("lit-3")
+            .documentNumber("KALU000000003")
+            .recordingDate(LocalDate.parse("2020-01-01"))
+            .yearsOfPublication(List.of("2020"))
+            .documentTypes(List.of("Buch"))
+            .dependentReferences(List.of())
+            .independentReferences(List.of("Juristische Ausbildung, 2020, 567-890"))
+            .mainTitle("Öffentliches Recht kompakt")
+            .documentaryTitle(null)
+            .authors(List.of("Hoffmann, Clara"))
+            .collaborators(List.of())
+            .shortReport("Lehrbuch für Studierende der Rechtswissenschaften")
+            .outline("Teil 1: Staatsorganisationsrecht; Teil 2: Grundrechte")
+            .build());
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/LiteratureSearchSchemaMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/LiteratureSearchSchemaMapperTest.java
@@ -1,0 +1,128 @@
+package de.bund.digitalservice.ris.search.unit.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import de.bund.digitalservice.ris.search.config.ApiConfig;
+import de.bund.digitalservice.ris.search.mapper.LiteratureSearchSchemaMapper;
+import de.bund.digitalservice.ris.search.models.opensearch.AbstractSearchEntity;
+import de.bund.digitalservice.ris.search.models.opensearch.Literature;
+import de.bund.digitalservice.ris.search.schema.CollectionSchema;
+import de.bund.digitalservice.ris.search.schema.LiteratureSearchSchema;
+import de.bund.digitalservice.ris.search.schema.SearchMemberSchema;
+import java.util.List;
+import java.util.function.IntFunction;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHitSupport;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.SearchHitsImpl;
+import org.springframework.data.elasticsearch.core.SearchPage;
+import org.springframework.data.elasticsearch.core.TotalHitsRelation;
+
+class LiteratureSearchSchemaMapperTest {
+
+  @Test
+  @DisplayName("correctly maps a single Page")
+  void fromDomainPage() {
+    var literature =
+        Literature.builder().id("TEST000000001").documentNumber("TEST000000001").build();
+
+    SearchHit<Literature> searchHit =
+        new SearchHit<>("1", "1", "routing", 1, null, null, null, null, null, null, literature);
+    SearchHits<Literature> searchHits =
+        new SearchHitsImpl<>(
+            1, TotalHitsRelation.EQUAL_TO, 1, null, null, List.of(searchHit), null, null, null);
+    SearchPage<Literature> source =
+        SearchHitSupport.searchPageFor(searchHits, PageRequest.of(0, 1));
+
+    CollectionSchema<SearchMemberSchema<LiteratureSearchSchema>> destination =
+        LiteratureSearchSchemaMapper.fromSearchPage(source);
+    LiteratureSearchSchema expectedItem = destination.member().get(0).item();
+    assertEquals(literature.documentNumber(), expectedItem.documentNumber());
+    assertEquals(1, destination.totalItems());
+    assertEquals(destination.member().size(), destination.totalItems());
+    assertTrue(destination.id().startsWith(ApiConfig.Paths.LITERATURE));
+  }
+
+  @Test
+  @DisplayName("has correct links to other pages if the result set has more than one page")
+  void fromDomainPageMultiple() {
+    int pageSize = 5;
+    int lastPageSize = 3;
+
+    IntFunction<SearchHit<AbstractSearchEntity>> buildItem =
+        index ->
+            new SearchHit<>(
+                String.valueOf(index),
+                String.valueOf(index),
+                "routing",
+                1,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                (AbstractSearchEntity) Literature.builder().documentNumber("doc-" + index).build());
+
+    var firstPageContents = IntStream.range(0, pageSize).mapToObj(buildItem).toList();
+    var middlePageContents = IntStream.range(pageSize, pageSize * 2).mapToObj(buildItem).toList();
+    var lastPageContents =
+        IntStream.range(pageSize * 2, pageSize * 2 + lastPageSize).mapToObj(buildItem).toList();
+
+    int total = firstPageContents.size() + middlePageContents.size() + lastPageContents.size();
+
+    var firstPageImpl = createSearchPage(firstPageContents, 0, pageSize, total);
+    CollectionSchema<SearchMemberSchema<LiteratureSearchSchema>> firstPage =
+        LiteratureSearchSchemaMapper.fromSearchPage(firstPageImpl);
+
+    var middlePageImpl = createSearchPage(middlePageContents, 1, pageSize, total);
+    CollectionSchema<SearchMemberSchema<LiteratureSearchSchema>> middlePage =
+        LiteratureSearchSchemaMapper.fromSearchPage(middlePageImpl);
+
+    var lastPageImpl = createSearchPage(lastPageContents, 2, pageSize, total);
+    CollectionSchema<SearchMemberSchema<LiteratureSearchSchema>> lastPage =
+        LiteratureSearchSchemaMapper.fromSearchPage(lastPageImpl);
+
+    String prefix = ApiConfig.Paths.LITERATURE + "/doc-";
+
+    assertEquals(prefix + "0", getItemId(firstPage, 0));
+    assertEquals(prefix + "4", getItemId(firstPage, firstPage.member().size() - 1));
+
+    assertEquals(prefix + "5", getItemId(middlePage, 0));
+    assertEquals(prefix + "9", getItemId(middlePage, middlePage.member().size() - 1));
+
+    assertEquals(prefix + "10", getItemId(lastPage, 0));
+    assertEquals(prefix + "12", getItemId(lastPage, lastPage.member().size() - 1));
+
+    assertEquals(firstPageContents.size(), firstPage.member().size());
+    assertEquals(middlePageContents.size(), middlePage.member().size());
+    assertEquals(lastPageContents.size(), lastPage.member().size());
+
+    assertEquals(total, firstPage.totalItems());
+    assertEquals(total, middlePage.totalItems());
+    assertEquals(total, lastPage.totalItems());
+
+    // all IDs should point to case law resources
+    assertTrue(firstPage.id().startsWith(ApiConfig.Paths.LITERATURE));
+    assertTrue(middlePage.id().startsWith(ApiConfig.Paths.LITERATURE));
+    assertTrue(lastPage.id().startsWith(ApiConfig.Paths.LITERATURE));
+  }
+
+  private SearchPage<AbstractSearchEntity> createSearchPage(
+      List<SearchHit<AbstractSearchEntity>> searchHits, int pageNumber, int pageSize, int total) {
+    return SearchHitSupport.searchPageFor(
+        new SearchHitsImpl<>(
+            total, TotalHitsRelation.EQUAL_TO, 1, null, null, searchHits, null, null, null),
+        PageRequest.of(pageNumber, pageSize));
+  }
+
+  private String getItemId(
+      CollectionSchema<SearchMemberSchema<LiteratureSearchSchema>> page, int index) {
+    return (page.member().get(index).item()).id();
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/LiteratureServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/LiteratureServiceTest.java
@@ -1,0 +1,98 @@
+package de.bund.digitalservice.ris.search.unit.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
+import de.bund.digitalservice.ris.search.models.opensearch.Literature;
+import de.bund.digitalservice.ris.search.repository.objectstorage.literature.LiteratureBucket;
+import de.bund.digitalservice.ris.search.repository.opensearch.LiteratureRepository;
+import de.bund.digitalservice.ris.search.service.LiteratureService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHitSupport;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.SearchHitsImpl;
+import org.springframework.data.elasticsearch.core.SearchPage;
+import org.springframework.data.elasticsearch.core.TotalHitsRelation;
+import org.springframework.data.elasticsearch.core.query.Query;
+
+@ExtendWith(MockitoExtension.class)
+class LiteratureServiceTest {
+
+  private LiteratureService literatureService;
+  private ElasticsearchOperations operationsMock;
+  private LiteratureBucket literatureBucketMock;
+  private LiteratureRepository literatureRepositoryMock;
+
+  @BeforeEach
+  void setUp() {
+    literatureRepositoryMock = Mockito.mock(LiteratureRepository.class);
+    literatureBucketMock = Mockito.mock(LiteratureBucket.class);
+    operationsMock = Mockito.mock(ElasticsearchOperations.class);
+    this.literatureService =
+        new LiteratureService(literatureRepositoryMock, literatureBucketMock, operationsMock, null);
+  }
+
+  @Test
+  @DisplayName("Should return the search result from repository")
+  void shouldReturnSearchResult() {
+    var searchResult = Literature.builder().build();
+    var searchHit =
+        new SearchHit<>("1", "1", "routing", 1, null, null, null, null, null, null, searchResult);
+    Pageable pageable = PageRequest.of(0, 10);
+    SearchHits<Literature> searchHits =
+        new SearchHitsImpl<>(
+            1, TotalHitsRelation.EQUAL_TO, 1.0f, "", "", List.of(searchHit), null, null, null);
+    SearchPage<Literature> searchResultPage = SearchHitSupport.searchPageFor(searchHits, pageable);
+
+    when(operationsMock.search((Query) any(), eq(Literature.class))).thenReturn(searchHits);
+
+    var actual = literatureService.searchLiterature("anySearch", pageable);
+    Assertions.assertEquals(searchResultPage, actual);
+  }
+
+  @Test
+  @DisplayName("Should return an existing literature item by its document number")
+  void shouldReturnLiteratureByDocumentNumber() {
+    var expectedResult = List.of(Literature.builder().build());
+    when(literatureRepositoryMock.findByDocumentNumber("TEST000000001.akn"))
+        .thenReturn(expectedResult);
+
+    var actual = literatureService.getByDocumentNumber("TEST000000001.akn");
+    Assertions.assertEquals(expectedResult, actual);
+  }
+
+  @Test
+  @DisplayName("Should return existing file as bytes from folder if not in prototype environment")
+  void shouldReturnFileAsBytesFromFolderWhenNotInPrototypeEnvironment()
+      throws ObjectStoreServiceException {
+    Optional<byte[]> expectedResult = Optional.of("file-content".getBytes());
+    when(literatureBucketMock.get("TEST000000001.akn.xml")).thenReturn(expectedResult);
+
+    var actual = literatureService.getFileByDocumentNumber("TEST000000001.akn");
+    Assertions.assertEquals(expectedResult, actual);
+  }
+
+  @Test
+  @DisplayName("Should throw if file does not")
+  void shouldThrowIfFileNotFoundInFolder() throws ObjectStoreServiceException {
+    when(literatureBucketMock.get(any())).thenThrow(ObjectStoreServiceException.class);
+
+    Assertions.assertThrows(
+        ObjectStoreServiceException.class,
+        () -> literatureService.getFileByDocumentNumber("TEST000000001.akn"));
+  }
+}

--- a/frontend/src/public/openapi.json
+++ b/frontend/src/public/openapi.json
@@ -92,12 +92,220 @@
         }
       }
     },
+    "/v1/literature": {
+      "get": {
+        "tags": ["Literature"],
+        "summary": "List and search literature",
+        "description": "The endpoint returns a list of literature from our database. The list is paginated and can be filtered and sorted.",
+        "operationId": "searchAndFilter",
+        "parameters": [
+          {
+            "name": "documentNumber",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "yearOfPublication",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "array", "items": { "type": "string" } }
+          },
+          {
+            "name": "documentType",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "array", "items": { "type": "string" } }
+          },
+          {
+            "name": "author",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "array", "items": { "type": "string" } }
+          },
+          {
+            "name": "collaborator",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "array", "items": { "type": "string" } }
+          },
+          {
+            "name": "searchTerm",
+            "in": "query",
+            "description": "Searches for the given tokens in searchTerm. If searchTerm contains more than one token, all tokens must be in the document for the document to match.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Searches for the given tokens in searchTerm. If searchTerm contains more than one token, all tokens must be in the document for the document to match."
+            }
+          },
+          {
+            "name": "dateFrom",
+            "in": "query",
+            "description": "The from (greater than or equal) parameter returns all entities where date is later than, or equal to, the given date.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "The from (greater than or equal) parameter returns all entities where date is later than, or equal to, the given date."
+            }
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "description": "The to (less than or equal) parameter returns all entities where date is earlier than, or equal to, the given date.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "The to (less than or equal) parameter returns all entities where date is earlier than, or equal to, the given date."
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "The number of entities per page",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "maximum": 100,
+              "minimum": 1
+            },
+            "example": 100
+          },
+          {
+            "name": "pageIndex",
+            "in": "query",
+            "description": "The number of the page to request. The page starts with the value 0",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32", "minimum": 0 },
+            "example": 0
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date and documentNumber and not setting the sort field (sort by relevance descending).Add a leading - to set the order to descending (-date)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "The field to sort the results by. Default is the relevance score calculated by OpenSearch. Valid usage of the sort field are : date and documentNumber and not setting the sort field (sort by relevance descending).Add a leading - to set the order to descending (-date)",
+              "pattern": "^-?(|default|date|DATUM|documentNumber)$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionSchemaSearchMemberSchemaLiteratureSearchSchema"
+                }
+              }
+            }
+          },
+          "500": { "description": "Internal Server Error" }
+        }
+      }
+    },
+    "/v1/literature/{documentNumber}": {
+      "get": {
+        "tags": ["Literature"],
+        "summary": "Literature metadata",
+        "description": "The endpoint returns the metadata of a single literature from our database.",
+        "operationId": "getLiteratureMetadata",
+        "parameters": [
+          {
+            "name": "documentNumber",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "example": "STRE201770751"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/LiteratureSchema" }
+              }
+            }
+          },
+          "404": { "description": "Not Found" }
+        }
+      }
+    },
+    "/v1/literature/{documentNumber}.xml": {
+      "get": {
+        "tags": ["Literature"],
+        "summary": "Decision XML",
+        "description": "Returns a literature item as XML. This content is used as a source for the HTML endpoint.",
+        "operationId": "getLiteratureAsXml",
+        "parameters": [
+          {
+            "name": "documentNumber",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "example": "BJLU075748788"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/xml": {
+                "schema": { "type": "string", "format": "byte" }
+              }
+            }
+          },
+          "404": { "description": "Not Found" }
+        }
+      }
+    },
+    "/v1/literature/{documentNumber}.html": {
+      "get": {
+        "tags": ["Literature"],
+        "summary": "Literature HTML",
+        "description": "Renders and returns a literature item as HTML.",
+        "operationId": "getLiteratureAsHtml",
+        "parameters": [
+          {
+            "name": "documentNumber",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "example": "BJLU075748788"
+          },
+          {
+            "name": "get-resources-via",
+            "in": "header",
+            "description": "Used to select a different prefix for referenced resources, like images. Selecting 'PROXY' will prepend `/api`. Otherwise, the API base URL will be used.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "API",
+              "enum": ["API", "PROXY"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": { "text/html": { "schema": { "type": "string" } } }
+          },
+          "404": { "description": "Not Found" }
+        }
+      }
+    },
     "/v1/legislation": {
       "get": {
         "tags": ["Legislation"],
         "summary": "List and search legislation",
-        "description": "List all legislation in our database with support for filtering and pagination.\n\n## Example 1\n\nGet all legislation containing the tokens :` Gesetz`, `über`,`das`, `Verfahren`, `bei`, `sonstigen` and `Änderungen`.\n```http request\nGET /v1/legislation?searchTerm=Gesetz%20über%20das%20Verfahren%20bei%20sonstigen%20Änderungen\n```\nThe API will return only the legislation that contains all these terms. Please note that in practice very common tokens such as `das` are ignored\n(please see <a href=\"https://en.wikipedia.org/wiki/Stop_word\">https://en.wikipedia.org/wiki/Stop_word</a> for more details).\n\n## Example 2\n\nGet all legislation containing the tokens :` Gesetz` and `über` and were valid on 2020-01-01\n```http request\nGET /v1/legislation?temporalCoverageFrom=2020-01-01&temporalCoverageTo=2020-01-01&searchTerm=Gesetz%20über\n```\nThis example can be used to only return currently valid legislation by replacing 2020-01-01 with today's date.\n\n## Example 3\n\nGet all legislation that belong to the work eli `eli/bund/bgbl-1/1979/s1325/regelungstext-1`\n```http request\nGET /v1/legislation?eli=eli/bund/bgbl-1/1979/s1325/regelungstext-1\n```\n",
-        "operationId": "searchAndFilter",
+        "description": "List all legislation in our database with support for filtering and pagination.\n\n## Example 1\n\nGet all legislation containing the tokens :` Gesetz`, `über`,`das`, `Verfahren`, `bei`, `sonstigen` and `Änderungen`.\n```http request\nGET /v1/legislation?searchTerm=Gesetz%20über%20das%20Verfahren%20bei%20sonstigen%20Änderungen\n```\nThe API will return only the legislation that contains all these terms. Please note that in practice very common tokens such as `das` are ignored\n(please see <a href=\"https://en.wikipedia.org/wiki/Stop_word\">https://en.wikipedia.org/wiki/Stop_word</a> for more details).\n\n## Example 2\n\nGet all legislation containing the tokens :` Gesetz` and `über` and were valid on 2020-01-01\n```http request\nGET /v1/legislation?temporalCoverageFrom=2020-01-01&temporalCoverageTo=2020-01-01&searchTerm=Gesetz%20über\n```\nThis example can be used to only return currently valid legislation by replacing 2020-01-01 with today's date.\n\n## Example 3\n\nGet all legislation that belong to the work eli `eli/bund/bgbl-1/1979/s1325`\n```http request\nGET /v1/legislation?eli=eli/bund/bgbl-1/1979/s1325\n```\n",
+        "operationId": "searchAndFilter_1",
         "parameters": [
           {
             "name": "eli",
@@ -220,7 +428,7 @@
         }
       }
     },
-    "/v1/legislation/eli/{jurisdiction}/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}": {
+    "/v1/legislation/eli/{jurisdiction}/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}": {
       "get": {
         "tags": ["Legislation"],
         "summary": "Work and expression-level metadata",
@@ -232,15 +440,14 @@
             "in": "path",
             "description": "Country or regional code for the jurisdiction",
             "required": true,
-            "schema": { "type": "string", "enum": ["bund"] },
-            "example": "bund"
+            "schema": { "type": "string", "enum": ["bund"] }
           },
           {
             "name": "agent",
             "in": "path",
             "description": "Agent or authority issuing the legislation, e.g., 'bgbl-1' for Bundesgesetzblatt Teil I (Federal Law Gazette part I)",
             "required": true,
-            "schema": { "type": "string", "example": "bgbl-1" },
+            "schema": { "type": "string" },
             "example": "bgbl-1"
           },
           {
@@ -270,22 +477,15 @@
             "name": "version",
             "in": "path",
             "required": true,
-            "schema": { "type": "integer", "format": "int32", "example": 2 },
+            "schema": { "type": "integer", "format": "int32" },
             "example": 2
           },
           {
             "name": "language",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "example": "deu" },
+            "schema": { "type": "string" },
             "example": "deu"
-          },
-          {
-            "name": "subtype",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string", "example": "regelungstext-1" },
-            "example": "regelungstext-1"
           }
         ],
         "responses": {
@@ -456,32 +656,28 @@
             "name": "version",
             "in": "path",
             "required": true,
-            "schema": { "type": "integer", "format": "int32", "example": 2 },
+            "schema": { "type": "integer", "format": "int32" },
             "example": 2
           },
           {
             "name": "language",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "example": "deu" },
+            "schema": { "type": "string" },
             "example": "deu"
           },
           {
             "name": "pointInTimeManifestation",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "format": "date",
-              "example": "2020-06-19"
-            },
+            "schema": { "type": "string", "format": "date" },
             "example": "2020-06-19"
           },
           {
             "name": "subtype",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "example": "regelungstext-1" },
+            "schema": { "type": "string" },
             "example": "regelungstext-1"
           }
         ],
@@ -548,32 +744,28 @@
             "name": "version",
             "in": "path",
             "required": true,
-            "schema": { "type": "integer", "format": "int32", "example": 2 },
+            "schema": { "type": "integer", "format": "int32" },
             "example": 2
           },
           {
             "name": "language",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "example": "deu" },
+            "schema": { "type": "string" },
             "example": "deu"
           },
           {
             "name": "pointInTimeManifestation",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "format": "date",
-              "example": "2020-06-19"
-            },
+            "schema": { "type": "string", "format": "date" },
             "example": "2020-06-19"
           },
           {
             "name": "subtype",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "example": "regelungstext-1" },
+            "schema": { "type": "string" },
             "example": "regelungstext-1"
           },
           {
@@ -657,32 +849,28 @@
             "name": "version",
             "in": "path",
             "required": true,
-            "schema": { "type": "integer", "format": "int32", "example": 2 },
+            "schema": { "type": "integer", "format": "int32" },
             "example": 2
           },
           {
             "name": "language",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "example": "deu" },
+            "schema": { "type": "string" },
             "example": "deu"
           },
           {
             "name": "pointInTimeManifestation",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "format": "date",
-              "example": "2020-06-19"
-            },
+            "schema": { "type": "string", "format": "date" },
             "example": "2020-06-19"
           },
           {
             "name": "name",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "example": "image" },
+            "schema": { "type": "string" },
             "example": "image"
           },
           {
@@ -691,8 +879,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["pdf", "xml", "jpg", "gif"],
-              "example": "jpg"
+              "enum": ["pdf", "xml", "jpg", "gif"]
             },
             "example": "jpg"
           }
@@ -758,25 +945,21 @@
             "name": "version",
             "in": "path",
             "required": true,
-            "schema": { "type": "integer", "format": "int32", "example": 2 },
+            "schema": { "type": "integer", "format": "int32" },
             "example": 2
           },
           {
             "name": "language",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "example": "deu" },
+            "schema": { "type": "string" },
             "example": "deu"
           },
           {
             "name": "pointInTimeManifestation",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "format": "date",
-              "example": "2020-06-19"
-            },
+            "schema": { "type": "string", "format": "date" },
             "example": "2020-06-19"
           }
         ],
@@ -800,7 +983,7 @@
         "tags": ["All documents"],
         "summary": "Global search / list",
         "description": "This endpoint can be used to search for documents across different document kinds. Currently we support case law and legislation document kinds. The endpoint provides a paginated response with up to 10,000 results with at most 100 results per page.\n\nThe searchTerm parameter searches across multiple fields of a document at the same time. The fields searched depend on the document kind. See the filters guide for more information.\n\nDefault sorting is by relevance from most relevant to least relevant. Multiple factors are combined to boost the most relevant documents to the top of the result list. Additionally, sorting by date is possible by setting the sort query parameter to date.\n",
-        "operationId": "searchAndFilter_1",
+        "operationId": "searchAndFilter_2",
         "parameters": [
           {
             "name": "searchTerm",
@@ -1002,7 +1185,7 @@
         "tags": ["Case Law"],
         "summary": "List and search decisions",
         "description": "The endpoint returns a list of decisions from our database. The list is paginated and can be filtered and sorted.",
-        "operationId": "searchAndFilter_2",
+        "operationId": "searchAndFilter_3",
         "parameters": [
           {
             "name": "fileNumber",
@@ -1195,14 +1378,14 @@
             "name": "documentNumber",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "example": "BDRE000800001" },
+            "schema": { "type": "string" },
             "example": "BDRE000800001"
           },
           {
             "name": "name",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "example": "image" },
+            "schema": { "type": "string" },
             "example": "image"
           },
           {
@@ -1211,8 +1394,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["png", "jpg", "jpeg", "gif", "wmf", "emf", "bitmap"],
-              "example": "jpg"
+              "enum": ["png", "jpg", "jpeg", "gif", "wmf", "emf", "bitmap"]
             },
             "example": "jpg"
           }
@@ -1367,6 +1549,202 @@
           "@type": { "type": "string", "example": "Legislation" }
         }
       },
+      "CollectionSchemaSearchMemberSchemaLiteratureSearchSchema": {
+        "type": "object",
+        "properties": {
+          "@id": {
+            "type": "string",
+            "example": "/v1/document?pageIndex=0&size=5"
+          },
+          "totalItems": { "type": "integer", "format": "int64", "example": 1 },
+          "member": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchMemberSchemaLiteratureSearchSchema"
+            }
+          },
+          "view": {
+            "$ref": "#/components/schemas/PartialCollectionViewSchema"
+          },
+          "@type": { "type": "string", "example": "hydra:Collection" }
+        }
+      },
+      "LiteratureEncodingSchema": {
+        "type": "object",
+        "properties": {
+          "@id": { "type": "string" },
+          "contentUrl": { "type": "string" },
+          "encodingFormat": { "type": "string", "example": "text/html" },
+          "inLanguage": { "type": "string", "example": "de" },
+          "@type": { "type": "string", "example": "MediaObject" }
+        }
+      },
+      "LiteratureSearchSchema": {
+        "allOf": [
+          { "$ref": "#/components/schemas/AbstractDocumentSchema" },
+          {
+            "type": "object",
+            "properties": {
+              "@id": { "type": "string", "example": "KALU000000000" },
+              "inLanguage": { "type": "string", "example": "de" },
+              "documentNumber": {
+                "type": "string",
+                "description": "Dokumentnummer",
+                "example": "KALU000000000"
+              },
+              "recordingDate": {
+                "type": "string",
+                "format": "date",
+                "description": "The date on which the literature piece was recorded.",
+                "example": "2003-12-15"
+              },
+              "yearsOfPublication": {
+                "type": "array",
+                "description": "Veröffentlichungsjahre",
+                "example": "[2014, 2024-09]",
+                "items": { "type": "string" }
+              },
+              "documentTypes": {
+                "type": "array",
+                "description": "Dokumenttypen",
+                "example": "[Auf]",
+                "items": { "type": "string" }
+              },
+              "dependentReferences": {
+                "type": "array",
+                "description": "Unselbstständige Fundstellen",
+                "example": "[BUV, 1982, 123-123]",
+                "items": { "type": "string" }
+              },
+              "independentReferences": {
+                "type": "array",
+                "description": "Selbstständige Fundstellen",
+                "example": "[50 Jahre Betriebs-Berater, 1987, 123-456]",
+                "items": { "type": "string" }
+              },
+              "headline": { "type": "string", "description": "Haupttitel" },
+              "alternativeTitle": {
+                "type": "string",
+                "description": "Dokumentarischer Titel"
+              },
+              "authors": {
+                "type": "array",
+                "description": "Authoren",
+                "example": "[Musterfrau, Sabine]",
+                "items": { "type": "string" }
+              },
+              "collaborators": {
+                "type": "array",
+                "description": "Mitarbeiter",
+                "example": "[Mustermann, Max]",
+                "items": { "type": "string" }
+              },
+              "shortReport": { "type": "string", "description": "Kurzrefarat" },
+              "outline": { "type": "string", "description": "Gliederung" },
+              "encoding": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/LiteratureEncodingSchema"
+                }
+              }
+            }
+          }
+        ],
+        "properties": { "@type": { "type": "string", "example": "Literature" } }
+      },
+      "PartialCollectionViewSchema": {
+        "type": "object",
+        "properties": {
+          "first": { "type": "string" },
+          "previous": { "type": "string" },
+          "next": { "type": "string" },
+          "last": { "type": "string" },
+          "@type": {
+            "type": "string",
+            "example": "hydra:PartialCollectionView"
+          }
+        }
+      },
+      "SearchMemberSchemaLiteratureSearchSchema": {
+        "type": "object",
+        "properties": {
+          "item": { "$ref": "#/components/schemas/LiteratureSearchSchema" },
+          "textMatches": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TextMatchSchema" }
+          },
+          "@type": { "type": "string", "example": "SearchResult" }
+        }
+      },
+      "TextMatchSchema": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "text": { "type": "string" },
+          "location": { "type": "string" },
+          "@type": { "type": "string", "example": "SearchResultMatch" }
+        }
+      },
+      "LiteratureSchema": {
+        "type": "object",
+        "properties": {
+          "@id": { "type": "string", "example": "KALU000000000" },
+          "inLanguage": { "type": "string", "example": "de" },
+          "documentNumber": {
+            "type": "string",
+            "description": "Dokumentnummer",
+            "example": "KALU000000000"
+          },
+          "yearsOfPublication": {
+            "type": "array",
+            "description": "Veröffentlichungsjahre",
+            "example": "[2014, 2024-09]",
+            "items": { "type": "string" }
+          },
+          "documentTypes": {
+            "type": "array",
+            "description": "Dokumenttypen",
+            "example": "[Auf]",
+            "items": { "type": "string" }
+          },
+          "dependentReferences": {
+            "type": "array",
+            "description": "Unselbstständige Fundstellen",
+            "example": "[BUV, 1982, 123-123]",
+            "items": { "type": "string" }
+          },
+          "independentReferences": {
+            "type": "array",
+            "description": "Selbstständige Fundstellen",
+            "example": "[50 Jahre Betriebs-Berater, 1987, 123-456]",
+            "items": { "type": "string" }
+          },
+          "headline": { "type": "string", "description": "Haupttitel" },
+          "alternativeTitle": {
+            "type": "string",
+            "description": "Dokumentarischer Titel"
+          },
+          "authors": {
+            "type": "array",
+            "description": "Authoren",
+            "example": "[Musterfrau, Sabine]",
+            "items": { "type": "string" }
+          },
+          "collaborators": {
+            "type": "array",
+            "description": "Mitarbeiter",
+            "example": "[Mustermann, Max]",
+            "items": { "type": "string" }
+          },
+          "shortReport": { "type": "string", "description": "Kurzrefarat" },
+          "outline": { "type": "string", "description": "Gliederung" },
+          "encoding": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/LiteratureEncodingSchema" }
+          },
+          "@type": { "type": "string", "example": "Literature" }
+        }
+      },
       "CollectionSchemaSearchMemberSchemaLegislationWorkSearchSchema": {
         "type": "object",
         "properties": {
@@ -1461,19 +1839,6 @@
           "@type": { "type": "string", "example": "Legislation" }
         }
       },
-      "PartialCollectionViewSchema": {
-        "type": "object",
-        "properties": {
-          "first": { "type": "string" },
-          "previous": { "type": "string" },
-          "next": { "type": "string" },
-          "last": { "type": "string" },
-          "@type": {
-            "type": "string",
-            "example": "hydra:PartialCollectionView"
-          }
-        }
-      },
       "PublicationIssueSchema": {
         "type": "object",
         "properties": {
@@ -1492,15 +1857,6 @@
             "items": { "$ref": "#/components/schemas/TextMatchSchema" }
           },
           "@type": { "type": "string", "example": "SearchResult" }
-        }
-      },
-      "TextMatchSchema": {
-        "type": "object",
-        "properties": {
-          "name": { "type": "string" },
-          "text": { "type": "string" },
-          "location": { "type": "string" },
-          "@type": { "type": "string", "example": "SearchResultMatch" }
         }
       },
       "LegislationExpressionPartSchema": {
@@ -1736,7 +2092,8 @@
           "item": {
             "oneOf": [
               { "$ref": "#/components/schemas/CaseLawSearchSchema" },
-              { "$ref": "#/components/schemas/LegislationWorkSearchSchema" }
+              { "$ref": "#/components/schemas/LegislationWorkSearchSchema" },
+              { "$ref": "#/components/schemas/LiteratureSearchSchema" }
             ]
           },
           "textMatches": {


### PR DESCRIPTION
First of all sorry for the big single commit. Was my first work on the portal backend and I learnt how it is built by coding.

Many additions and some changes in already existing code. Just mentioning the most important changes for clarity (and stating my reasons):

- Added field `recordingDate` to the literature model. Firstly I needed a date field for the default sorting behaviour (for which the shared DATUM field is used, which points to a date field in the respective models), and secondly I think this field should be part of the model per se, as it seems to convey important information
- Accordingly adapted the mappers to transmit this new field, including the extraction of the field itself from the XML for which I extended the `FrbrWork` class for literature and added the `FrbrDate` class.
- Added missing mapping definitions for literature for opensearch


And here is the list of changes done but fell into the categories not-sure-if-it-is-right OR it-was-not-specified-and-decided-myself:
- Static method `getLiteratureHighlighter` in the `RisHighlightBuilder` pointing to `Literature.Fields.MAIN_TITLE`
- I chose the following fields of Literature to be directly searchable in `LiteratureSeachParams`: `documentNumber`, `yearOfPublication`, `documentType`, `author`, `collaborator`
- The `searchAndFilterLiterature` method of the `LiteratureService` is not being unit tested but directly integration-tested (same as in caselaw and norms)
- No unit tests for `LiteratureQueryBuilder` and `LiteratureSearchParams` but I don't think they are needed, specially for the latter
- What fields should be included in the `LiteratureSearchSchema`? For now I just copied over all the fields from the model itself (`Literature`) but is not clear to me what fields should NOT be return (probably `outline` and `shortReport`, which I have anyway excluded from the search results because of long text?)
- Is the `LiteratureSortParam` ok? As mentioned above I added the DATUM mapping for opensearch pointing to the new field `recordingDate`
- Default encoding values returned of HTML, XML but also ZIP. But there is no ZIP endpoint cause is not needed right? But then the possible encodings should only be HTML and XML? Change needed?
- I didn't modify the literature_mappings.json file, apart from adding the `recordingDate` field and the default shared `DATUM` one. Meaning without having keywords for literature the searching/filtering by array fields is done in the `LiteratureQueryBuilder` using `matchQuery` instead of `termQuery`, expecting an exact match as far as I understand. Also the queries are built like OR when multiple values in the same fields and with AND when different fields. Is this the expected way? Felt to me more natural and permissive and I think for caselaw filtering for the `types` field, is done also with OR