### PR TITLE
Remove openapi.json upload to docs repo

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -73,20 +73,24 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: "21.0"
           distribution: "temurin"
           cache: gradle
+
       - name: Cache SonarQube packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
+
       - name: Grant execute permission for gradlew
         working-directory: ./backend
         run: chmod +x gradlew
+
       - name: Run Tests and Scan with SonarQube
         if: ${{ github.actor != 'dependabot[bot]' }}
         id: sonarqube-tests
@@ -94,25 +98,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         working-directory: ./backend
+        # Running sonar includes unit and integration test
         run: ./gradlew sonar
-      - name: Upload OpenAPI specification
-        if: ${{ steps.sonarqube-tests.outcome == 'success' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: openapi.json
-          retention-days: 3
-          path: backend/out/openapi.json
-      - name: Run unit tests ( without SonarQube)
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        working-directory: ./backend
-        run: ./gradlew integrationTest
-      - name: Run integration tests (without SonarQube, for dependabot)
-        if: ${{ github.actor == 'dependabot[bot]' }}
-        working-directory: ./backend
-        run: ./gradlew integrationTest
+
       - name: Check SonarQube Quality Gate
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
         uses: sonarsource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # v1.2.0
         if: ${{ github.actor != 'dependabot[bot]' }}
         with:
@@ -120,6 +109,14 @@ jobs:
         timeout-minutes: 3 # Force to fail step after specific time
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+        # Dependabot does not have access to org tokens like SONAR_TOKEN
+        # thus run the tests without sonar in dependabot PRs
+      - name: Run unit and integration tests
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        working-directory: ./backend
+        run: ./gradlew integrationTest
+
       - name: Send status to Slack
         uses: digitalservicebund/notify-on-failure-gha@671832f192aee0a068fd92b2f6deb975df794a84 # v1.6.1
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
@@ -187,7 +184,6 @@ jobs:
       trivy-java-db-repository: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
       trivy-offile-scan: true
 
-
   generate-backend-code-documentation:
     runs-on: ubuntu-latest
     steps:
@@ -247,37 +243,3 @@ jobs:
               -m "From commit: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}" &&
             git push origin main &&
             echo "Pushed reports to ${{ github.server_url }}/${{ env.reports-repo }}" >> $GITHUB_STEP_SUMMARY
-
-  push-openapi-spec:
-    runs-on: ubuntu-latest
-    env:
-      documentation-repo: digitalservicebund/ris-portal-docs
-    needs:
-      - backend-tests-and-code-quality
-    if: ${{ github.ref == 'refs/heads/main' }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: ${{ env.documentation-repo }}
-          token: ${{ secrets.DOCS_REPO_GITHUB_TOKEN }}
-      - name: Setup git config
-        run: |
-          git config user.name "${{ github.repository }}"
-          # This email identifies the commit as GitHub Actions - see https://github.com/orgs/community/discussions/26560
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: Download OpenAPI spec artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          path: docs/data/
-          name: openapi.json
-      - name: Push reports
-        env:
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-        run: |
-          git add docs/data/openapi.json &&
-          git diff-index --cached --quiet HEAD ||
-            git commit \
-              -m "$COMMIT_MESSAGE" \
-              -m "From commit: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}" &&
-            git push origin main &&
-            echo "Pushed documentation to ${{ github.server_url }}/${{ env.documentation-repo }}" >> $GITHUB_STEP_SUMMARY

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -32,9 +32,6 @@ swagger:
     url: http://localhost:8090
     description: Local development server
 
-feature-flags:
-  advanced-search: true
-
 springdoc:
   swagger-ui:
     supportedSubmitMethods: ["get"]

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/SwaggerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/SwaggerIntegrationTest.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -21,12 +20,12 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
 
 /*
- * Advanced search functionality is disabled in this test so it doesn't show up in the generated openapi.json file.
+ * Test that generates an openapi.json by running the backend and querying the /v3/api-docs
+ * endpoint. The file is written to the frontend so it can be used there for type generation.
  */
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {
-      "feature-flags.advanced-search=false",
       "swagger.server.url=https://testphase.rechtsinformationen.bund.de",
       "swagger.server.description=Public API (preview)"
     })
@@ -44,21 +43,17 @@ class SwaggerIntegrationTest extends ContainersIntegrationBase {
         .andDo(
             item -> {
               byte[] content = item.getResponse().getContentAsByteArray();
-              // Maintaining both the frontend /docs url and portal-docs-repo
-              List.of("./../frontend/src/public", "./out")
-                  .forEach(
-                      path -> {
-                        Path outDir = Paths.get(path);
-                        try {
-                          Files.createDirectories(outDir);
-                          File outputFile = new File(outDir.toFile(), "openapi.json");
-                          try (FileOutputStream outputStream = new FileOutputStream(outputFile)) {
-                            outputStream.write(content);
-                          }
-                        } catch (IOException exception) {
-                          throw new RuntimeException(exception);
-                        }
-                      });
+              Path outDir = Paths.get("./../frontend/src/public");
+
+              try {
+                Files.createDirectories(outDir);
+                File outputFile = new File(outDir.toFile(), "openapi.json");
+                try (FileOutputStream outputStream = new FileOutputStream(outputFile)) {
+                  outputStream.write(content);
+                }
+              } catch (IOException exception) {
+                throw new RuntimeException(exception);
+              }
             })
         .andExpect(
             jsonPath(


### PR DESCRIPTION
- adapt test that generates the openapi.json so it is now only added to the frontend
- remove unused flag
- remove redundant test step in backend pipeline

I will remove the `DOCS_REPO_GITHUB_TOKEN` after it is merged.

RISDEV-11176