### PR TITLE
RISDEV-0000 restore info box about past + future versions in article

### DIFF
--- a/backend/e2e-data/norm/eli/bund/bgbl-1/2020/s1126/2020-08-04/1/deu/2020-08-04/regelungstext-1.xml
+++ b/backend/e2e-data/norm/eli/bund/bgbl-1/2020/s1126/2020-08-04/1/deu/2020-08-04/regelungstext-1.xml
@@ -37,10 +37,11 @@
             <akn:lifecycle GUID="b4c5d6e7-f8a9-4890-abcd-3456abcde123" eId="meta-n1_lebzykl-n1" source="attributsemantik-noch-undefiniert">
                 <akn:eventRef GUID="c5d6e7f8-a9b0-4890-abcd-4567abcde123" date="2020-08-04" eId="meta-n1_lebzykl-n1_ereignis-n1" refersTo="ausfertigung" source="attributsemantik-noch-undefiniert" type="generation"/>
                 <akn:eventRef GUID="d6e7f8a9-b0c1-4890-abcd-5678abcde123" date="2020-08-09" eId="meta-n1_lebzykl-n1_ereignis-n2" refersTo="inkrafttreten" source="attributsemantik-noch-undefiniert" type="generation"/>
+                <akn:eventRef GUID="e7f8a9b0-c1d2-4890-abcd-6789abcde124" date="2022-08-03" eId="meta-n1_lebzykl-n1_ereignis-n3" refersTo="ausserkrafttreten" source="attributsemantik-noch-undefiniert" type="generation"/>
             </akn:lifecycle>
             <akn:temporalData GUID="e7f8a9b0-c1d2-4890-abcd-6789abcde123" eId="meta-n1_geltzeiten-n1" source="attributsemantik-noch-undefiniert">
                 <akn:temporalGroup GUID="f8a9b0c1-d2e3-4890-abcd-7890abcde123" eId="meta-n1_geltzeiten-n1_geltungszeitgr-n1">
-                    <akn:timeInterval GUID="a9b0c1d2-e3f4-4890-abcd-8901abcde123" eId="meta-n1_geltzeiten-n1_geltungszeitgr-n1_gelzeitintervall-n1" refersTo="geltungszeit" start="#meta-n1_lebzykl-n1_ereignis-n2"/>
+                    <akn:timeInterval GUID="a9b0c1d2-e3f4-4890-abcd-8901abcde123" eId="meta-n1_geltzeiten-n1_geltungszeitgr-n1_gelzeitintervall-n1" end="#meta-n1_lebzykl-n1_ereignis-n3" refersTo="geltungszeit" start="#meta-n1_lebzykl-n1_ereignis-n2"/>
                 </akn:temporalGroup>
             </akn:temporalData>
             <akn:proprietary GUID="b0c1d2e3-f4a5-4890-abcd-901abcde1234" eId="meta-n1_proprietary-n1" source="attributsemantik-noch-undefiniert">

--- a/backend/e2e-data/norm/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu/2022-08-04/regelungstext-1.xml
+++ b/backend/e2e-data/norm/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu/2022-08-04/regelungstext-1.xml
@@ -39,13 +39,14 @@
                 <akn:eventRef GUID="d6e7f8a9-b0c1-4890-abcd-5678abcde123" date="2020-08-09" eId="meta-n1_lebzykl-n1_ereignis-n2" refersTo="inkrafttreten" source="attributsemantik-noch-undefiniert" type="generation"/>
                 <akn:eventRef GUID="d6e7f8a9-b0c1-4890-abcd-5678abcde123" date="2022-08-04" eId="meta-n1_lebzykl-n1_ereignis-n3" refersTo="ausserkrafttreten" source="attributsemantik-noch-undefiniert" type="amendment"/>
                 <akn:eventRef GUID="d6e7f8a9-b0c1-4890-abcd-5678abcde123" date="2022-08-09" eId="meta-n1_lebzykl-n1_ereignis-n4" refersTo="inkrafttreten" source="attributsemantik-noch-undefiniert" type="amendment"/>
