### PR TITLE
RISDEV-0000 fix broken escaping of commit messages in CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -271,11 +271,13 @@ jobs:
           path: docs/data/
           name: openapi.json
       - name: Push reports
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           git add docs/data/openapi.json &&
           git diff-index --cached --quiet HEAD ||
             git commit \
-              -m ${{ toJSON(github.event.head_commit.message) }} \
+              -m "$COMMIT_MESSAGE" \
               -m "From commit: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}" &&
             git push origin main &&
             echo "Pushed documentation to ${{ github.server_url }}/${{ env.documentation-repo }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
When committing updated OpenAPI specs, escaping the commit message with `toJSON` isn't sufficient because it doesn't escape backticks. Those are often used in Markdown-formatted commit messages, causing the pipeline to fail. Since backticks may also be interpreted as command substitution in shell environments, it additionally exposes us to shell injection attacks.

See
https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable

