### PR TITLE
RISDEV-11413 missing links in breadcrumb of Einzelnorm

### DIFF
--- a/backend/e2e-data/norm/eli/bund/bgbl-1/1972/s2459/1999-04-20/4/deu/1999-04-20/regelungstext-1.xml
+++ b/backend/e2e-data/norm/eli/bund/bgbl-1/1972/s2459/1999-04-20/4/deu/1999-04-20/regelungstext-1.xml
@@ -210,6 +210,58 @@
                     </akn:paragraph>
                 </akn:article>
             </akn:section>
+            <akn:section GUID="77777777-aaaa-bbbb-cccc-ddddddddddee" eId="hauptteil-n1_abschnitt-n3">
+                <akn:num GUID="88888888-aaaa-bbbb-cccc-ddddddddddee" eId="hauptteil-n1_abschnitt-n3_bezeichnung-n1">
+                    Dritter Abschnitt
+                </akn:num>
+                <akn:heading GUID="99999999-aaaa-bbbb-cccc-ddddddddddee" eId="hauptteil-n1_abschnitt-n3_überschrift-n1">
+                    Datenschutz und Datensicherheit bei Wahlgeräten
+                </akn:heading>
+                <akn:subsection GUID="aaaaaaaa-1111-2222-3333-ddddddddddee" eId="hauptteil-n1_abschnitt-n3_uabschnitt-n1">
+                    <akn:num GUID="bbbbbbbb-1111-2222-3333-ddddddddddee" eId="hauptteil-n1_abschnitt-n3_uabschnitt-n1_bezeichnung-n1">
+                        Erster Unterabschnitt
+                    </akn:num>
+                    <akn:heading GUID="cccccccc-1111-2222-3333-ddddddddddee" eId="hauptteil-n1_abschnitt-n3_uabschnitt-n1_überschrift-n1">
+                        Anforderungen an die Datenspeicherung
+                    </akn:heading>
+                    <akn:article GUID="dddddddd-1111-2222-3333-ddddddddddee" eId="art-z3" period="#meta-n1_geltzeiten-n1_geltungszeitgr-n3" refersTo="stammform">
+                        <akn:num GUID="eeeeeeee-1111-2222-3333-ddddddddddee" eId="art-z3_bezeichnung-n1">§ 9</akn:num>
+                        <akn:heading GUID="ffffffff-1111-2222-3333-ddddddddddee" eId="art-z3_überschrift-n1">
+                            Datenschutzanforderungen
+                        </akn:heading>
+                        <akn:paragraph GUID="11111111-aaaa-bbbb-cccc-eeeeeeeeeeff" eId="art-z3_abs-z1">
+                            <akn:num GUID="22222222-aaaa-bbbb-cccc-eeeeeeeeeeff" eId="art-z3_abs-z1_bezeichnung-n1">(1)</akn:num>
+                            <akn:content GUID="33333333-aaaa-bbbb-cccc-eeeeeeeeeeff" eId="art-z3_abs-z1_inhalt-n1">
+                                <akn:p GUID="44444444-aaaa-bbbb-cccc-eeeeeeeeeeff" eId="art-z3_abs-z1_inhalt-n1_text-n1">
+                                    Wahlgeräte dürfen keine personenbezogenen Daten der Wählerinnen und Wähler speichern.
+                                </akn:p>
+                            </akn:content>
+                        </akn:paragraph>
+                    </akn:article>
+                </akn:subsection>
+                <akn:subsection GUID="55555555-aaaa-bbbb-cccc-eeeeeeeeeeff" eId="hauptteil-n1_abschnitt-n3_uabschnitt-n2">
+                    <akn:num GUID="66666666-aaaa-bbbb-cccc-eeeeeeeeeeff" eId="hauptteil-n1_abschnitt-n3_uabschnitt-n2_bezeichnung-n1">
+                        Zweiter Unterabschnitt
+                    </akn:num>
+                    <akn:heading GUID="77777777-aaaa-bbbb-cccc-eeeeeeeeeeff" eId="hauptteil-n1_abschnitt-n3_uabschnitt-n2_überschrift-n1">
+                        Technische Sicherheitsmaßnahmen
+                    </akn:heading>
+                    <akn:article GUID="88888888-aaaa-bbbb-cccc-eeeeeeeeeeff" eId="art-z4" period="#meta-n1_geltzeiten-n1_geltungszeitgr-n3" refersTo="stammform">
+                        <akn:num GUID="99999999-aaaa-bbbb-cccc-eeeeeeeeeeff" eId="art-z4_bezeichnung-n1">§ 10</akn:num>
+                        <akn:heading GUID="aabbccdd-1122-3344-5566-778899aabbcc" eId="art-z4_überschrift-n1">
+                            Verschlüsselung und Zugriffsschutz
+                        </akn:heading>
+                        <akn:paragraph GUID="bbccddee-1122-3344-5566-778899aabbcc" eId="art-z4_abs-z1">
+                            <akn:num GUID="ccddeeff-1122-3344-5566-778899aabbcc" eId="art-z4_abs-z1_bezeichnung-n1">(1)</akn:num>
+                            <akn:content GUID="ddeeff00-1122-3344-5566-778899aabbcc" eId="art-z4_abs-z1_inhalt-n1">
+                                <akn:p GUID="eeff0011-1122-3344-5566-778899aabbcc" eId="art-z4_abs-z1_inhalt-n1_text-n1">
+                                    Die in Wahlgeräten gespeicherten Daten sind durch geeignete technische Maßnahmen gegen unbefugten Zugriff zu schützen.
+                                </akn:p>
+                            </akn:content>
+                        </akn:paragraph>
+                    </akn:article>
+                </akn:subsection>
+            </akn:section>
         </akn:body>
     </akn:act>
 </akn:akomaNtoso>

