### PR TITLE
feat(seo): add meta tags for static pages RISDEV-8607

### DIFF
--- a/frontend/src/composables/useStaticPageSeo.spec.ts
+++ b/frontend/src/composables/useStaticPageSeo.spec.ts
@@ -1,0 +1,720 @@
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useStaticPageSeo } from "./useStaticPageSeo";
+import type staticPageSeo from "~/i18n/staticPageSeo.json";
+
+const mockUseHead = vi.fn();
+mockNuxtImport("useHead", () => mockUseHead);
+
+const mockUrl = new URL("https://example.com/test-page");
+const mockUseRequestURL = vi.fn(() => mockUrl);
+mockNuxtImport("useRequestURL", () => mockUseRequestURL);
+
+type MetaTag = {
+  name?: string;
+  property?: string;
+  content: string;
+};
+
+describe("useStaticPageSeo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("with valid page keys", () => {
+    it("should set correct meta tags for startseite page", () => {
+      useStaticPageSeo("startseite");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title: "Rechtsinformationen des Bundes",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Nutzen Sie das neue Rechtsinformationsportal des Bundes – Gesetze, Verordnungen und Urteile auf einen Blick.",
+          },
+          { property: "og:title", content: "Rechtsinformationen des Bundes" },
+          {
+            property: "og:description",
+            content:
+              "Nutzen Sie das neue Rechtsinformationsportal des Bundes – Gesetze, Verordnungen und Urteile auf einen Blick.",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          { name: "twitter:title", content: "Rechtsinformationen des Bundes" },
+          {
+            name: "twitter:description",
+            content:
+              "Nutzen Sie das neue Rechtsinformationsportal des Bundes – Gesetze, Verordnungen und Urteile auf einen Blick.",
+          },
+        ],
+      });
+    });
+
+    it("should set correct meta tags for suche page", () => {
+      useStaticPageSeo("suche");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title: "Suche im Rechtsinformationsportal des Bundes",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Finden Sie gezielt Gesetze, Verordnungen und Entscheidungen – schnell, präzise und übersichtlich.",
+          },
+          {
+            property: "og:title",
+            content: "Suche im Rechtsinformationsportal des Bundes",
+          },
+          {
+            property: "og:description",
+            content:
+              "Finden Sie gezielt Gesetze, Verordnungen und Entscheidungen – schnell, präzise und übersichtlich.",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          {
+            name: "twitter:title",
+            content: "Suche im Rechtsinformationsportal des Bundes",
+          },
+          {
+            name: "twitter:description",
+            content:
+              "Finden Sie gezielt Gesetze, Verordnungen und Entscheidungen – schnell, präzise und übersichtlich.",
+          },
+        ],
+      });
+    });
+
+    it("should set correct meta tags for ueber page", () => {
+      useStaticPageSeo("ueber");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title: "Über das neue Rechtsinformationsportal des Bundes",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Erfahren Sie, wie das Portal Gesetze und Urteile für alle frei zugänglich macht.",
+          },
+          {
+            property: "og:title",
+            content: "Über das neue Rechtsinformationsportal des Bundes",
+          },
+          {
+            property: "og:description",
+            content:
+              "Erfahren Sie, wie das Portal Gesetze und Urteile für alle frei zugänglich macht.",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          {
+            name: "twitter:title",
+            content: "Über das neue Rechtsinformationsportal des Bundes",
+          },
+          {
+            name: "twitter:description",
+            content:
+              "Erfahren Sie, wie das Portal Gesetze und Urteile für alle frei zugänglich macht.",
+          },
+        ],
+      });
+    });
+
+    it("should set correct meta tags for feedback page", () => {
+      useStaticPageSeo("feedback");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title: "Feedback zum Rechtsinformationsportal des Bundes",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Teilen Sie Ihre Rückmeldungen und Anregungen zur Testphase – Ihr Input hilft bei der Weiterentwicklung.",
+          },
+          {
+            property: "og:title",
+            content: "Feedback zum Rechtsinformationsportal des Bundes",
+          },
+          {
+            property: "og:description",
+            content:
+              "Teilen Sie Ihre Rückmeldungen und Anregungen zur Testphase – Ihr Input hilft bei der Weiterentwicklung.",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          {
+            name: "twitter:title",
+            content: "Feedback zum Rechtsinformationsportal des Bundes",
+          },
+          {
+            name: "twitter:description",
+            content:
+              "Teilen Sie Ihre Rückmeldungen und Anregungen zur Testphase – Ihr Input hilft bei der Weiterentwicklung.",
+          },
+        ],
+      });
+    });
+
+    it("should set correct meta tags for kontakt page", () => {
+      useStaticPageSeo("kontakt");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title: "Kontakt zum Rechtsinformationsportal des Bundes",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Hier erreichen Sie uns bei Fragen, Hinweisen oder technischen Problemen rund um das Portal.",
+          },
+          {
+            property: "og:title",
+            content: "Kontakt zum Rechtsinformationsportal des Bundes",
+          },
+          {
+            property: "og:description",
+            content:
+              "Hier erreichen Sie uns bei Fragen, Hinweisen oder technischen Problemen rund um das Portal.",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          {
+            name: "twitter:title",
+            content: "Kontakt zum Rechtsinformationsportal des Bundes",
+          },
+          {
+            name: "twitter:description",
+            content:
+              "Hier erreichen Sie uns bei Fragen, Hinweisen oder technischen Problemen rund um das Portal.",
+          },
+        ],
+      });
+    });
+
+    it("should set correct meta tags for impressum page", () => {
+      useStaticPageSeo("impressum");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title: "Impressum des Rechtsinformationsportals des Bundes",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Angaben gemäß § 5 TMG – Herausgeber, Verantwortliche und rechtliche Hinweise zum Portal.",
+          },
+          {
+            property: "og:title",
+            content: "Impressum des Rechtsinformationsportals des Bundes",
+          },
+          {
+            property: "og:description",
+            content:
+              "Angaben gemäß § 5 TMG – Herausgeber, Verantwortliche und rechtliche Hinweise zum Portal.",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          {
+            name: "twitter:title",
+            content: "Impressum des Rechtsinformationsportals des Bundes",
+          },
+          {
+            name: "twitter:description",
+            content:
+              "Angaben gemäß § 5 TMG – Herausgeber, Verantwortliche und rechtliche Hinweise zum Portal.",
+          },
+        ],
+      });
+    });
+
+    it("should set correct meta tags for datenschutz page", () => {
+      useStaticPageSeo("datenschutz");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title: "Datenschutzrichtlinie des Rechtsinformationsportals des Bundes",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Wie wir Ihre Daten schützen, welche Rechte Sie haben und welche Verfahren wir anwenden.",
+          },
+          {
+            property: "og:title",
+            content:
+              "Datenschutzrichtlinie des Rechtsinformationsportals des Bundes",
+          },
+          {
+            property: "og:description",
+            content:
+              "Wie wir Ihre Daten schützen, welche Rechte Sie haben und welche Verfahren wir anwenden.",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          {
+            name: "twitter:title",
+            content:
+              "Datenschutzrichtlinie des Rechtsinformationsportals des Bundes",
+          },
+          {
+            name: "twitter:description",
+            content:
+              "Wie wir Ihre Daten schützen, welche Rechte Sie haben und welche Verfahren wir anwenden.",
+          },
+        ],
+      });
+    });
+
+    it("should set correct meta tags for barrierefreiheit page", () => {
+      useStaticPageSeo("barrierefreiheit");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title: "Barrierefreiheit im Rechtsinformationsportal des Bundes",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Informationen zur digitalen Zugänglichkeit, zum technischen Standard und zur Feedback-Möglichkeit.",
+          },
+          {
+            property: "og:title",
+            content: "Barrierefreiheit im Rechtsinformationsportal des Bundes",
+          },
+          {
+            property: "og:description",
+            content:
+              "Informationen zur digitalen Zugänglichkeit, zum technischen Standard und zur Feedback-Möglichkeit.",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          {
+            name: "twitter:title",
+            content: "Barrierefreiheit im Rechtsinformationsportal des Bundes",
+          },
+          {
+            name: "twitter:description",
+            content:
+              "Informationen zur digitalen Zugänglichkeit, zum technischen Standard und zur Feedback-Möglichkeit.",
+          },
+        ],
+      });
+    });
+
+    it("should set correct meta tags for cookies page", () => {
+      useStaticPageSeo("cookies");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title:
+          "Cookie-Einstellungen für das Rechtsinformationsportal des Bundes",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Wählen Sie, welche Cookies Sie zulassen – für eine bessere, datenschutzgerechte Nutzung.",
+          },
+          {
+            property: "og:title",
+            content:
+              "Cookie-Einstellungen für das Rechtsinformationsportal des Bundes",
+          },
+          {
+            property: "og:description",
+            content:
+              "Wählen Sie, welche Cookies Sie zulassen – für eine bessere, datenschutzgerechte Nutzung.",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          {
+            name: "twitter:title",
+            content:
+              "Cookie-Einstellungen für das Rechtsinformationsportal des Bundes",
+          },
+          {
+            name: "twitter:description",
+            content:
+              "Wählen Sie, welche Cookies Sie zulassen – für eine bessere, datenschutzgerechte Nutzung.",
+          },
+        ],
+      });
+    });
+
+    it("should set correct meta tags for opensource page", () => {
+      useStaticPageSeo("opensource");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title: "Open Source im Rechtsinformationsportal des Bundes",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Informationen zur verwendeten Open-Source-Software, zu Lizenzen und Beteiligungsmöglichkeiten.",
+          },
+          {
+            property: "og:title",
+            content: "Open Source im Rechtsinformationsportal des Bundes",
+          },
+          {
+            property: "og:description",
+            content:
+              "Informationen zur verwendeten Open-Source-Software, zu Lizenzen und Beteiligungsmöglichkeiten.",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          {
+            name: "twitter:title",
+            content: "Open Source im Rechtsinformationsportal des Bundes",
+          },
+          {
+            name: "twitter:description",
+            content:
+              "Informationen zur verwendeten Open-Source-Software, zu Lizenzen und Beteiligungsmöglichkeiten.",
+          },
+        ],
+      });
+    });
+
+    it("should set correct meta tags for nutzungstests page", () => {
+      useStaticPageSeo("nutzungstests");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title: "Nutzungstests zum Rechtsinformationsportal des Bundes",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Erfahren Sie, wie das Portal getestet wird, welche Ergebnisse vorliegen und wie Sie teilnehmen können.",
+          },
+          {
+            property: "og:title",
+            content: "Nutzungstests zum Rechtsinformationsportal des Bundes",
+          },
+          {
+            property: "og:description",
+            content:
+              "Erfahren Sie, wie das Portal getestet wird, welche Ergebnisse vorliegen und wie Sie teilnehmen können.",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          {
+            name: "twitter:title",
+            content: "Nutzungstests zum Rechtsinformationsportal des Bundes",
+          },
+          {
+            name: "twitter:description",
+            content:
+              "Erfahren Sie, wie das Portal getestet wird, welche Ergebnisse vorliegen und wie Sie teilnehmen können.",
+          },
+        ],
+      });
+    });
+
+    it("should set correct meta tags for api page", () => {
+      useStaticPageSeo("api");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title: "API-Dokumentation des Rechtsinformationsportals des Bundes",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Technische Dokumentation und API-Referenz für den Zugriff auf Rechtsinformationen des Bundes.",
+          },
+          {
+            property: "og:title",
+            content:
+              "API-Dokumentation des Rechtsinformationsportals des Bundes",
+          },
+          {
+            property: "og:description",
+            content:
+              "Technische Dokumentation und API-Referenz für den Zugriff auf Rechtsinformationen des Bundes.",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          {
+            name: "twitter:title",
+            content:
+              "API-Dokumentation des Rechtsinformationsportals des Bundes",
+          },
+          {
+            name: "twitter:description",
+            content:
+              "Technische Dokumentation und API-Referenz für den Zugriff auf Rechtsinformationen des Bundes.",
+          },
+        ],
+      });
+    });
+
+    it("should set correct meta tags for nutzungstests-datenschutz page", () => {
+      useStaticPageSeo("nutzungstests-datenschutz");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title:
+          "Datenschutzerklärung zu den Nutzungstests des Rechtsinformationsportals des Bundes",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Erfahren Sie, wie wir Ihre Daten bei Teilnahme an unseren Nutzungstests erfassen, verwenden und schützen",
+          },
+          {
+            property: "og:title",
+            content:
+              "Datenschutzerklärung zu den Nutzungstests des Rechtsinformationsportals des Bundes",
+          },
+          {
+            property: "og:description",
+            content:
+              "Erfahren Sie, wie wir Ihre Daten bei Teilnahme an unseren Nutzungstests erfassen, verwenden und schützen",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          {
+            name: "twitter:title",
+            content:
+              "Datenschutzerklärung zu den Nutzungstests des Rechtsinformationsportals des Bundes",
+          },
+          {
+            name: "twitter:description",
+            content:
+              "Erfahren Sie, wie wir Ihre Daten bei Teilnahme an unseren Nutzungstests erfassen, verwenden und schützen",
+          },
+        ],
+      });
+    });
+
+    it("should set correct meta tags for translations-list page", () => {
+      useStaticPageSeo("translations-list");
+
+      expect(mockUseHead).toHaveBeenCalledWith({
+        title: "English Translations of German Federal Laws and Regulations",
+        link: [{ rel: "canonical", href: "https://example.com/test-page" }],
+        meta: [
+          {
+            name: "description",
+            content:
+              "Access official English translations of selected German laws and regulations. These translations are for informational purposes only and are not legally binding.",
+          },
+          {
+            property: "og:title",
+            content:
+              "English Translations of German Federal Laws and Regulations",
+          },
+          {
+            property: "og:description",
+            content:
+              "Access official English translations of selected German laws and regulations. These translations are for informational purposes only and are not legally binding.",
+          },
+          { property: "og:url", content: "https://example.com/test-page" },
+          {
+            name: "twitter:title",
+            content:
+              "English Translations of German Federal Laws and Regulations",
+          },
+          {
+            name: "twitter:description",
+            content:
+              "Access official English translations of selected German laws and regulations. These translations are for informational purposes only and are not legally binding.",
+          },
+        ],
+      });
+    });
+  });
+
+  describe("with invalid page keys", () => {
+    it("should return early and not call useHead when page key does not exist", () => {
+      // @ts-expect-error - Testing invalid key
+      useStaticPageSeo("nonexistent-page");
+
+      expect(mockUseHead).not.toHaveBeenCalled();
+    });
+
+    it("should return early and not call useHead when page key is undefined", () => {
+      // @ts-expect-error - Testing undefined key
+      useStaticPageSeo(undefined);
+
+      expect(mockUseHead).not.toHaveBeenCalled();
+    });
+
+    it("should return early and not call useHead when page key is null", () => {
+      // @ts-expect-error - Testing null key
+      useStaticPageSeo(null);
+
+      expect(mockUseHead).not.toHaveBeenCalled();
+    });
+
+    it("should return early and not call useHead when page key is empty string", () => {
+      // @ts-expect-error - Testing empty string key
+      useStaticPageSeo("");
+
+      expect(mockUseHead).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("URL handling", () => {
+    it("should use the URL from useRequestURL for canonical link and og:url", () => {
+      const customUrl = new URL("https://custom-domain.com/custom-path");
+      mockUseRequestURL.mockReturnValueOnce(customUrl);
+
+      useStaticPageSeo("startseite");
+
+      expect(mockUseRequestURL).toHaveBeenCalled();
+      expect(mockUseHead).toHaveBeenCalledWith(
+        expect.objectContaining({
+          link: [
+            { rel: "canonical", href: "https://custom-domain.com/custom-path" },
+          ],
+          meta: expect.arrayContaining([
+            {
+              property: "og:url",
+              content: "https://custom-domain.com/custom-path",
+            },
+          ]),
+        }),
+      );
+    });
+
+    it("should handle different URL formats correctly", () => {
+      const urlWithQuery = new URL(
+        "https://example.com/page?param=value&other=test",
+      );
+      mockUseRequestURL.mockReturnValueOnce(urlWithQuery);
+
+      useStaticPageSeo("startseite");
+
+      expect(mockUseHead).toHaveBeenCalledWith(
+        expect.objectContaining({
+          link: [
+            {
+              rel: "canonical",
+              href: "https://example.com/page?param=value&other=test",
+            },
+          ],
+          meta: expect.arrayContaining([
+            {
+              property: "og:url",
+              content: "https://example.com/page?param=value&other=test",
+            },
+          ]),
+        }),
+      );
+    });
+  });
+
+  describe("meta tag structure", () => {
+    it("should include all required meta tags", () => {
+      useStaticPageSeo("startseite");
+
+      const callArgs = mockUseHead.mock.calls[0][0];
+
+      expect(callArgs).toHaveProperty("title");
+      expect(callArgs).toHaveProperty("link");
+      expect(callArgs).toHaveProperty("meta");
+
+      expect(callArgs.link).toHaveLength(1);
+      expect(callArgs.link[0]).toEqual({
+        rel: "canonical",
+        href: "https://example.com/test-page",
+      });
+
+      expect(callArgs.meta).toHaveLength(6);
+
+      // Check for description meta tag
+      expect(callArgs.meta).toContainEqual({
+        name: "description",
+        content:
+          "Nutzen Sie das neue Rechtsinformationsportal des Bundes – Gesetze, Verordnungen und Urteile auf einen Blick.",
+      });
+
+      // Check for Open Graph meta tags
+      expect(callArgs.meta).toContainEqual({
+        property: "og:title",
+        content: "Rechtsinformationen des Bundes",
+      });
+      expect(callArgs.meta).toContainEqual({
+        property: "og:description",
+        content:
+          "Nutzen Sie das neue Rechtsinformationsportal des Bundes – Gesetze, Verordnungen und Urteile auf einen Blick.",
+      });
+      expect(callArgs.meta).toContainEqual({
+        property: "og:url",
+        content: "https://example.com/test-page",
+      });
+
+      // Check for Twitter meta tags
+      expect(callArgs.meta).toContainEqual({
+        name: "twitter:title",
+        content: "Rechtsinformationen des Bundes",
+      });
+      expect(callArgs.meta).toContainEqual({
+        name: "twitter:description",
+        content:
+          "Nutzen Sie das neue Rechtsinformationsportal des Bundes – Gesetze, Verordnungen und Urteile auf einen Blick.",
+      });
+    });
+
+    it("should use the same title for page title, og:title, and twitter:title", () => {
+      useStaticPageSeo("startseite");
+
+      const callArgs = mockUseHead.mock.calls[0][0];
+      const expectedTitle = "Rechtsinformationen des Bundes";
+
+      expect(callArgs.title).toBe(expectedTitle);
+
+      const ogTitleMeta = callArgs.meta.find(
+        (meta: MetaTag) => meta.property === "og:title",
+      );
+      const twitterTitleMeta = callArgs.meta.find(
+        (meta: MetaTag) => meta.name === "twitter:title",
+      );
+
+      expect(ogTitleMeta?.content).toBe(expectedTitle);
+      expect(twitterTitleMeta?.content).toBe(expectedTitle);
+    });
+
+    it("should use the same description for meta description, og:description, and twitter:description", () => {
+      useStaticPageSeo("startseite");
+
+      const callArgs = mockUseHead.mock.calls[0][0];
+      const expectedDescription =
+        "Nutzen Sie das neue Rechtsinformationsportal des Bundes – Gesetze, Verordnungen und Urteile auf einen Blick.";
+
+      const descriptionMeta = callArgs.meta.find(
+        (meta: MetaTag) => meta.name === "description",
+      );
+      const ogDescriptionMeta = callArgs.meta.find(
+        (meta: MetaTag) => meta.property === "og:description",
+      );
+      const twitterDescriptionMeta = callArgs.meta.find(
+        (meta: MetaTag) => meta.name === "twitter:description",
+      );
+
+      expect(descriptionMeta?.content).toBe(expectedDescription);
+      expect(ogDescriptionMeta?.content).toBe(expectedDescription);
+      expect(twitterDescriptionMeta?.content).toBe(expectedDescription);
+    });
+  });
+
+  describe("type safety", () => {
+    it("should accept all valid page keys from the JSON file", () => {
+      const validKeys: (keyof typeof staticPageSeo)[] = [
+        "startseite",
+        "suche",
+        "ueber",
+        "feedback",
+        "kontakt",
+        "impressum",
+        "datenschutz",
+        "barrierefreiheit",
+        "cookies",
+        "opensource",
+        "nutzungstests",
+        "api",
+        "nutzungstests-datenschutz",
+        "translations-list",
+      ];
+
+      validKeys.forEach((key) => {
+        expect(() => useStaticPageSeo(key)).not.toThrow();
+      });
+    });
+  });
+});

--- a/frontend/src/composables/useStaticPageSeo.ts
+++ b/frontend/src/composables/useStaticPageSeo.ts
@@ -1,0 +1,23 @@
+import staticPageSeo from "~/i18n/staticPageSeo.json";
+
+export function useStaticPageSeo(page: keyof typeof staticPageSeo) {
+  const entry = staticPageSeo[page];
+  if (!entry) return;
+
+  const title = entry.titel;
+  const description = entry.beschreibung;
+  const url = useRequestURL();
+
+  useHead({
+    title,
+    link: [{ rel: "canonical", href: url.href }],
+    meta: [
+      { name: "description", content: description },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { property: "og:url", content: url.href },
+      { name: "twitter:title", content: title },
+      { name: "twitter:description", content: description },
+    ],
+  });
+}

--- a/frontend/src/i18n/staticPageSeo.json
+++ b/frontend/src/i18n/staticPageSeo.json
@@ -1,0 +1,58 @@
+{
+  "startseite": {
+    "titel": "Rechtsinformationen des Bundes",
+    "beschreibung": "Nutzen Sie das neue Rechtsinformationsportal des Bundes – Gesetze, Verordnungen und Urteile auf einen Blick."
+  },
+  "suche": {
+    "titel": "Suche im Rechtsinformationsportal des Bundes",
+    "beschreibung": "Finden Sie gezielt Gesetze, Verordnungen und Entscheidungen – schnell, präzise und übersichtlich."
+  },
+  "ueber": {
+    "titel": "Über das neue Rechtsinformationsportal des Bundes",
+    "beschreibung": "Erfahren Sie, wie das Portal Gesetze und Urteile für alle frei zugänglich macht."
+  },
+  "feedback": {
+    "titel": "Feedback zum Rechtsinformationsportal des Bundes",
+    "beschreibung": "Teilen Sie Ihre Rückmeldungen und Anregungen zur Testphase – Ihr Input hilft bei der Weiterentwicklung."
+  },
+  "kontakt": {
+    "titel": "Kontakt zum Rechtsinformationsportal des Bundes",
+    "beschreibung": "Hier erreichen Sie uns bei Fragen, Hinweisen oder technischen Problemen rund um das Portal."
+  },
+  "impressum": {
+    "titel": "Impressum des Rechtsinformationsportals des Bundes",
+    "beschreibung": "Angaben gemäß § 5 TMG – Herausgeber, Verantwortliche und rechtliche Hinweise zum Portal."
+  },
+  "datenschutz": {
+    "titel": "Datenschutzrichtlinie des Rechtsinformationsportals des Bundes",
+    "beschreibung": "Wie wir Ihre Daten schützen, welche Rechte Sie haben und welche Verfahren wir anwenden."
+  },
+  "barrierefreiheit": {
+    "titel": "Barrierefreiheit im Rechtsinformationsportal des Bundes",
+    "beschreibung": "Informationen zur digitalen Zugänglichkeit, zum technischen Standard und zur Feedback-Möglichkeit."
+  },
+  "cookies": {
+    "titel": "Cookie-Einstellungen für das Rechtsinformationsportal des Bundes",
+    "beschreibung": "Wählen Sie, welche Cookies Sie zulassen – für eine bessere, datenschutzgerechte Nutzung."
+  },
+  "opensource": {
+    "titel": "Open Source im Rechtsinformationsportal des Bundes",
+    "beschreibung": "Informationen zur verwendeten Open-Source-Software, zu Lizenzen und Beteiligungsmöglichkeiten."
+  },
+  "nutzungstests": {
+    "titel": "Nutzungstests zum Rechtsinformationsportal des Bundes",
+    "beschreibung": "Erfahren Sie, wie das Portal getestet wird, welche Ergebnisse vorliegen und wie Sie teilnehmen können."
+  },
+  "api": {
+    "titel": "API-Dokumentation des Rechtsinformationsportals des Bundes",
+    "beschreibung": "Technische Dokumentation und API-Referenz für den Zugriff auf Rechtsinformationen des Bundes."
+  },
+  "nutzungstests-datenschutz": {
+    "titel": "Datenschutzerklärung zu den Nutzungstests des Rechtsinformationsportals des Bundes",
+    "beschreibung": "Erfahren Sie, wie wir Ihre Daten bei Teilnahme an unseren Nutzungstests erfassen, verwenden und schützen"
+  },
+  "translations-list": {
+    "titel": "English Translations of German Federal Laws and Regulations",
+    "beschreibung": "Access official English translations of selected German laws and regulations. These translations are for informational purposes only and are not legally binding."
+  }
+}

--- a/frontend/src/pages/about/index.vue
+++ b/frontend/src/pages/about/index.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import StaticPageWrapper from "~/components/CustomLayouts/StaticPageWrapper.vue";
 import { StatusCardType } from "~/components/types";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
 
-useHead({ title: "Über den Service" });
 definePageMeta({ alias: ["/ueber"] });
+
+useStaticPageSeo("ueber");
 </script>
 
 <template>

--- a/frontend/src/pages/accessibility/index.vue
+++ b/frontend/src/pages/accessibility/index.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import StaticPageWrapper from "~/components/CustomLayouts/StaticPageWrapper.vue";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
 import ContactDetails from "~/pages/contact/ContactDetails.vue";
 
-useHead({ title: "Erklärung zur Barrierefreiheit" });
 definePageMeta({ alias: ["/barrierefreiheit"] });
+
+useStaticPageSeo("barrierefreiheit");
 </script>
 
 <template>

--- a/frontend/src/pages/contact/index.vue
+++ b/frontend/src/pages/contact/index.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import StaticPageWrapper from "~/components/CustomLayouts/StaticPageWrapper.vue";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
 import ContactDetails from "~/pages/contact/ContactDetails.vue";
 
-useHead({ title: "Kontakt" });
 definePageMeta({ alias: ["/kontakt"] });
+
+useStaticPageSeo("kontakt");
 </script>
 
 <template>

--- a/frontend/src/pages/cookie-settings/index.vue
+++ b/frontend/src/pages/cookie-settings/index.vue
@@ -2,11 +2,11 @@
 import { storeToRefs } from "pinia";
 import PrimeVueButton from "primevue/button";
 import StaticPageWrapper from "~/components/CustomLayouts/StaticPageWrapper.vue";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
 import { usePostHogStore } from "~/stores/usePostHogStore";
 import IconCheck from "~icons/ic/check";
 import IconClose from "~icons/ic/close";
 
-useHead({ title: "Cookie-Einstellungen" });
 definePageMeta({ alias: ["/cookie-einstellungen"] });
 
 const store = usePostHogStore();
@@ -14,6 +14,8 @@ const { userConsent } = storeToRefs(store);
 function handleSetTracking(value: boolean) {
   store.setTracking(value);
 }
+
+useStaticPageSeo("cookies");
 </script>
 
 <template>

--- a/frontend/src/pages/data-protection/index.vue
+++ b/frontend/src/pages/data-protection/index.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import StaticPageWrapper from "~/components/CustomLayouts/StaticPageWrapper.vue";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
 
-useHead({ title: "Datenschutzerklärung" });
 definePageMeta({ alias: ["/datenschutz"] });
+
+useStaticPageSeo("datenschutz");
 </script>
 
 <template>

--- a/frontend/src/pages/docs/index.vue
+++ b/frontend/src/pages/docs/index.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { ApiReference } from "@scalar/api-reference";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
 import "@scalar/api-reference/style.css";
 import openApiSpec from "~/public/openapi.json";
 
-useHead({ title: "Documentation" });
 definePageMeta({ alias: ["/docs"], layout: "docs" });
+
+useStaticPageSeo("api");
 </script>
 
 <template>

--- a/frontend/src/pages/feedback/index.vue
+++ b/frontend/src/pages/feedback/index.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import FeedbackForm from "~/components/Analytics/FeedbackForm.vue";
 import StaticPageWrapper from "~/components/CustomLayouts/StaticPageWrapper.vue";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
 
-useHead({ title: "Feedback geben" });
+useStaticPageSeo("feedback");
 </script>
 
 <template>

--- a/frontend/src/pages/imprint/index.vue
+++ b/frontend/src/pages/imprint/index.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import StaticPageWrapper from "~/components/CustomLayouts/StaticPageWrapper.vue";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
 
-useHead({ title: "Impressum" });
 definePageMeta({ alias: ["/impressum"] });
+
+useStaticPageSeo("impressum");
 </script>
 
 <template>

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -4,11 +4,14 @@ import bmjvLogo from "~/assets/img/BMJV_de_v1__Web_farbig.svg";
 import ButtonLink from "~/components/ButtonLink.vue";
 import SimpleSearchInput from "~/components/Search/SimpleSearch/SimpleSearchInput.vue";
 import { useRedirectToSearch } from "~/composables/useRedirectToSearch";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
 import IcBaselineLaunch from "~icons/ic/baseline-launch";
 
 const redirectToSearch = useRedirectToSearch();
 
 definePageMeta({ layout: "base" });
+
+useStaticPageSeo("startseite");
 </script>
 
 <template>

--- a/frontend/src/pages/open-source/index.vue
+++ b/frontend/src/pages/open-source/index.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import StaticPageWrapper from "~/components/CustomLayouts/StaticPageWrapper.vue";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
 import IcBaselineLaunch from "~icons/ic/baseline-launch";
-useHead({ title: "Open Source" });
+
 definePageMeta({ alias: ["/opensource"] });
+
+useStaticPageSeo("opensource");
 </script>
 
 <template>

--- a/frontend/src/pages/search/index.vue
+++ b/frontend/src/pages/search/index.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import ContentWrapper from "~/components/CustomLayouts/ContentWrapper.vue";
 import SimpleSearch from "~/components/Search/SimpleSearch/SimpleSearch.vue";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
+
+useStaticPageSeo("suche");
 </script>
 
 <template>

--- a/frontend/src/pages/translations/index.vue
+++ b/frontend/src/pages/translations/index.vue
@@ -4,6 +4,7 @@ import Button from "primevue/button";
 import InputText from "primevue/inputtext";
 import ContentWrapper from "~/components/CustomLayouts/ContentWrapper.vue";
 import type { BreadcrumbItem } from "~/components/Ris/RisBreadcrumb.vue";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
 import { fetchTranslationList } from "~/composables/useTranslationData";
 import type { TranslationContent } from "~/composables/useTranslationData";
 import IconSearch from "~icons/ic/search";
@@ -69,6 +70,8 @@ const minisearch = computed(() => {
 function handleSearch() {
   activeSearchTerm.value = searchTerm.value;
 }
+
+useStaticPageSeo("translations-list");
 </script>
 
 <template>

--- a/frontend/src/pages/usage-tests-data-protection/index.vue
+++ b/frontend/src/pages/usage-tests-data-protection/index.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import StaticPageWrapper from "~/components/CustomLayouts/StaticPageWrapper.vue";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
 
-useHead({
-  title: "Datenschutzerklärung für Nutzungstests",
-});
 definePageMeta({ alias: ["/nutzungstests-datenschutz"] });
+
+useStaticPageSeo("nutzungstests-datenschutz");
 const title =
   "Datenschutzerklärung für die Registrierung für Nutzungsstudien für das Projekt „Testphase Rechtsinformationsportal“";
 </script>

--- a/frontend/src/pages/usage-tests/index.vue
+++ b/frontend/src/pages/usage-tests/index.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import StaticPageWrapper from "~/components/CustomLayouts/StaticPageWrapper.vue";
+import { useStaticPageSeo } from "~/composables/useStaticPageSeo";
 
-useHead({
-  title: "Für Nutzungstests registrieren",
-});
 definePageMeta({ alias: ["/nutzungstests"] });
+
+useStaticPageSeo("nutzungstests");
 </script>
 
 <template>


### PR DESCRIPTION
- Added new JSON titles & descriptions for each static page.
- Introduced useStaticPageSeo(page) composable and wired into all static pages
- includes test for useStaticPageSeo.spec.ts composable

RISDEV-8607