### PR TITLE
Fix swagger button hover styling

### DIFF
--- a/api-docs/.vitepress/theme/components/SwaggerButton.vue
+++ b/api-docs/.vitepress/theme/components/SwaggerButton.vue
@@ -8,7 +8,7 @@ const { theme } = useData();
   <ButtonLink
     :href="theme.swaggerUiUrl"
     target="_blank"
-    class="not-prose mt-16 bg-blue-800 hover:bg-blue-600 p-16 ris-label2-bold text-white no-underline focus:text-white focus-visible:text-white"
+    class="not-prose mt-16 bg-blue-800 hover:bg-blue-600 hover:text-white p-16 ris-label2-bold text-white no-underline focus:text-white focus-visible:text-white"
   >
     Test the API in Swagger
   </ButtonLink>

--- a/api-docs/.vitepress/theme/layout/Sidebar.vue
+++ b/api-docs/.vitepress/theme/layout/Sidebar.vue
@@ -12,7 +12,7 @@ import Logo from "../components/Logo.vue";
       <nav class="mt-96 overflow-y h-full w-full py-8">
         <SidebarMenu :model="menuItems" />
       </nav>
-      <SwaggerButton />
+      <SwaggerButton class="mb-8" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
- fix button hover text color
- give swagger link button in sidebar bottom margin so the focus state border is not cut off

RISDEV-11297