### PR TITLE
RISDEV-11298-add missing encoding to fassungen list expression schema

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/Norm.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/Norm.java
@@ -150,6 +150,8 @@ public final class Norm implements AbstractSearchEntity {
     public static final String EXPRESSION_ELI = "expression_eli";
     public static final String EXPRESSION_ELI_KEYWORD = "expression_eli.keyword";
     public static final String LATEST_MANIFESTATION_ELI = "latest_manifestation_eli";
+    public static final String LATEST_MANIFESTATION_ELI_KEYWORD =
+        "latest_manifestation_eli.keyword";
     public static final String TABLE_OF_CONTENTS = "table_of_contents";
     public static final String CONCLUSIONS_FORMULA = "conclusions_formula";
     public static final String PREAMBLE_FORMULA = "preamble_formula";

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormsService.java
@@ -144,6 +144,7 @@ public class NormsService {
             .docValueField(Norm.Fields.OFFICIAL_SHORT_TITLE_KEYWORD)
             .docValueField(Norm.Fields.NORMS_DATE, DATE_FORMAT)
             .docValueField(Norm.Fields.OFFICIAL_ABBREVIATION_KEYWORD)
+            .docValueField(Norm.Fields.LATEST_MANIFESTATION_ELI_KEYWORD)
             .fetchSource(false)
             .from(pageable.getPageNumber() * pageable.getPageSize())
             .size(pageable.getPageSize());
@@ -174,6 +175,8 @@ public class NormsService {
 
                     String officialTitle = getField(fields, Norm.Fields.OFFICIAL_TITLE_KEYWORD);
                     String shortTitle = getField(fields, Norm.Fields.OFFICIAL_SHORT_TITLE_KEYWORD);
+                    String manifestationEli =
+                        getField(fields, Norm.Fields.LATEST_MANIFESTATION_ELI_KEYWORD);
                     String abbreviation =
                         getField(fields, Norm.Fields.OFFICIAL_ABBREVIATION_KEYWORD);
                     return Norm.builder()
@@ -187,6 +190,7 @@ public class NormsService {
                         .normsDate(normsDate)
                         .entryIntoForceDate(entryIntoForceDate)
                         .expiryDate(expiryDate)
+                        .manifestationEliExample(manifestationEli)
                         .build();
                   })
               .toList();

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/service/NormsServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/service/NormsServiceTest.java
@@ -46,15 +46,29 @@ class NormsServiceTest extends ContainersIntegrationBase {
             .entryIntoForceDate(LocalDate.of(2025, 5, 5))
             .expiryDate(null)
             .expressionEli("eli/bund/bgbl-1/2020/s1126/2025-05-05/deu")
+            .manifestationEliExample(
+                "eli/bund/bgbl-1/2020/s1126/2025-05-05/deu/2920-08-04/regelungstext-1.xml")
+            .officialTitle("latest title")
+            .datePublished(LocalDate.of(2022, 1, 1))
+            .officialShortTitle("latest short title")
+            .normsDate(LocalDate.of(2022, 1, 1))
+            .officialAbbreviation("latest abbr")
             .workEli("eli/bund/bgbl-1/2020/s1126")
             .build();
 
     var olderExpression =
         Norm.builder()
-            .id("eli/bund/bgbl-1/2020/s1126/2020-05-05/deu")
-            .entryIntoForceDate(LocalDate.of(2020, 5, 5))
+            .id("eli/bund/bgbl-1/2022/s1126/2022-05-05/deu")
+            .entryIntoForceDate(LocalDate.of(2022, 5, 5))
             .expiryDate(LocalDate.of(2025, 5, 5))
-            .expressionEli("eli/bund/bgbl-1/2020/s1126/2020-05-05/deu")
+            .expressionEli("eli/bund/bgbl-1/2022/s1126/2022-05-05/deu")
+            .manifestationEliExample(
+                "eli/bund/bgbl-1/2022/s1126/2025-05-05/deu/2920-08-04/regelungstext-1.xml")
+            .officialTitle("oldest title")
+            .datePublished(LocalDate.of(2020, 1, 1))
+            .officialShortTitle("oldest short title")
+            .normsDate(LocalDate.of(2020, 1, 1))
+            .officialAbbreviation("oldest abbr")
             .workEli("eli/bund/bgbl-1/2020/s1126")
             .build();
     repository.save(olderExpression);
@@ -66,19 +80,9 @@ class NormsServiceTest extends ContainersIntegrationBase {
 
     assertThat(test.getTotalElements()).isEqualTo(2);
     assertThat(test.getTotalPages()).isEqualTo(1);
-    assertThat(test.getContent().getFirst().getExpressionEli())
-        .isEqualTo(latestExpression.getExpressionEli());
-    assertThat(test.getContent().getFirst().getExpiryDate())
-        .isEqualTo(latestExpression.getExpiryDate());
-    assertThat(test.getContent().getFirst().getEntryIntoForceDate())
-        .isEqualTo(latestExpression.getEntryIntoForceDate());
 
-    assertThat(test.getContent().getLast().getExpressionEli())
-        .isEqualTo(olderExpression.getExpressionEli());
-    assertThat(test.getContent().getLast().getExpiryDate())
-        .isEqualTo(olderExpression.getExpiryDate());
-    assertThat(test.getContent().getLast().getEntryIntoForceDate())
-        .isEqualTo(olderExpression.getEntryIntoForceDate());
+    assertThat(test.getContent().getFirst()).isEqualTo(latestExpression);
+    assertThat(test.getContent().getLast()).isEqualTo(olderExpression);
   }
 
   @Test


### PR DESCRIPTION
With the manifestationEli being indexed as a keyword now, we can query it while retrieving the list of all expressions of a work.
This aligns the schema more with the api changes introduced in RISDEV-11298.