### PR TITLE
RISDEV-11283 reapply "responsive font size + minor fixes for mobile action menu"

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
   },
   "packageManager": "pnpm@10.28.1",
   "dependencies": {
-    "@digitalservicebund/ris-ui": "4.1.1",
+    "@digitalservicebund/ris-ui": "4.1.2",
     "@nuxtjs/mdc": "0.21.1",
     "@nuxtjs/sitemap": "8.0.13",
     "@sentry/nuxt": "10.49.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@digitalservicebund/ris-ui':
-        specifier: 4.1.1
-        version: 4.1.1(primevue@4.5.5(vue@3.5.32(typescript@5.9.3)))(tailwindcss@4.2.3)(vue@3.5.32(typescript@5.9.3))
+        specifier: 4.1.2
+        version: 4.1.2(primevue@4.5.5(vue@3.5.32(typescript@5.9.3)))(tailwindcss@4.2.3)(vue@3.5.32(typescript@5.9.3))
       '@nuxtjs/mdc':
         specifier: 0.21.1
         version: 0.21.1(magicast@0.5.2)
@@ -353,8 +353,8 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@digitalservicebund/ris-ui@4.1.1':
-    resolution: {integrity: sha512-LFvukpl3wRBDH5gJhBzZH3LJhMWmO7o9F6bnka0lqTXpDMWO37yF9YIN9AyihRwCuSqOZIZThWmMxTBXEwgJ3w==}
+  '@digitalservicebund/ris-ui@4.1.2':
+    resolution: {integrity: sha512-r7lEe/jECe8+yzonkDHLmcKNkCTwnYOhnppzI1F8fjO3WGHr/L2bjTetxsozljGylM02rla/PyLYYWzXD8apbg==}
     peerDependencies:
       primevue: ^4.0.0
       tailwindcss: ^4.0.0
@@ -6797,7 +6797,7 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@digitalservicebund/ris-ui@4.1.1(primevue@4.5.5(vue@3.5.32(typescript@5.9.3)))(tailwindcss@4.2.3)(vue@3.5.32(typescript@5.9.3))':
+  '@digitalservicebund/ris-ui@4.1.2(primevue@4.5.5(vue@3.5.32(typescript@5.9.3)))(tailwindcss@4.2.3)(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       primevue: 4.5.5(vue@3.5.32(typescript@5.9.3))
       tailwindcss: 4.2.3

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -7,6 +7,15 @@
 
 @theme {
   --max-width-prose: 45rem;
+
+  /* Added as part of RISDEV-11283 (mobile action menu) for initial responsive
+  typography. Should be moved to RIS UI when implementing RISDEV-10822 (new
+  breakpoints) */
+  --breakpoint-xs: 384px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 1024px;
+  --breakpoint-xl: 1280px;
+  --breakpoint-2xl: 1536px;
 }
 
 @layer base {
@@ -26,6 +35,13 @@
 
 @utility link-hover {
   @apply no-underline hover:underline;
+}
+
+/* Added as part of RISDEV-11283 (mobile action menu) for initial responsive
+typography. Should be moved to RIS UI when implementing all of responsive
+typography (RISDEV-10826). */
+@utility body-font {
+  @apply ris-body2-regular xs:ris-body1-regular;
 }
 
 mark {

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -7,15 +7,6 @@
 
 @theme {
   --max-width-prose: 45rem;
-
-  /* Added as part of RISDEV-11283 (mobile action menu) for initial responsive
-  typography. Should be moved to RIS UI when implementing RISDEV-10822 (new
-  breakpoints) */
-  --breakpoint-xs: 384px;
-  --breakpoint-md: 768px;
-  --breakpoint-lg: 1024px;
-  --breakpoint-xl: 1280px;
-  --breakpoint-2xl: 1536px;
 }
 
 @layer base {
@@ -41,7 +32,7 @@
 typography. Should be moved to RIS UI when implementing all of responsive
 typography (RISDEV-10826). */
 @utility body-font {
-  @apply ris-body2-regular xs:ris-body1-regular;
+  @apply ris-body2-regular sm:ris-body1-regular;
 }
 
 mark {

--- a/frontend/src/components/documents/actionMenu/ActionMenu.vue
+++ b/frontend/src/components/documents/actionMenu/ActionMenu.vue
@@ -51,12 +51,12 @@ const handleDrawerItemClick = async (item: ActionMenuItem) => {
         iconPos: 'right',
       }"
     >
-      <ul class="-mt-12">
+      <ul class="-mt-8">
         <li v-for="item in actions">
           <button
             v-if="item.disabled"
             type="button"
-            class="ris-body2-regular flex w-full cursor-not-allowed items-center gap-8 py-12 text-gray-800"
+            class="body-font flex w-full cursor-not-allowed items-center gap-8 py-12 text-gray-800"
             disabled
           >
             <component :is="item.iconComponent" class="shrink-0" />
@@ -65,7 +65,7 @@ const handleDrawerItemClick = async (item: ActionMenuItem) => {
 
           <NuxtLink
             v-else-if="item.url"
-            class="ris-body2-regular flex items-center gap-8 py-12 no-underline"
+            class="body-font flex items-center gap-8 py-12 no-underline"
             external
             :data-attr="(item as ActionMenuItem).analyticsId"
             :to="item.url"
@@ -78,7 +78,7 @@ const handleDrawerItemClick = async (item: ActionMenuItem) => {
           <button
             v-else
             type="button"
-            class="ris-body2-regular flex w-full items-center gap-8 py-12"
+            class="body-font flex w-full items-center gap-8 py-12"
             :data-attr="(item as ActionMenuItem).analyticsId"
             @click="handleDrawerItemClick(item)"
           >


### PR DESCRIPTION
#1914 broke some spacings on some devices by accidentally dropping the `sm` breakpoint, and was therefore reverted. This PR applies the changes again without changing the breakpoints. This means that the responsive typography in the action menu is applied at the correct breakpoint (`sm`), but what `sm` means currently differs from the design spec. Since changing the breakpoints requires some more changes across the application, this will be done in a different ticket.