### PR TITLE
Show custom 404 error page

### DIFF
--- a/api-docs/nginx.conf
+++ b/api-docs/nginx.conf
@@ -1,6 +1,7 @@
 server {
     listen       8080;
     server_name  _;
+    error_page 404 /404.html;
 
     location / {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
- adjust the nginx.config to show the applications 404 page instead of nginx's default error page

RISDEV-11175