### PR TITLE
RISDEV-11410-omit-deprecated-fields

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormSchemaMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormSchemaMapper.java
@@ -140,10 +140,8 @@ public class NormSchemaMapper {
         .id(idPrefix + "#" + article.eId())
         .name(article.name())
         .eId(article.eId())
-        .guid(article.guid())
         .entryIntoForceDate(article.entryIntoForceDate())
         .expiryDate(article.expiryDate())
-        .isActive(DateUtils.isActive(article.entryIntoForceDate(), article.expiryDate()))
         .encoding(encoding)
         .build();
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/LegislationExpressionPartSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/LegislationExpressionPartSchema.java
@@ -32,12 +32,7 @@ public record LegislationExpressionPartSchema(
             example = "hauptteitel-para-1",
             requiredMode = Schema.RequiredMode.REQUIRED)
         String eId,
-    @Schema(
-            example = "550e8400-e29b-41d4-a716-446655440000",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-        String guid,
     @Schema(example = "§ 1", requiredMode = Schema.RequiredMode.REQUIRED) String name,
-    @Nullable @Schema(example = "true") Boolean isActive,
     @Nullable @Schema(example = "2003-12-15") LocalDate entryIntoForceDate,
     @Nullable @Schema(example = "2003-12-15") LocalDate expiryDate,
     @Nullable @Schema(description = "The source data for this part, if available on its own")

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/NormsControllerApiTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/NormsControllerApiTest.java
@@ -98,12 +98,10 @@ class NormsControllerApiTest extends ContainersIntegrationBase {
             jsonPath("$.hasPart", hasSize(2)),
             jsonPath("$.hasPart[0].@type", is("Legislation")),
             jsonPath("$.hasPart[0].eId", is("eid1")),
-            jsonPath("$.hasPart[0].guid", is("guid1")),
             jsonPath(
                 "$.hasPart[0].@id",
                 is("/v1/legislation/eli/bund/bgbl-1/1000/test/2000-10-06/2/deu#eid1")),
             jsonPath("$.hasPart[0].name", is("§ 1 Example article")),
-            jsonPath("$.hasPart[0].isActive", is(true)),
             jsonPath("$.hasPart[0].entryIntoForceDate", is("2023-12-31")),
             jsonPath("$.hasPart[0].expiryDate", is("3000-01-02")));
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/NormSchemaMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/NormSchemaMapperTest.java
@@ -116,7 +116,6 @@ class NormSchemaMapperTest {
                     LegislationExpressionPartSchema.builder()
                         .id("/v1/legislation/expressionEli#eId")
                         .eId("eId")
-                        .isActive(true)
                         .encoding(
                             List.of(
                                 LegislationObjectSchema.builder()

--- a/frontend/src/public/openapi.json
+++ b/frontend/src/public/openapi.json
@@ -2225,7 +2225,7 @@
               },
               "exampleOfWork": {
                 "$ref": "#/components/schemas/LegislationWorkSchema",
-                "description": "the work the expression is based on"
+                "description": "The work the expression is based on"
               },
               "temporalCoverage": {
                 "type": "string",
@@ -2348,12 +2348,7 @@
             "description": "Expression-level identifier, uniquely identifying this element in an FRBR expression",
             "example": "hauptteitel-para-1"
           },
-          "guid": {
-            "type": "string",
-            "example": "550e8400-e29b-41d4-a716-446655440000"
-          },
           "name": { "type": "string", "example": "§ 1" },
-          "isActive": { "type": "boolean", "example": true },
           "entryIntoForceDate": {
             "type": "string",
             "format": "date",
@@ -2370,7 +2365,7 @@
             "items": { "$ref": "#/components/schemas/LegislationObjectSchema" }
           }
         },
-        "required": ["@id", "eId", "guid", "name"]
+        "required": ["@id", "eId", "name"]
       },
       "LegislationExpressionSchema": {
         "type": "object",
@@ -2398,7 +2393,7 @@
           },
           "exampleOfWork": {
             "$ref": "#/components/schemas/LegislationWorkSchema",
-            "description": "the work the expression is based on"
+            "description": "The work the expression is based on"
           },
           "legislationIdentifier": {
             "type": "string",

--- a/frontend/src/types/api-generated.d.ts
+++ b/frontend/src/types/api-generated.d.ts
@@ -850,7 +850,7 @@ export interface components {
       name: string;
       /** @example eli/bund/bgbl-1/1975/s1760/1998-01-29/10/deu */
       legislationIdentifier: string;
-      /** @description the work the expression is based on */
+      /** @description The work the expression is based on */
       exampleOfWork: components["schemas"]["LegislationWorkSchema"];
       /**
        * @description Textual string indicating a time period in [ISO 8601 time interval format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals)
@@ -929,12 +929,8 @@ export interface components {
        * @example hauptteitel-para-1
        */
       eId: string;
-      /** @example 550e8400-e29b-41d4-a716-446655440000 */
-      guid: string;
       /** @example § 1 */
       name: string;
-      /** @example true */
-      isActive?: boolean;
       /**
        * Format: date
        * @example 2003-12-15
@@ -969,7 +965,7 @@ export interface components {
        * @example Kakaoverordnung
        */
       alternateName: string;
-      /** @description the work the expression is based on */
+      /** @description The work the expression is based on */
       exampleOfWork: components["schemas"]["LegislationWorkSchema"];
       /** @example eli/bund/bgbl-1/1975/s1760/1998-01-29/10/deu */
       legislationIdentifier: string;


### PR DESCRIPTION
this PR removes the unused fields GUID and isActive from the LegislationExpressionPartSchema.

* Both fields do not exist in the schema.org Legislation schema and are unused. 
* If isActive should become relevant again, the legislationLegalForce property, described in the LegislationExpressionSchema is to be used. Both schemas are of type schema:Legislation