### PR TITLE
RISDEV-11460-missing-attachments-id

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/EncodingSchemaFactory.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/EncodingSchemaFactory.java
@@ -21,6 +21,7 @@ public class EncodingSchemaFactory {
 
   private static final String LANGUAGE = "de";
 
+  /** valid schemaTypes to appear in an encoding array */
   public enum SchemaType {
     HTML("html"),
     XML("xml"),
@@ -49,6 +50,14 @@ public class EncodingSchemaFactory {
     };
   }
 
+  /**
+   * Generates a legislation encoding schema based on the provided base URL and SchemaType
+   *
+   * @param type the SchemaType for the requested encoding schema
+   * @param baseUrl the base URL to be used for constructing the encoding schema attributes for HTML
+   *     and XML formats
+   * @return {@code LegislationObjectSchema} according to the given SchemaType
+   */
   public static LegislationObjectSchema legislationEncodingSchema(SchemaType type, String baseUrl) {
     return LegislationObjectSchema.builder()
         .id(id(type, baseUrl))

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/EncodingSchemaFactory.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/EncodingSchemaFactory.java
@@ -21,7 +21,7 @@ public class EncodingSchemaFactory {
 
   private static final String LANGUAGE = "de";
 
-  private enum SchemaType {
+  public enum SchemaType {
     HTML("html"),
     XML("xml"),
     ZIP("zip");
@@ -49,8 +49,7 @@ public class EncodingSchemaFactory {
     };
   }
 
-  private static LegislationObjectSchema legislationEncodingSchema(
-      SchemaType type, String baseUrl) {
+  public static LegislationObjectSchema legislationEncodingSchema(SchemaType type, String baseUrl) {
     return LegislationObjectSchema.builder()
         .id(id(type, baseUrl))
         .contentUrl(contentUrl(type, baseUrl))

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormSchemaMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormSchemaMapper.java
@@ -14,7 +14,6 @@ import de.bund.digitalservice.ris.search.utils.DateUtils;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.springframework.http.MediaType;
 
 /**
  * Utility class for mapping {@link Norm} domain objects to a {@link LegislationExpressionSchema}.
@@ -160,10 +159,9 @@ public class NormSchemaMapper {
     // Only attachments have their own manifestationELi and receive an encoding object.
     if (article.manifestationEli() != null) {
       final LegislationObjectSchema encodingItem =
-          LegislationObjectSchema.builder()
-              .encodingFormat(MediaType.APPLICATION_XML_VALUE)
-              .contentUrl(CONTENT_BASE_URL + article.manifestationEli())
-              .build();
+          EncodingSchemaFactory.legislationEncodingSchema(
+              EncodingSchemaFactory.SchemaType.XML,
+              CONTENT_BASE_URL + article.manifestationEli().replace(".xml", ""));
       encoding = List.of(encodingItem);
     } else {
       encoding = List.of();

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormSchemaMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormSchemaMapper.java
@@ -85,11 +85,20 @@ public class NormSchemaMapper {
       return Collections.emptyList();
     }
 
-    var encodingBaseUrl = CONTENT_BASE_URL + manifestationEli.replace(".xml", "");
-    var encodingZipBaseUrl =
-        CONTENT_BASE_URL + manifestationEli.substring(0, manifestationEli.lastIndexOf('/'));
+    var encodingBaseUrl = getEncodingBaseUrlFromManifestationEli(manifestationEli);
+    var encodingZipBaseUrl = encodingBaseUrl.substring(0, encodingBaseUrl.lastIndexOf('/'));
 
     return EncodingSchemaFactory.legislationEncodingSchemas(encodingBaseUrl, encodingZipBaseUrl);
+  }
+
+  /**
+   * construct the baseUrl for encoding objects from the manifestationEli
+   *
+   * @param manifestationEli of a legislation object
+   * @return contentBaseUrl of a legislation object
+   */
+  private static String getEncodingBaseUrlFromManifestationEli(String manifestationEli) {
+    return CONTENT_BASE_URL + manifestationEli.replace(".xml", "");
   }
 
   /**
@@ -161,7 +170,7 @@ public class NormSchemaMapper {
       final LegislationObjectSchema encodingItem =
           EncodingSchemaFactory.legislationEncodingSchema(
               EncodingSchemaFactory.SchemaType.XML,
-              CONTENT_BASE_URL + article.manifestationEli().replace(".xml", ""));
+              getEncodingBaseUrlFromManifestationEli(article.manifestationEli()));
       encoding = List.of(encodingItem);
     } else {
       encoding = List.of();

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/NormSchemaMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/NormSchemaMapperTest.java
@@ -90,7 +90,9 @@ class NormSchemaMapperTest {
                         .encoding(
                             List.of(
                                 LegislationObjectSchema.builder()
-                                    .contentUrl(ApiConfig.Paths.LEGISLATION + "/eli")
+                                    .id("/v1/legislation/eli/xml")
+                                    .inLanguage("de")
+                                    .contentUrl(ApiConfig.Paths.LEGISLATION + "/eli.xml")
                                     .encodingFormat("application/xml")
                                     .build()))
                         .build()))
@@ -228,8 +230,11 @@ class NormSchemaMapperTest {
                                         .encoding(
                                             List.of(
                                                 LegislationObjectSchema.builder()
-                                                    .contentUrl("/v1/legislation/attachment/eli")
+                                                    .id("/v1/legislation/attachment/eli/xml")
+                                                    .contentUrl(
+                                                        "/v1/legislation/attachment/eli.xml")
                                                     .encodingFormat("application/xml")
+                                                    .inLanguage("de")
                                                     .build()))
                                         .build()))
                             .build()))


### PR DESCRIPTION
Reuse EncodingSchemaFactory to guarantee that ids are set for attachment parts of a legislation