### PR TITLE
Fix button appearance in focus state

### DIFF
--- a/api-docs/.vitepress/theme/components/ButtonLink.vue
+++ b/api-docs/.vitepress/theme/components/ButtonLink.vue
@@ -2,7 +2,7 @@
 const props = defineProps<{ href: string }>();
 </script>
 <template>
-  <a :href="props.href" v-bind="$attrs" class="ds-button">
+  <a :href="props.href" class="ds-button">
     <slot />
   </a>
 </template>

--- a/api-docs/.vitepress/theme/components/SwaggerButton.vue
+++ b/api-docs/.vitepress/theme/components/SwaggerButton.vue
@@ -4,9 +4,9 @@ import ButtonLink from "./ButtonLink.vue";
 
 <template>
   <ButtonLink
-    href="/swagger-ui/index.html"
+    href="https://docs.rechtsinformationen.bund.de/swagger-ui/index.html"
     target="_blank"
-    class="not-prose mt-16 bg-blue-800 hover:bg-blue-600 p-16 ris-label2-bold text-white"
+    class="not-prose mt-16 bg-blue-800 hover:bg-blue-600 p-16 ris-label2-bold text-white no-underline focus:text-white focus-visible:text-white"
   >
     Test the API in Swagger
   </ButtonLink>


### PR DESCRIPTION
- make sure the button is still readable in focus state
- hardcode the swagger url so its clear that this is no internal link
 
Ideally the url would be provided via a runtime configuration so it can be easily changed per deployment. But this doesn't seem super easy for a statically served site, so for simplicity and as we don't deploy the docs in multiple environments so far, a hardcoded url is used for now 

RISDEV-11297