### PR TITLE
Add CORS allow headers for swagger-ui

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/CorsConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/CorsConfig.java
@@ -87,6 +87,21 @@ public class CorsConfig {
             .allowedMethods("GET", "HEAD", "OPTIONS")
             .allowedOrigins(CorsConfiguration.ALL)
             .allowedHeaders(CorsConfiguration.ALL);
+
+        registry
+            .addMapping("/swagger-ui/**")
+            .allowedMethods("GET")
+            .allowedOriginPatterns(docsUrl)
+            .allowedHeaders(CorsConfiguration.ALL);
+
+        // Note: this has nothing to do with our api docs
+        // but is a path used by swagger to serve/access the
+        // openapi specification for the endpoints.
+        registry
+            .addMapping("/v3/api-docs/**")
+            .allowedMethods("GET")
+            .allowedOriginPatterns(docsUrl)
+            .allowedHeaders(CorsConfiguration.ALL);
       }
     };
   }


### PR DESCRIPTION
- to be able to make the swagger UI reachable under docs.rechtsinformationen.bund.de/swagger-ui we need to add allow headers to the CORS configuration for the prototype backend

RISDEV-11297