+                <akn:eventRef GUID="f8a9b0c1-d2e3-4890-abcd-6789abcde125" date="2030-01-01" eId="meta-n1_lebzykl-n1_ereignis-n5" refersTo="ausserkrafttreten" source="attributsemantik-noch-undefiniert" type="amendment"/>
             </akn:lifecycle>
             <akn:temporalData GUID="e7f8a9b0-c1d2-4890-abcd-6789abcde123" eId="meta-n1_geltzeiten-n1" source="attributsemantik-noch-undefiniert">
                 <akn:temporalGroup GUID="f8a9b0c1-d2e3-4890-abcd-7890abcde123" eId="meta-n1_geltzeiten-n1_geltungszeitgr-n1">
                     <akn:timeInterval GUID="a9b0c1d2-e3f4-4890-abcd-8901abcde123" eId="meta-n1_geltzeiten-n1_geltungszeitgr-n1_gelzeitintervall-n1" refersTo="geltungszeit" start="#meta-n1_lebzykl-n1_ereignis-n2"/>
                 </akn:temporalGroup>
                 <akn:temporalGroup GUID="f8a9b0c2-d2e3-4890-abcd-7890abcde123" eId="meta-n1_geltzeiten-n1_geltungszeitgr-n2">
-                    <akn:timeInterval GUID="a9b0c2d2-e3f4-4890-abcd-8901abcde123" eId="meta-n1_geltzeiten-n1_geltungszeitgr-n2_gelzeitintervall-n1" refersTo="geltungszeit" start="#meta-n1_lebzykl-n1_ereignis-n4"/>
+                    <akn:timeInterval GUID="a9b0c2d2-e3f4-4890-abcd-8901abcde123" eId="meta-n1_geltzeiten-n1_geltungszeitgr-n2_gelzeitintervall-n1" end="#meta-n1_lebzykl-n1_ereignis-n5" refersTo="geltungszeit" start="#meta-n1_lebzykl-n1_ereignis-n4"/>
                 </akn:temporalGroup>
             </akn:temporalData>
             <akn:proprietary GUID="b0c1d2e3-f4a5-4890-abcd-901abcde1234" eId="meta-n1_proprietary-n1" source="attributsemantik-noch-undefiniert">
@@ -72,7 +73,7 @@
             </akn:formula>
         </akn:preamble>
         <akn:body GUID="c7d8e9f0-a1b2-4890-abcd-6789abcde123" eId="hauptteil-n1">
-            <akn:article GUID="d8e9f0a1-b2c3-4890-abcd-7890abcde123" eId="art-z1" period="#meta-n1_geltzeiten-n1_geltungszeitgr-n1" refersTo="stammform">
+            <akn:article GUID="d8e9f0a1-b2c3-4890-abcd-7890abcde123" eId="art-z1" period="#meta-n1_geltzeiten-n1_geltungszeitgr-n2" refersTo="stammform">
                 <akn:num GUID="e9f0a1b2-c3d4-4890-abcd-890abcdef123" eId="art-z1_bezeichnung-n1">Art 1</akn:num>
                 <akn:heading GUID="f0a1b2c3-d4e5-4890-abcd-901abcdef123" eId="art-z1_überschrift-n1">Fiktive Bestimmungen zur Einführung</akn:heading>
                 <akn:paragraph GUID="a1b2c3d4-e5f6-4890-abcd-0123456789ac" eId="art-z1_abs-z1">

--- a/backend/e2e-data/norm/eli/bund/bgbl-1/2020/s1126/2920-08-04/1/deu/2920-08-04/regelungstext-1.xml
+++ b/backend/e2e-data/norm/eli/bund/bgbl-1/2020/s1126/2920-08-04/1/deu/2920-08-04/regelungstext-1.xml
@@ -76,7 +76,7 @@
             </akn:formula>
         </akn:preamble>
         <akn:body GUID="c7d8e9f0-a1b2-4890-abcd-6789abcde123" eId="hauptteil-n1">
