### PR TITLE
fix(search): remove text-balance from result headings to fix wrapping

### DIFF
--- a/frontend/src/components/Search/Result/Caselaw/CaselawSearchResult.vue
+++ b/frontend/src/components/Search/Result/Caselaw/CaselawSearchResult.vue
@@ -159,7 +159,7 @@ function trackResultClick(url: string) {
     </div>
     <NuxtLink
       :to="metadata.url"
-      class="ris-heading3-bold max-w-title link-hover mt-8 block text-balance text-blue-800"
+      class="ris-heading3-bold max-w-title link-hover mt-8 block text-blue-800"
       @click="trackResultClick(metadata.url)"
     >
       <h2>
@@ -181,9 +181,9 @@ function trackResultClick(url: string) {
           external
           @click="trackResultClick(`${metadata.url}#${section.id}`)"
         >
-          <div role="heading" aria-level="3">
+          <h3>
             {{ section.title }}
-          </div>
+          </h3>
           : </NuxtLink
         >{{ " " }}
         <span

--- a/frontend/src/components/Search/Result/Norms/NormSearchResult.vue
+++ b/frontend/src/components/Search/Result/Norms/NormSearchResult.vue
@@ -66,7 +66,7 @@ function openResult(url: string) {
     <NuxtLink
       v-if="!!link"
       :to="link"
-      class="ris-heading3-bold max-w-title link-hover mt-8 block text-balance text-blue-800"
+      class="ris-heading3-bold max-w-title link-hover mt-8 block text-blue-800"
       @click="openResult(link)"
     >
       <div
@@ -93,11 +93,7 @@ function openResult(url: string) {
             :to="`${link}#${highlight.location || ''}`"
             @click="openResult(`${link}#${highlight.location || ''}`)"
           >
-            <div
-              role="heading"
-              aria-level="3"
-              v-html="sanitizeSearchResult(highlight.name)"
-            />
+            <h3 v-html="sanitizeSearchResult(highlight.name)" />
           </NuxtLink>
         </div>
         <div


### PR DESCRIPTION
Also replaces role="heading" with semantic <h3> tags to satisfy SonarQube accessibility rule

Resolves RISDEV-0000