### PR TITLE
RISDEV-11413 simplify eID encoding, decoding and Umlaut conversion

### DIFF
--- a/backend/src/main/resources/XSLT/html/case-law.xslt
+++ b/backend/src/main/resources/XSLT/html/case-law.xslt
@@ -8,14 +8,6 @@
 
 	<xsl:output method="html" encoding="UTF-8" />
 
-	<xsl:function name="local:encode-for-uri" as="xs:string">
-		<xsl:param name="uri" as="xs:string" />
-		<xsl:variable name="uri" select="replace($uri, 'ä', 'ae')" />
-		<xsl:variable name="uri" select="replace($uri, 'ö', 'oe')" />
-		<xsl:variable name="uri" select="replace($uri, 'ü', 'ue')" />
-		<xsl:value-of select="$uri" />
-	</xsl:function>
-
 	<xsl:param name="ressourcenpfad" as="xs:string" select="''"/>
 
 	<!-- akn wrapper elements (can be removed but content is kept) -->
@@ -210,7 +202,7 @@
 	<xsl:template match="akn:a[@class='border-number-link']">
 		<a>
 			<xsl:attribute name="href">
-				<xsl:value-of select="concat('#', local:encode-for-uri(.))" />
+				<xsl:value-of select="concat('#', .)" />
 			</xsl:attribute>
 			<xsl:attribute name="aria-label">
 				<xsl:value-of select="concat('Springe zu Randnummer: ', .)" />

--- a/backend/src/main/resources/XSLT/html/ldml_de/include/hilfsfunktionen.xsl
+++ b/backend/src/main/resources/XSLT/html/ldml_de/include/hilfsfunktionen.xsl
@@ -37,15 +37,6 @@
         </xsl:if>
     </xsl:function>
 
-    <!-- Ersetzt Umlaute -->
-    <xsl:function name="akn:encode-for-uri" as="xs:string">
-        <xsl:param name="uri" as="xs:string" />
-        <xsl:variable name="uri" select="replace($uri, 'ä', 'ae')" />
-        <xsl:variable name="uri" select="replace($uri, 'ö', 'oe')" />
-        <xsl:variable name="uri" select="replace($uri, 'ü', 'ue')" />
-        <xsl:value-of select="$uri" />
-    </xsl:function>
-
 
     <!--
         ################

--- a/backend/src/main/resources/XSLT/html/ldml_de/include/inhalt.xsl
+++ b/backend/src/main/resources/XSLT/html/ldml_de/include/inhalt.xsl
@@ -158,7 +158,7 @@
     <!-- @eIds zu @id in HTML -->
     <xsl:template match="@eId" priority="2">
         <xsl:attribute name="id">
-            <xsl:value-of select="akn:encode-for-uri(.)" />
+            <xsl:value-of select="." />
         </xsl:attribute>
     </xsl:template>
 
@@ -480,7 +480,7 @@
     <!-- An der Stelle ihres Vorkommens wird zu einer authorialNote nur der @marker selbst ausgegeben, der Inhalt
     hingegen kann an passender Stelle mit authorial-notes-collection ausgegeben werden -->
     <xsl:template match="akn:authorialNote">
-        <a href="{concat('#', akn:encode-for-uri(@eId))}">
+        <a href="{concat('#', @eId)}">
             <sup>
                 <xsl:value-of select="@marker"/>
             </sup>
@@ -511,7 +511,7 @@
         <xsl:if test=".//akn:authorialNote[not(@placementBase)]">
             <ol class="{$fussnoten}">
                 <xsl:for-each select=".//akn:authorialNote[not(@placementBase)]">
-                    <li id="{akn:encode-for-uri(@eId)}" class="{$fussnote}">
+                    <li id="{@eId}" class="{$fussnote}">
                         <xsl:call-template name="authorial-note-content"/>
                     </li>
                 </xsl:for-each>
@@ -535,7 +535,7 @@
         <xsl:if test="$nichtamtliche-fussnoten-elemente">
             <ul class="{$nichtamtliche-fussnoten}">
                 <xsl:for-each select="$nichtamtliche-fussnoten-elemente">
-                    <li id="{akn:encode-for-uri(@eId)}" class="{$fussnote}">
+                    <li id="{@eId}" class="{$fussnote}">
                         <xsl:apply-templates/>
                     </li>
                 </xsl:for-each>
@@ -554,7 +554,7 @@
         </span>
         <p>
             <xsl:value-of select="."/><xsl:text> </xsl:text>
-            <a class="{$rueckverweis}" aria-label="Zurück zum Inhalt" href="{concat('#', akn:encode-for-uri($parent-id))}">↑</a>
+            <a class="{$rueckverweis}" aria-label="Zurück zum Inhalt" href="{concat('#', $parent-id)}">↑</a>
         </p>
     </xsl:template>
 
@@ -571,7 +571,7 @@
         <xsl:variable name="marker-eId" select="concat('#', @eId)"/>
 
         <xsl:for-each select="//akn:authorialNote[@placementBase=$marker-eId]">
-            <div id="{akn:encode-for-uri(@eId)}" class="{$fussnote}">
+            <div id="{@eId}" class="{$fussnote}">
                 <xsl:call-template name="authorial-note-content"/>
             </div>
         </xsl:for-each>

--- a/backend/src/main/resources/XSLT/html/ldml_de/ris-portal.xsl
+++ b/backend/src/main/resources/XSLT/html/ldml_de/ris-portal.xsl
@@ -120,7 +120,7 @@
         <article>
             <xsl:apply-templates select="@*" />
             <!-- wrap h2 in link that points to $dokumentpfad/@eId -->
-            <a href="{concat($dokumentpfad, '/', akn:encode-for-uri(@eId))}">
+            <a href="{concat($dokumentpfad, '/', @eId)}">
                 <xsl:call-template name="num-and-heading-h2"/>
             </a>
             <!-- process remaining elements -->
@@ -269,7 +269,7 @@
         <xsl:param name="attachment-eId" tunnel="yes"/>
         <xsl:choose>
             <xsl:when test="not($is-single-article)">
-                <a href="{concat($dokumentpfad, '/', akn:encode-for-uri($attachment-eId))}">
+                <a href="{concat($dokumentpfad, '/', $attachment-eId)}">
                     <h2 class="{$einzelvorschrift}">
                         <xsl:apply-templates/>
                     </h2>
@@ -296,7 +296,7 @@
         <div class="akn-doc" data-name="offene-struktur">
         <xsl:choose>
             <xsl:when test="not($is-single-article)">
-                <a href="{concat($dokumentpfad, '/', akn:encode-for-uri($attachment-eId))}">
+                <a href="{concat($dokumentpfad, '/', $attachment-eId)}">
                     <h2 class="{$einzelvorschrift}">
                         Anlage
                     </h2>

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/xslt/NormXsltTransformerServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/xslt/NormXsltTransformerServiceTest.java
@@ -191,16 +191,16 @@ class NormXsltTransformerServiceTest {
     var expectedToc =
         """
         <div class="level-1">
-         <span class="akn-span" id="praeambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n1_span-n1">Abschnitt 1</span>
+         <span class="akn-span" id="präambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n1_span-n1">Abschnitt 1</span>
         </div>
         <div class="level-2">
-         <span class="akn-span" id="praeambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n2_span-n1">Allgemeine Bestimmungen</span>
+         <span class="akn-span" id="präambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n2_span-n1">Allgemeine Bestimmungen</span>
         </div>
         <div class="level-5">
-         <span class="akn-span" id="praeambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n3_span-n1">Art 1</span> <span class="akn-span" id="praeambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n3_span-n2">Test Title</span>
+         <span class="akn-span" id="präambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n3_span-n1">Art 1</span> <span class="akn-span" id="präambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n3_span-n2">Test Title</span>
         </div>
         <div class="level-1">
-         <span class="akn-span" id="praeambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n4_span-n1">Art 2</span> <span class="akn-span" id="praeambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n4_span-n2">Another Test Title</span>
+         <span class="akn-span" id="präambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n4_span-n1">Art 2</span> <span class="akn-span" id="präambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n4_span-n2">Another Test Title</span>
         </div>""";
     final Document parsed = Jsoup.parse(html);
 
@@ -222,7 +222,7 @@ class NormXsltTransformerServiceTest {
          <article id="art-z1" data-period="#meta-n1_geltzeiten-n1_geltungszeitgr-n1">
             <h2 class="einzelvorschrift">
               <span class="akn-num" id="art-z1_bezeichnung-n1">§ 1</span>
-              <span class="akn-heading" id="art-z1_ueberschrift-n1">
+              <span class="akn-heading" id="art-z1_überschrift-n1">
                 Basic HTML Elements
               </span>
             </h2>

--- a/backend/src/test/resources/data/XsltTransformerServiceTest/preambleFormulaWithUmlaut.html
+++ b/backend/src/test/resources/data/XsltTransformerServiceTest/preambleFormulaWithUmlaut.html
@@ -8,9 +8,9 @@
 </head>
 <body class="akn-akomaNtoso">
 <h2 class="einzelvorschrift">Eingangsformel</h2>
-<article id="praeambel-1_formel-1" class="eingangsformel">
+<article id="präambel-1_formel-1" class="eingangsformel">
     <h2 class="einzelvorschrift"></h2>
-    <p id="praeambel-1_formel-1_text-1">PreambleTest</p>
+    <p id="präambel-1_formel-1_text-1">PreambleTest</p>
 </article>
 </body>
 </html>

--- a/frontend/e2e/norm.spec.ts
+++ b/frontend/e2e/norm.spec.ts
@@ -164,7 +164,7 @@ test.describe("view norm page", async () => {
     await sidebar.getByRole("link", { name: "Eingangsformel" }).click();
 
     await expect(page).toHaveURL(
-      "/norms/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu#praeambel-n1_formel-n1",
+      "/norms/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu#präambel-n1_formel-n1",
     );
 
     const heading = page.getByRole("heading", { name: "Eingangsformel" });

--- a/frontend/e2e/normArticle.spec.ts
+++ b/frontend/e2e/normArticle.spec.ts
@@ -154,8 +154,7 @@ test.describe("view norm article page", () => {
   test("clicking Eingangsformel heading link navigates to Eingangsformel article", async ({
     page,
   }) => {
-    const normUrl = "/norms/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu";
-    await navigate(page, normUrl);
+    await navigate(page, "/norms/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu");
 
     // The Eingangsformel heading in the main content is wrapped in a link to the article page
     await page
@@ -167,6 +166,18 @@ test.describe("view norm article page", () => {
     await expect(
       page.getByRole("heading", { level: 1, name: "Eingangsformel" }),
     ).toBeVisible();
+  });
+
+  test("highlights Eingangsformel as selected in TOC", async ({
+    page,
+    isMobileTest,
+  }) => {
+    test.skip(isMobileTest);
+
+    await navigate(
+      page,
+      "/norms/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu/präambel-n1_formel-n1",
+    );
 
     await expect(
       page.getByRole("treeitem", { name: "Eingangsformel" }),
@@ -226,6 +237,18 @@ test.describe("view norm article page", () => {
         name: "§§ 18 bis 21 (weggefallen)",
       }),
     ).toBeVisible();
+  });
+
+  test("highlights repealed article as selected in TOC", async ({
+    page,
+    isMobileTest,
+  }) => {
+    test.skip(isMobileTest);
+
+    await navigate(
+      page,
+      "/norms/eli/bund/bgbl-1/1964/s902/2009-02-05/19/deu/art-z%c2%a7%c2%a7%2018%20bis%2021",
+    );
 
     await expect(
       page.getByRole("treeitem", { name: "§§ 18 bis 21, (weggefallen)" }),

--- a/frontend/e2e/normArticle.spec.ts
+++ b/frontend/e2e/normArticle.spec.ts
@@ -151,26 +151,6 @@ test.describe("view norm article page", () => {
     });
   });
 
-  test("table of contents renders on article page", async ({
-    page,
-    isMobileTest,
-  }) => {
-    test.skip(isMobileTest);
-
-    await navigate(
-      page,
-      "/norms/eli/bund/bgbl-1/1964/s902/2009-02-05/19/deu/art-z1",
-    );
-
-    const tocNav = page.getByRole("navigation", { name: "Inhalte" });
-    await expect(tocNav).toBeVisible();
-
-    const selectedItem = tocNav.getByRole("treeitem", {
-      name: /§\s*1,/i,
-    });
-    await expect(selectedItem).toHaveAttribute("aria-selected", "true");
-  });
-
   test("clicking Eingangsformel heading link navigates to Eingangsformel article", async ({
     page,
   }) => {
@@ -184,14 +164,13 @@ test.describe("view norm article page", () => {
       .first()
       .click();
 
-    await page.waitForURL(
-      "/norms/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu/pr%C3%A4ambel-n1_formel-n1",
-      { waitUntil: "commit" },
-    );
-
     await expect(
       page.getByRole("heading", { level: 1, name: "Eingangsformel" }),
     ).toBeVisible();
+
+    await expect(
+      page.getByRole("treeitem", { name: "Eingangsformel" }),
+    ).toHaveAttribute("aria-selected", "true");
   });
 
   test("clicking Nächster Paragraf on Eingangsformel article navigates to next article", async ({
@@ -203,10 +182,6 @@ test.describe("view norm article page", () => {
     );
 
     await page.getByRole("link", { name: "Nächster Paragraf" }).click();
-    await page.waitForURL(
-      "/norms/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu/art-z1",
-      { waitUntil: "commit" },
-    );
 
     await expect(
       page.getByRole("heading", {
@@ -216,7 +191,7 @@ test.describe("view norm article page", () => {
     ).toBeVisible();
   });
 
-  test("clicking Eingangsformel in TOC on art-z1 page navigates to Eingangsformel article", async ({
+  test("clicking Eingangsformel in TOC on article page navigates to Eingangsformel article", async ({
     page,
     isMobileTest,
   }) => {
@@ -229,13 +204,96 @@ test.describe("view norm article page", () => {
     const tocNav = page.getByRole("navigation", { name: "Inhalte" });
     await tocNav.getByRole("link", { name: "Eingangsformel" }).click();
 
-    await page.waitForURL(
-      "/norms/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu/pr%C3%A4ambel-n1_formel-n1",
-      { waitUntil: "commit" },
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Eingangsformel" }),
+    ).toBeVisible();
+  });
+
+  test("navigates to a repealed article by clicking on a heading link", async ({
+    page,
+  }) => {
+    await navigate(page, "/norms/eli/bund/bgbl-1/1964/s902/2009-02-05/19/deu");
+
+    await page
+      .getByRole("main")
+      .getByRole("link", { name: "§§ 18 bis 21 (weggefallen)" })
+      .first()
+      .click();
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "§§ 18 bis 21 (weggefallen)",
+      }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("treeitem", { name: "§§ 18 bis 21, (weggefallen)" }),
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("navigates to a repealed article by clicking Nächster Paragraf", async ({
+    page,
+  }) => {
+    await navigate(
+      page,
+      "/norms/eli/bund/bgbl-1/1964/s902/2009-02-05/19/deu/art-z3",
+    );
+
+    await page.getByRole("link", { name: "Nächster Paragraf" }).click();
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "§§ 18 bis 21 (weggefallen)",
+      }),
+    ).toBeVisible();
+  });
+
+  test("navigates to previous article from a repealed article", async ({
+    page,
+  }) => {
+    await navigate(
+      page,
+      "/norms/eli/bund/bgbl-1/1964/s902/2009-02-05/19/deu/art-z%C2%A7%C2%A7%2018%20bis%2021",
     );
 
     await expect(
-      page.getByRole("heading", { level: 1, name: "Eingangsformel" }),
+      page.getByRole("heading", {
+        level: 1,
+        name: "§§ 18 bis 21 (weggefallen)",
+      }),
+    ).toBeVisible();
+
+    await page.getByRole("link", { name: "Vorheriger Paragraf" }).click();
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "§ 3 Testregelung für freiwillige Dienste im öffentlichen Sektor",
+      }),
+    ).toBeVisible();
+  });
+
+  test("navigates to a repealed article by clicking on the TOC item", async ({
+    page,
+    isMobileTest,
+  }) => {
+    test.skip(isMobileTest);
+
+    await navigate(
+      page,
+      "/norms/eli/bund/bgbl-1/1964/s902/2009-02-05/19/deu/art-z3",
+    );
+
+    const tocNav = page.getByRole("navigation", { name: "Inhalte" });
+    await tocNav.getByRole("link", { name: "§§ 18 bis 21" }).click();
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "§§ 18 bis 21 (weggefallen)",
+      }),
     ).toBeVisible();
   });
 

--- a/frontend/e2e/simpleSearch.spec.ts
+++ b/frontend/e2e/simpleSearch.spec.ts
@@ -420,6 +420,17 @@ test.describe("searching legislation", () => {
       page.getByRole("combobox", { name: "Keine zeitliche Begrenzung" }),
     ).not.toBeVisible();
   });
+
+  test("navigates to article view for search results", async ({ page }) => {
+    await navigate(page, "/search?query=Eingangsformel&documentKind=N");
+
+    const searchResult = getSearchResults(page).first();
+    await searchResult.getByRole("link", { name: "Eingangsformel" }).click();
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Eingangsformel" }),
+    ).toBeVisible();
+  });
 });
 
 test.describe("searching caselaw", () => {

--- a/frontend/src/components/search/NormSearchResult.spec.ts
+++ b/frontend/src/components/search/NormSearchResult.spec.ts
@@ -235,7 +235,7 @@ describe("NormSearchResult", () => {
     const articleHeading = screen.getByText("Article 1");
     expect(articleHeading).toBeInTheDocument();
     const link = articleHeading.closest("a");
-    expect(link?.getAttribute("href")).contains("/PraeoeueAeOeUeambel");
+    expect(link?.getAttribute("href")).contains("/PräöüÄÖÜambel");
   });
 
   describe("validity status badge", () => {

--- a/frontend/src/components/search/NormSearchResult.vue
+++ b/frontend/src/components/search/NormSearchResult.vue
@@ -83,7 +83,7 @@ const headerItems = computed<SearchResultHeaderItem[]>(() => {
 });
 
 const getArticleUrl = (highlight: TextMatch) =>
-  `${link.value}/${highlight.location ? encodeForUri(highlight.location) : ""}`;
+  `${link.value}/${highlight.location ?? ""}`;
 </script>
 
 <template>

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import type { RouteLocationRaw } from "#vue-router";
 import type { BreadcrumbItem } from "~/components/Breadcrumbs.vue";
 import { type Article, DocumentKind } from "~/types/api";
 import IcBaselineArrowBack from "~icons/ic/baseline-arrow-back";
 import IcBaselineArrowForward from "~icons/ic/baseline-arrow-Forward";
 
 definePageMeta({
-  // note: this is an expression ELI plus the article eId
+  // expression ELI + article eId
   alias:
     "/eli/:jurisdiction/:agent/:year/:naturalIdentifier/:pointInTime/:version/:language/:eId",
   layout: "norm",
@@ -54,33 +54,52 @@ const expressionValidityInterval = computed(() =>
 );
 
 const article: Ref<Article | undefined> = computed(() =>
-  norm.value?.hasPart?.find((part) => part.eId == eId.value),
+  // The eId is taken from the router, which always automatically decodes URIs.
+  // However some eIds are pre-encoded in the XML data (e.g. "art-z§§ 1 bis 3"
+  // is encoded in the XML but will automatically be decoded by the router).
+  // For this reason, we need to also decode the eId in the data to make them
+  // comparable.
+  norm.value?.hasPart?.find(
+    (part) => decodeURIComponent(part.eId) == eId.value,
+  ),
 );
 
-const previousArticleUrl: Ref<string | undefined> = computed(() =>
+const previousArticleUrl: Ref<RouteLocationRaw | undefined> = computed(() =>
   getRouteForSiblingArticle(article.value, -1),
 );
 
-const nextArticleUrl: Ref<string | undefined> = computed(() =>
+const nextArticleUrl: Ref<RouteLocationRaw | undefined> = computed(() =>
   getRouteForSiblingArticle(article.value, 1),
 );
 
 function getRouteForSiblingArticle(
-  baseArticle: Article | undefined,
-  indexDifference: number,
-): string | undefined {
-  if (!norm.value || !baseArticle || !norm.value.hasPart) return undefined;
+  self: Article | undefined,
+  offset: number,
+): RouteLocationRaw | undefined {
+  if (!norm.value || !self || !norm.value.hasPart) return undefined;
+
   const hasPart = norm.value.hasPart;
-  const newIndex =
-    hasPart.findIndex((item) => item.eId == baseArticle?.eId) + indexDifference;
-  if (newIndex < 0 || newIndex >= hasPart.length) return undefined;
-  return route.fullPath.replace(/\/[^/]*$/, `/${hasPart[newIndex]?.eId}`);
+  const newIndex = hasPart.findIndex((item) => item.eId === self?.eId) + offset;
+
+  if (!hasPart[newIndex]) return undefined;
+
+  return {
+    name: route.name ?? undefined,
+    query: route.query,
+    // The router will automatically encode things, but some eId might already
+    // be encoded in the XML data (e.g. "art-z§§ 1 bis 3"). Decode first and
+    // let the router encode it again to prevent double encoding, which will
+    // lead to 404s.
+    params: { ...route.params, eId: decodeURIComponent(hasPart[newIndex].eId) },
+  };
 }
 
 const currentNodePath = computed(() =>
   findNodePath(tableOfContents.value, eId.value ?? ""),
 );
+
 const normBreadcrumbTitle = computed(() => getNormBreadcrumbTitle(norm.value));
+
 const breadcrumbItems: Ref<BreadcrumbItem[]> = computed(() => {
   const validFrom = dateFormattedDDMMYYYY(
     expressionValidityInterval.value?.from,

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -56,8 +56,8 @@ const tableOfContents = computed(() => {
   const normPath = route.path;
   return tocItemsToTreeViewItems(
     metadata.value.tableOfContents,
-    (id) => ({ path: normPath, hash: `#${encodeForUri(id)}` }),
-    (id) => ({ path: normPath, hash: `#${encodeForUri(id)}` }),
+    (id) => ({ path: normPath, hash: `#${id}` }),
+    (id) => ({ path: normPath, hash: `#${id}` }),
   );
 });
 

--- a/frontend/src/utils/tableOfContents.spec.ts
+++ b/frontend/src/utils/tableOfContents.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { findNodePath, tocItemsToTreeViewItems } from "./tableOfContents";
 import type { TableOfContentsItem } from "~/types/api";
-import { encodeForUri } from "./textFormatting";
 
 const getHeadingTarget = (id: string, headingPath = "/heading") => ({
   path: headingPath,
@@ -9,7 +8,7 @@ const getHeadingTarget = (id: string, headingPath = "/heading") => ({
 });
 
 const getLeafTarget = (id: string, leafPath = "/leaf") => ({
-  path: `${leafPath}/${encodeForUri(id)}`,
+  path: `${leafPath}/${id}`,
 });
 
 describe("tableOfContents", () => {
@@ -73,7 +72,7 @@ describe("tableOfContents", () => {
       expect(result[0]?.children?.[0]?.key).toBe("art-1");
     });
 
-    it("encodes IDs correctly in generated URLs", () => {
+    it("uses raw IDs in generated URLs", () => {
       const items: TableOfContentsItem[] = [
         {
           "@type": "TocEntry",
@@ -91,7 +90,7 @@ describe("tableOfContents", () => {
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0]?.to).toEqual({ path: "/leaf/Praeoeue AeOeUe §1" });
+      expect(result[0]?.to).toEqual({ path: "/leaf/Präöü ÄÖÜ §1" });
     });
 
     it("keeps raw IDs for selection and encodes hash links for router navigation", () => {

--- a/frontend/src/utils/tableOfContents.spec.ts
+++ b/frontend/src/utils/tableOfContents.spec.ts
@@ -93,6 +93,31 @@ describe("tableOfContents", () => {
       expect(result[0]?.to).toEqual({ path: "/leaf/Präöü ÄÖÜ §1" });
     });
 
+    it("decodes percent-encoded IDs for use as selection key", () => {
+      const items: TableOfContentsItem[] = [
+        {
+          "@type": "TocEntry",
+          id: "art-z%c2%a7%c2%a7%2018%20bis%2021",
+          marker: "§§ 18 bis 21",
+          heading: "Pre-encoded eId",
+          children: [],
+        },
+      ];
+
+      const result = tocItemsToTreeViewItems(
+        items,
+        getHeadingTarget,
+        getLeafTarget,
+      );
+
+      // key must be decoded so it can be compared to route.params.eId (always decoded by Vue Router)
+      expect(result[0]?.key).toBe("art-z§§ 18 bis 21");
+      // to uses the raw id so the router can encode it correctly
+      expect(result[0]?.to).toEqual({
+        path: "/leaf/art-z%c2%a7%c2%a7%2018%20bis%2021",
+      });
+    });
+
     it("keeps raw IDs for selection and encodes hash links for router navigation", () => {
       const items: TableOfContentsItem[] = [
         {

--- a/frontend/src/utils/tableOfContents.ts
+++ b/frontend/src/utils/tableOfContents.ts
@@ -10,7 +10,11 @@ export function tocItemsToTreeViewItems(
 ): TreeItem[] {
   return items.map((child) => {
     const childTreeItem: TreeItem = {
-      key: child.id,
+      // Some eIDs (e.g. "art-z§§ 1 bis 3") are URL encoded in the XML. The
+      // frontend router automatically de-/encodes values that are used as
+      // parameters in routes. "Normalize" the value by decoding to prevent
+      // double encoding/decoding and make them comparable.
+      key: decodeURIComponent(child.id),
       title: child.marker,
       subtitle: child.heading,
       to: getLeafTarget(child.id),

--- a/frontend/src/utils/textFormatting.spec.ts
+++ b/frontend/src/utils/textFormatting.spec.ts
@@ -165,27 +165,6 @@ describe("formatNames", () => {
   });
 });
 
-describe("encodeForUri", () => {
-  it("returns the same string when no umlauts are present", () => {
-    expect(encodeForUri("RIS informationen 123")).toBe("RIS informationen 123");
-  });
-
-  it("handles umlauts in different cases and multiple occurrences", () => {
-    expect(encodeForUri()).toBe("");
-    expect(encodeForUri("müller")).toBe("mueller");
-    expect(encodeForUri("für")).toBe("fuer");
-    expect(encodeForUri("käsebrötchen")).toBe("kaesebroetchen");
-    expect(encodeForUri("Äpfel und Früchte")).toBe("Aepfel und Fruechte");
-    expect(encodeForUri("Übergröße & müde Schüler")).toBe(
-      "Uebergroeße & muede Schueler",
-    );
-    expect(encodeForUri("🏡 süße Träume")).toBe("🏡 sueße Traeume");
-    expect(encodeForUri("🌧 Ärger über Ölpreise")).toBe(
-      "🌧 Aerger ueber Oelpreise",
-    );
-  });
-});
-
 describe("getSingularOrPlural", () => {
   it("returns singular if count is undefined", () => {
     expect(getSingularOrPlural("singular", "plural")).toBe("singular");

--- a/frontend/src/utils/textFormatting.ts
+++ b/frontend/src/utils/textFormatting.ts
@@ -119,26 +119,6 @@ export function formatNames(names: string[]): string[] {
 }
 
 /**
- * Encodes German umlauts into ASCII-friendly equivalents for URI usage.
- * Mirrors the logic used in XSLT:
- *  ä → ae, ö → oe, ü → ue (and uppercase versions)
- */
-export function encodeForUri(text?: string): string {
-  if (!text) return "";
-
-  const map: Record<string, string> = {
-    ä: "ae",
-    ö: "oe",
-    ü: "ue",
-    Ä: "Ae",
-    Ö: "Oe",
-    Ü: "Ue",
-  };
-
-  return text.replaceAll(/[äöüÄÖÜ]/g, (char: string) => map[char] ?? char);
-}
-
-/**
  * Given a noun in singular and plural form, choses the correct one based on the provided count.
  * @param singular
  * @param plural


### PR DESCRIPTION
This PR:

- **Removes all logic for converting Umlaute in eIDs:** We used to translate Umlaute in eIDs to their `ae`, `oe`, `ue` equivalents. It's a constant source of bugs and confusing behavior and is better handled by the browser, frontend router, and Spring endpoints. In addition, LDML.de 1.9 will change the specification to remove Umlaute from eIDs altogether (though if and when we upgrade is not clear at this point).

- **Further simplifies URL encoding/decoding in the frontend** by delegating URL construction to the router where possible, letting it handle this stuff for us; clearly documents edge cases where manual encoding and decoding is still necessary.

- Adds E2E tests for previously uncovered and potentially tricky eIDs