### PR TITLE
dont set view paraemter for text tab

### DIFF
--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -250,7 +250,9 @@ const detailsTabPanelTitleId = useId();
               :key="view.path"
               :value="view.path"
               :as="NuxtLink"
-              :to="{ query: { view: view.path } }"
+              :to="{
+                query: view.path !== 'text' ? { view: view.path } : undefined,
+              }"
               :aria-controls="undefined"
               :data-attr="view.analyticsId"
               class="flex items-center gap-8"


### PR DESCRIPTION
Don't set the view url parameter in text view, treating it as the default.
This stops the page from reloading if navigation links in toc are used after switching tabs.