--- a/frontend/e2e/normArticle.spec.ts
+++ b/frontend/e2e/normArticle.spec.ts
@@ -374,6 +374,39 @@ test.describe("can view metadata of norm articles", () => {
   });
 });
 
+test("shows correct breadcrumbs for a nested article", async ({
+  page,
+  privateFeaturesEnabled,
+}) => {
+  test.skip(!privateFeaturesEnabled);
+
+  await navigate(
+    page,
+    "/norms/eli/bund/bgbl-1/1972/s2459/1999-04-20/4/deu/art-z3",
+  );
+
+  const breadcrumb = page.getByRole("navigation", { name: "Pfadnavigation" });
+
+  await expect(
+    breadcrumb.getByRole("link", { name: "Startseite" }),
+  ).toBeVisible();
+  await expect(
+    breadcrumb.getByRole("link", { name: "Gesetze & Verordnungen" }),
+  ).toBeVisible();
+  await expect(
+    breadcrumb.getByRole("link", { name: "BWahlGV vom 24.04.1999" }),
+  ).toBeVisible();
+  await expect(
+    breadcrumb.getByRole("link", { name: "Dritter Abschnitt" }),
+  ).toBeVisible();
+  await expect(
+    breadcrumb.getByRole("link", { name: "Erster Unterabschnitt" }),
+  ).toBeVisible();
+  await expect(
+    breadcrumb.getByText("§ 9 Datenschutzanforderungen"),
+  ).toBeVisible();
+});
+
 test("sets up meta tags for article page", async ({ page }) => {
   await navigate(
     page,

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -17,6 +17,7 @@ definePageMeta({
 });
 
 const route = useRoute();
+
 const privateFeaturesEnabled = usePrivateFeaturesFlag();
 
 const expressionEli = Object.values(route.params).slice(0, -1).join("/");
@@ -50,12 +51,6 @@ const tableOfContents = computed(() => {
     (id) => ({ path: `${normPath}/${id}` }),
   );
 });
-
-const expressionValidityInterval = computed(() =>
-  privateFeaturesEnabled
-    ? temporalCoverageToValidityInterval(norm?.value?.temporalCoverage)
-    : undefined,
-);
 
 const article: Ref<Article | undefined> = computed(() =>
   // The eId is taken from the router, which always automatically decodes URIs.
@@ -119,16 +114,18 @@ function getRouteForSiblingArticle(
   };
 }
 
-const currentNodePath = computed(() =>
-  findNodePath(tableOfContents.value, eId.value ?? ""),
-);
-
-const normBreadcrumbTitle = computed(() => getNormBreadcrumbTitle(norm.value));
-
 const breadcrumbItems: Ref<BreadcrumbItem[]> = computed(() => {
-  const validFrom = dateFormattedDDMMYYYY(
-    expressionValidityInterval.value?.from,
-  );
+  const currentNodePath = eId.value
+    ? (findNodePath(tableOfContents.value, eId.value) ?? [])
+    : [];
+
+  const title = getNormBreadcrumbTitle(norm.value);
+
+  const expressionValidityInterval = privateFeaturesEnabled
+    ? temporalCoverageToValidityInterval(norm?.value?.temporalCoverage)
+    : undefined;
+
+  const validFrom = dateFormattedDDMMYYYY(expressionValidityInterval?.from);
   const validFromDisplay = validFrom ? ` vom ${validFrom}` : "";
 
   const list: BreadcrumbItem[] = [
@@ -136,18 +133,18 @@ const breadcrumbItems: Ref<BreadcrumbItem[]> = computed(() => {
       label: formatDocumentKind(DocumentKind.Norm),
       route: `/search?documentKind=${DocumentKind.Norm}`,
     },
-    {
-      label: normBreadcrumbTitle.value + validFromDisplay,
-      route: normPath,
-    },
+    { label: title + validFromDisplay, route: normPath },
   ];
 
-  currentNodePath.value?.forEach((node) =>
-    list.push({
-      label: [node.title, node.subtitle].filter(Boolean).join(" "),
-      route: typeof node.to === "string" ? node.to : undefined,
-    } as BreadcrumbItem),
-  );
+  currentNodePath.forEach((node) => {
+    const label =
+      node === currentNodePath.at(-1)
+        ? [node.title, node.subtitle].filter(Boolean).join(" ")
+        : (node.title ?? "");
+
+    list.push({ label, route: node.to });
+  });
+
   return list;
 });
 
@@ -292,7 +289,7 @@ useDynamicSeo({ title, description });
         <template #sidebar>
           <DocumentsNormsNormTableOfContents
             v-if="tableOfContents.length"
-            :subheading="normBreadcrumbTitle"
+            :subheading="getNormBreadcrumbTitle(norm)"
             :subheading-to="normPath"
             :table-of-contents="tableOfContents"
             :selected-key="eId"


### PR DESCRIPTION
Fixes a regression in breadcrumbs of Einzelnormen introduced by da13f1f55b8041e7e9b3c6bae3d9ebc46dd691c5:

- all breadcrumbs now link to the correct position in the document again
- only the last element shows the full title, elements in between only appear labeled with their markers
- adds missing tests