### PR TITLE
RISDEV-0000-remove-caselaw-highlights

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/CaseLawSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/CaseLawSchema.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 import lombok.Builder;
 
 /** A DTO for court decisions in a specific encoding, following schema.org naming guidelines. */
@@ -62,9 +61,7 @@ public record CaseLawSchema(
         @JsonProperty("@id")
         String id,
     @Schema(example = "de", requiredMode = Schema.RequiredMode.REQUIRED) String inLanguage,
-    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<CaseLawEncodingSchema> encoding,
-    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        Map<String, List<String>> highlightedFields)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<CaseLawEncodingSchema> encoding)
     implements JsonldResource {
 
   @Override

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/CaseLawSearchSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/CaseLawSearchSchema.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 import lombok.Builder;
 
 /** A DTO for court decisions in a specific encoding, following schema.org naming guidelines. */
@@ -40,9 +39,7 @@ public record CaseLawSearchSchema(
             requiredMode = Schema.RequiredMode.REQUIRED)
         @JsonProperty("@id")
         String id,
-    @Schema(example = "de", requiredMode = Schema.RequiredMode.REQUIRED) String inLanguage,
-    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        Map<String, List<String>> highlightedFields)
+    @Schema(example = "de", requiredMode = Schema.RequiredMode.REQUIRED) String inLanguage)
     implements AbstractDocumentSchema, JsonldResource {
 
   @Override

--- a/frontend/src/components/Pagination.spec.ts
+++ b/frontend/src/components/Pagination.spec.ts
@@ -17,7 +17,6 @@ const createMockSearchResult = (): SearchResult<CaseLaw> => ({
     deviatingDocumentNumber: [],
     inLanguage: "de",
     encoding: [],
-    highlightedFields: {},
   },
   textMatches: [],
 });

--- a/frontend/src/components/search/CaseLawSearchResult.spec.ts
+++ b/frontend/src/components/search/CaseLawSearchResult.spec.ts
@@ -26,7 +26,6 @@ const searchResult: SearchResult<CaseLaw> = {
     fileNumbers: ["123", "testing highlighted file number is here"],
     decisionName: ["Decision Name"],
     documentType: "Document Type",
-    highlightedFields: {},
   },
   textMatches: [],
 };

--- a/frontend/src/public/openapi.json
+++ b/frontend/src/public/openapi.json
@@ -2021,7 +2021,7 @@
           "@type": { "type": "string", "example": "SearchResultMatch" },
           "name": { "type": "string" },
           "text": { "type": "string" },
-          "location": { "type": "string" }
+          "location": { "type": ["string", "null"] }
         },
         "required": ["name", "text"]
       },
@@ -2585,14 +2585,7 @@
                 "type": "string",
                 "example": "/v1/case-law/ECLI:DE:FGRLP:1969:0905.IV85.68.0A"
               },
-              "inLanguage": { "type": "string", "example": "de" },
-              "highlightedFields": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "array",
-                  "items": { "type": "string" }
-                }
-              }
+              "inLanguage": { "type": "string", "example": "de" }
             }
           }
         ],
@@ -2605,7 +2598,6 @@
           "ecli",
           "encoding",
           "fileNumbers",
-          "highlightedFields",
           "inLanguage"
         ]
       },
@@ -2802,13 +2794,6 @@
           "encoding": {
             "type": "array",
             "items": { "$ref": "#/components/schemas/CaseLawEncodingSchema" }
-          },
-          "highlightedFields": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "array",
-              "items": { "type": "string" }
-            }
           }
         },
         "required": [
@@ -2820,7 +2805,6 @@
           "ecli",
           "encoding",
           "fileNumbers",
-          "highlightedFields",
           "inLanguage",
           "keywords"
         ]

--- a/frontend/src/types/api-generated.d.ts
+++ b/frontend/src/types/api-generated.d.ts
@@ -723,7 +723,7 @@ export interface components {
       "@type"?: string;
       name: string;
       text: string;
-      location?: string;
+      location?: string | null;
     };
     LiteratureSchema: {
       /** @example Literature */
@@ -1086,9 +1086,6 @@ export interface components {
       "@id": string;
       /** @example de */
       inLanguage: string;
-      highlightedFields: {
-        [key: string]: string[];
-      };
     });
     CollectionSchemaSearchMemberSchemaAbstractDocumentSchema: {
       /** @example hydra:Collection */
@@ -1232,9 +1229,6 @@ export interface components {
       /** @example de */
       inLanguage: string;
       encoding: components["schemas"]["CaseLawEncodingSchema"][];
-      highlightedFields: {
-        [key: string]: string[];
-      };
     };
     CourtSearchResult: {
       /** @example BGH Karlsruhe */

--- a/frontend/src/utils/anyDocument.spec.ts
+++ b/frontend/src/utils/anyDocument.spec.ts
@@ -29,7 +29,6 @@ describe("anyDocument", () => {
         deviatingDocumentNumber: [],
         inLanguage: "",
         encoding: [],
-        highlightedFields: {},
       };
 
       expect(isCaselaw(doc)).toBe(true);
@@ -98,7 +97,6 @@ describe("anyDocument", () => {
         deviatingDocumentNumber: [],
         inLanguage: "",
         encoding: [],
-        highlightedFields: {},
       };
 
       expect(isLegislation(doc)).toBe(false);
@@ -200,7 +198,6 @@ describe("anyDocument", () => {
         deviatingDocumentNumber: [],
         inLanguage: "",
         encoding: [],
-        highlightedFields: {},
       };
 
       expect(getIdentifier(doc)).toBe("4711");

--- a/frontend/src/utils/caseLaw.spec.ts
+++ b/frontend/src/utils/caseLaw.spec.ts
@@ -31,7 +31,6 @@ describe("caseLaw", () => {
           inLanguage: "de",
         },
       ],
-      highlightedFields: {},
     };
 
     it("returns the URL for a matching format", () => {


### PR DESCRIPTION
This PR removes the highlightedFields map form the caselaw schemas. Those are not used or mapped anywhere. We don't have highlighted Fields on any other api response schemas.