-            <akn:article GUID="d8e9f0a1-b2c3-4890-abcd-7890abcde123" eId="art-z1" period="#meta-n1_geltzeiten-n1_geltungszeitgr-n1" refersTo="stammform">
+            <akn:article GUID="d8e9f0a1-b2c3-4890-abcd-7890abcde123" eId="art-z1" period="#meta-n1_geltzeiten-n1_geltungszeitgr-n3" refersTo="stammform">
                 <akn:num GUID="e9f0a1b2-c3d4-4890-abcd-890abcdef123" eId="art-z1_bezeichnung-n1">Art 1</akn:num>
                 <akn:heading GUID="f0a1b2c3-d4e5-4890-abcd-901abcdef123" eId="art-z1_überschrift-n1">Fiktive Bestimmungen zur Einführung</akn:heading>
                 <akn:paragraph GUID="a1b2c3d4-e5f6-4890-abcd-0123456789ac" eId="art-z1_abs-z1">

--- a/frontend/e2e/normVersions.spec.ts
+++ b/frontend/e2e/normVersions.spec.ts
@@ -130,6 +130,58 @@ test.describe("displays metadata correctly", async () => {
   });
 });
 
+test("shows an info about future versions on a historic norm article", async ({
+  page,
+  privateFeaturesEnabled,
+}) => {
+  test.skip(!privateFeaturesEnabled);
+
+  await navigate(
+    page,
+    "/norms/eli/bund/bgbl-1/2020/s1126/2020-08-04/1/deu/art-z1",
+  );
+
+  await expect(
+    page.getByText("Sie lesen einen Paragrafen einer historischen Fassung."),
+  ).toBeVisible();
+
+  await page
+    .getByRole("link", { name: "Zur aktuell gültigen Fassung" })
+    .click();
+
+  await expect(
+    page.getByRole("heading", {
+      name: "Zum Testen von Fassungen - Aktuelle Fassung",
+    }),
+  ).toBeVisible();
+});
+
+test("shows an info about previous versions on a future norm article", async ({
+  page,
+  privateFeaturesEnabled,
+}) => {
+  test.skip(!privateFeaturesEnabled);
+
+  await navigate(
+    page,
+    "/norms/eli/bund/bgbl-1/2020/s1126/2920-08-04/1/deu/art-z1",
+  );
+
+  await expect(
+    page.getByText("Sie lesen einen Paragrafen einer zukünftigen Fassung."),
+  ).toBeVisible();
+
+  await page
+    .getByRole("link", { name: "Zur aktuell gültigen Fassung" })
+    .click();
+
+  await expect(
+    page.getByRole("heading", {
+      name: "Zum Testen von Fassungen - Aktuelle Fassung",
+    }),
+  ).toBeVisible();
+});
+
 test("displays validity in breadcrumb navigation", async ({
   page,
   privateFeaturesEnabled,

--- a/frontend/src/composables/useNormVersions.ts
+++ b/frontend/src/composables/useNormVersions.ts
@@ -51,7 +51,7 @@ function getNorms(params: LegislationSearchParams) {
   return { status, data };
 }
 
-export function useValidNormVersions(eli: string) {
+export function useValidNormVersions(eli: string | undefined) {
   const today = getCurrentDateInGermanyFormatted();
   return getNorms({
     eli: eli,

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -131,7 +131,7 @@ const htmlTitle = computed(() => data.value?.articleHeading);
 const validVersions =
   norm.value?.legislationLegalForce === "InForce"
     ? undefined
-    : useValidNormVersions(norm.value?.legislationIdentifier);
+    : useValidNormVersions(norm.value?.exampleOfWork?.legislationIdentifier);
 
 const inForceNormLink = computed(() => {
   if (


### PR DESCRIPTION
Fixes a regression introduced in 2f4784e7 where past or future versions of an article would no longer show a reference to the current version:

- references correct property in the data for identifying past and future versions
- fixes broken test data that made testing this impossible
- adds E2E tests to cover the behavior