### PR TITLE
Make feedback endpoint return 501 in none prototype environment

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/client/posthog/PostHogClientDummy.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/client/posthog/PostHogClientDummy.java
@@ -8,6 +8,6 @@ public class PostHogClientDummy implements PostHogClient {
 
   @Override
   public void submitFeedback(String feedback, String url, String userId, String surveyId) {
-    /**/
+    throw new UnsupportedOperationException("Feedback submission is not supported");
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
@@ -143,6 +143,13 @@ public class ControllerExceptionHandler {
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
   }
 
+  @ExceptionHandler(UnsupportedOperationException.class)
+  public ResponseEntity<CustomErrorResponse> handleUnsupportedOperationException(
+      UnsupportedOperationException ex) {
+    logger.warn(ex.getMessage());
+    return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+  }
+
   public static ResponseEntity<CustomErrorResponse> return403() {
     CustomError error =
         CustomError.builder()

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/FeedbackController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/FeedbackController.java
@@ -8,10 +8,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Map;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.ErrorResponseException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -64,13 +62,10 @@ public class FeedbackController {
       @Parameter(name = "user_id", description = "The user identifier to be sent")
           @RequestParam(value = "user_id")
           String userId) {
-    try {
-      postHogService.sendFeedback(userId, url, text);
-      return ResponseEntity.ok()
-          .contentType(MediaType.APPLICATION_JSON)
-          .body(Map.of("message", "Feedback sent successfully"));
-    } catch (Exception exception) {
-      throw new ErrorResponseException(HttpStatusCode.valueOf(500), exception.getCause());
-    }
+
+    postHogService.sendFeedback(userId, url, text);
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(Map.of("message", "Feedback sent successfully"));
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/client/PostHogClientDummyTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/client/PostHogClientDummyTest.java
@@ -1,0 +1,23 @@
+package de.bund.digitalservice.ris.search.unit.client;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import de.bund.digitalservice.ris.search.client.posthog.PostHogClientDummy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PostHogClientDummyTest {
+
+  @Test
+  void throwsUnsupportedOperationException() {
+    var postHogClient = new PostHogClientDummy();
+
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+        .isThrownBy(
+            () -> {
+              postHogClient.submitFeedback("", "", "", "");
+            });
+  }
+}

--- a/frontend/src/stores/usePostHogStore.ts
+++ b/frontend/src/stores/usePostHogStore.ts
@@ -73,11 +73,11 @@ export const usePostHogStore = defineStore("postHog", () => {
       url: router.currentRoute.value.fullPath,
       user_id: getUserPostHogId(),
     });
-    const result = await useFetch(
+    const { error } = await useFetch(
       `${backendURL}/v1/feedback?${params.toString()}`,
     );
 
-    if (!result) {
+    if (error.value) {
       throw new Error(`Error sending feedback`);
     }
   }


### PR DESCRIPTION
- as we don't support feedback submission in none prototype environments, the API endpoint should return a 501 as the operation is not supported 