### PR TITLE
RISDEV-0000 tidy + optimize PrimeVue imports

### DIFF
--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -53,12 +53,23 @@
             // Enforce consistent import path for icons
             "group": ["virtual:icons/**"],
             "message": "Import icons from ~icons/..."
+          },
+          {
+            // Enforce consistent import for PrimeVue components. Note that this
+            // is a 99% solution and some exceptions are legitimate (most
+            // relevant for us: Tooltip and useToast). However adding these to
+            // the rule here would be very complicated. Use a `// oxlint-disable
+            // no-restricted-imports` directive when you need them.
+            "group": ["primevue/*"],
+            "allowTypeImports": true,
+            "message": "Import PrimeVue components from \"primevue\""
           }
         ],
         "paths": [
-          // Importing individual utilities from lodash fails in the production build,
-          // see https://github.com/nuxt/nuxt/issues/21034. This requires some additional
-          // setup to fix; in the meantime enforce the default import to prevent accidents.
+          // Importing individual utilities from lodash fails in the production
+          // build, see https://github.com/nuxt/nuxt/issues/21034. This requires
+          // some additional setup to fix; in the meantime enforce the default
+          // import to prevent accidents.
           {
             "name": "lodash",
             "allowImportNames": ["default"]

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -55,6 +55,9 @@ export default defineNuxtConfig({
         },
       }),
     ],
+    optimizeDeps: {
+      include: ["primevue", "@digitalservicebund/ris-ui/primevue"],
+    },
   },
   typescript: {
     typeCheck: process.env.CI !== "true",

--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Toast from "primevue/toast";
+import { Toast } from "primevue";
 
 useHead({
   titleTemplate: (pageTitle) =>

--- a/frontend/src/components/AutoComplete.vue
+++ b/frontend/src/components/AutoComplete.vue
@@ -1,11 +1,9 @@
 <script lang="ts" setup>
-import IcBaselineKeyboardArrowDown from "~icons/ic/baseline-keyboard-arrow-down";
-import IcBaselineClose from "~icons/ic/baseline-close";
-import AutoCompleteComponent, {
-  type AutoCompleteProps as BaseAutoCompleteProps,
-} from "primevue/autocomplete";
-import ProgressSpinner from "primevue/progressspinner";
+import { AutoComplete as BaseAutoComplete, ProgressSpinner } from "primevue";
+import { type AutoCompleteProps as BaseAutoCompleteProps } from "primevue/autocomplete";
 import { ref } from "vue";
+import IcBaselineClose from "~icons/ic/baseline-close";
+import IcBaselineKeyboardArrowDown from "~icons/ic/baseline-keyboard-arrow-down";
 
 export interface AutoCompleteSuggestion {
   id: string;
@@ -85,7 +83,7 @@ const dropdownButtonFocus = ref(false);
 </script>
 
 <template>
-  <AutoCompleteComponent
+  <BaseAutoComplete
     ref="autoCompleteRef"
     v-bind="$attrs"
     :suggestions="props.suggestions"
@@ -158,5 +156,5 @@ const dropdownButtonFocus = ref(false);
         </div>
       </div>
     </template>
-  </AutoCompleteComponent>
+  </BaseAutoComplete>
 </template>

--- a/frontend/src/components/DateInput.spec.ts
+++ b/frontend/src/components/DateInput.spec.ts
@@ -1,6 +1,6 @@
 import { userEvent } from "@testing-library/user-event";
 import { render, screen } from "@testing-library/vue";
-import InputText from "primevue/inputtext";
+import { InputText } from "primevue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
 import type { ValidationError } from "./DateInput.vue";

--- a/frontend/src/components/SingleAccordion.vue
+++ b/frontend/src/components/SingleAccordion.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import Accordion from "primevue/accordion";
-import AccordionContent from "primevue/accordioncontent";
-import AccordionHeader from "primevue/accordionheader";
-import AccordionPanel from "primevue/accordionpanel";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionHeader,
+  AccordionPanel,
+} from "primevue";
 import { computed } from "vue";
 import IcOutlineExpandCircleDown from "~icons/ic/outline-expand-circle-down";
 

--- a/frontend/src/components/YearInput.spec.ts
+++ b/frontend/src/components/YearInput.spec.ts
@@ -1,6 +1,6 @@
 import { userEvent } from "@testing-library/user-event";
 import { render, screen } from "@testing-library/vue";
-import InputText from "primevue/inputtext";
+import { InputText } from "primevue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
 import YearInput from "./YearInput.vue";

--- a/frontend/src/components/analytics/ConsentBanner.vue
+++ b/frontend/src/components/analytics/ConsentBanner.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import PrimeVueButton from "primevue/button";
+import { Button } from "primevue";
 import { usePostHog } from "~/composables/usePostHog";
 
 const { userConsent, isBannerVisible, setTracking } = usePostHog();
@@ -44,7 +44,7 @@ const handleSetTracking = async (value: boolean) => {
           @submit.prevent="handleSetTracking(true)"
         >
           <input type="hidden" name="consent" value="true" />
-          <PrimeVueButton
+          <Button
             label="Akzeptieren"
             data-testid="accept-cookie"
             type="submit"
@@ -57,11 +57,7 @@ const handleSetTracking = async (value: boolean) => {
           @submit.prevent="handleSetTracking(false)"
         >
           <input type="hidden" name="consent" value="false" />
-          <PrimeVueButton
-            label="Ablehnen"
-            data-testid="decline-cookie"
-            type="submit"
-          />
+          <Button label="Ablehnen" data-testid="decline-cookie" type="submit" />
         </form>
         <NuxtLink :to="{ name: 'data-protection' }" class="ris-link1-regular">
           Datenschutzerklärung

--- a/frontend/src/components/analytics/FeedbackForm.global.vue
+++ b/frontend/src/components/analytics/FeedbackForm.global.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { Button } from "primevue";
-import PrimevueTextarea from "primevue/textarea";
 import { NuxtLink } from "#components";
+import { Button, Textarea } from "primevue";
 import { usePostHog } from "~/composables/usePostHog";
 import { isStringEmpty } from "~/utils/textFormatting";
 import ErrorOutline from "~icons/ic/outline-error-outline";
@@ -120,7 +119,7 @@ watch(
           <label :for="feedbackMessageId" class="ris-label2-regular">
             Feedback
           </label>
-          <PrimevueTextarea
+          <Textarea
             :id="feedbackMessageId"
             v-model="feedback"
             :invalid="!isStringEmpty(errorMessage)"

--- a/frontend/src/components/documents/actionMenu/ActionMenu.spec.ts
+++ b/frontend/src/components/documents/actionMenu/ActionMenu.spec.ts
@@ -1,6 +1,7 @@
 import { renderSuspended } from "@nuxt/test-utils/runtime";
 import { userEvent } from "@testing-library/user-event";
 import { screen, waitFor } from "@testing-library/vue";
+// oxlint-disable-next-line no-restricted-imports
 import Tooltip from "primevue/tooltip";
 import { vi } from "vitest";
 import ActionMenu, {

--- a/frontend/src/components/documents/actionMenu/AdministrativeDirectiveActionMenu.spec.ts
+++ b/frontend/src/components/documents/actionMenu/AdministrativeDirectiveActionMenu.spec.ts
@@ -1,6 +1,7 @@
 import { mockNuxtImport, renderSuspended } from "@nuxt/test-utils/runtime";
 import { userEvent } from "@testing-library/user-event/dist/cjs/index.js";
 import { screen } from "@testing-library/vue";
+// oxlint-disable-next-line no-restricted-imports
 import Tooltip from "primevue/tooltip";
 import { describe, expect, it, vi } from "vitest";
 import AdministrativeDirectiveActionMenu from "~/components/documents/actionMenu/AdministrativeDirectiveActionMenu.vue";

--- a/frontend/src/components/documents/actionMenu/CaseLawActionMenu.spec.ts
+++ b/frontend/src/components/documents/actionMenu/CaseLawActionMenu.spec.ts
@@ -1,6 +1,7 @@
 import { mockNuxtImport, renderSuspended } from "@nuxt/test-utils/runtime";
 import { userEvent } from "@testing-library/user-event/dist/cjs/index.js";
 import { screen } from "@testing-library/vue";
+// oxlint-disable-next-line no-restricted-imports
 import Tooltip from "primevue/tooltip";
 import { describe, expect, it, vi } from "vitest";
 import CaseLawActionMenu from "~/components/documents/actionMenu/CaseLawActionMenu.vue";

--- a/frontend/src/components/documents/actionMenu/LiteratureActionMenu.spec.ts
+++ b/frontend/src/components/documents/actionMenu/LiteratureActionMenu.spec.ts
@@ -1,6 +1,7 @@
 import { mockNuxtImport, renderSuspended } from "@nuxt/test-utils/runtime";
 import { userEvent } from "@testing-library/user-event/dist/cjs/index.js";
 import { screen } from "@testing-library/vue";
+// oxlint-disable-next-line no-restricted-imports
 import Tooltip from "primevue/tooltip";
 import { describe, expect, it, vi } from "vitest";
 import LiteratureActionMenu from "~/components/documents/actionMenu/LiteratureActionMenu.vue";

--- a/frontend/src/components/documents/actionMenu/NormActionMenu.spec.ts
+++ b/frontend/src/components/documents/actionMenu/NormActionMenu.spec.ts
@@ -1,6 +1,7 @@
 import { mockNuxtImport, renderSuspended } from "@nuxt/test-utils/runtime";
 import { userEvent } from "@testing-library/user-event/dist/cjs/index.js";
 import { screen } from "@testing-library/vue";
+// oxlint-disable-next-line no-restricted-imports
 import Tooltip from "primevue/tooltip";
 import { describe, expect, it, vi } from "vitest";
 import NormActionMenu from "~/components/documents/actionMenu/NormActionMenu.vue";

--- a/frontend/src/components/documents/actionMenu/NormTranslationActionMenu.spec.ts
+++ b/frontend/src/components/documents/actionMenu/NormTranslationActionMenu.spec.ts
@@ -1,6 +1,7 @@
 import { mockNuxtImport, renderSuspended } from "@nuxt/test-utils/runtime";
 import { userEvent } from "@testing-library/user-event/dist/cjs/index.js";
 import { screen } from "@testing-library/vue";
+// oxlint-disable-next-line no-restricted-imports
 import Tooltip from "primevue/tooltip";
 import { describe, expect, it, vi } from "vitest";
 import NormTranslationActionMenu from "~/components/documents/actionMenu/NormTranslationActionMenu.vue";

--- a/frontend/src/components/documents/norms/NormVersionList.vue
+++ b/frontend/src/components/documents/norms/NormVersionList.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import _ from "lodash";
-import Column from "primevue/column";
-import DataTable from "primevue/datatable";
+import { Column, DataTable } from "primevue";
 import Badge from "~/components/Badge.vue";
 import type { LegislationExpression } from "~/types/api";
 import { dateFormattedDDMMYYYY } from "~/utils/dateFormatting";

--- a/frontend/src/components/documents/norms/VersionWarningMessage.vue
+++ b/frontend/src/components/documents/norms/VersionWarningMessage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import Message from "primevue/message";
 import type { RouteLocationRaw } from "#vue-router";
+import { Message } from "primevue";
 import type { LegislationExpression } from "~/types/api";
 import { dateFormattedDDMMYYYY } from "~/utils/dateFormatting";
 import type { ValidityStatus } from "~/utils/norm";

--- a/frontend/src/components/search/CategoryFilter.vue
+++ b/frontend/src/components/search/CategoryFilter.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { MenuItem, MenuItemCommandEvent } from "primevue/menuitem";
-import PanelMenu from "primevue/panelmenu";
+import { PanelMenu } from "primevue";
 import {
   computeExpandedKeys,
   categoryFilterItems,

--- a/frontend/src/components/search/DateRangeFilter.vue
+++ b/frontend/src/components/search/DateRangeFilter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import PrimevueSelect from "primevue/select";
+import { Select } from "primevue";
 import type { ValidationError } from "~/components/DateInput.vue";
 import type {
   DateFilterValue,
@@ -78,7 +78,7 @@ const toDate = computed({
   <div class="flex flex-col gap-16">
     <span class="flex flex-col gap-8">
       <label :for="dateModeSelectId" class="ris-label2-regular">Zeitraum</label>
-      <PrimevueSelect
+      <Select
         :id="dateModeSelectId"
         v-model="selectedType"
         :options="items"

--- a/frontend/src/components/search/ItemsPerPageDropdown.vue
+++ b/frontend/src/components/search/ItemsPerPageDropdown.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import PrimevueSelect from "primevue/select";
+import { Select } from "primevue";
 
 const model = defineModel<number>({ required: true });
 
@@ -27,7 +27,7 @@ const itemsPerPageSelectId = useId();
     <label :for="itemsPerPageSelectId" class="ris-label2-regular"
       >Einträge pro Seite</label
     >
-    <PrimevueSelect
+    <Select
       :id="itemsPerPageSelectId"
       v-model="itemsPerPage"
       option-label="label"

--- a/frontend/src/components/search/SortSelect.vue
+++ b/frontend/src/components/search/SortSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import PrimevueSelect from "primevue/select";
+import { Select } from "primevue";
 import { computed } from "vue";
 import { DocumentKind } from "~/types/api";
 import { sortMode } from "~/utils/search/sortMode";
@@ -67,7 +67,7 @@ const sortSelectId = useId();
 <template>
   <span class="flex w-auto items-center gap-8">
     <label :for="sortSelectId" class="ris-label2-regular">Sortieren nach</label>
-    <PrimevueSelect
+    <Select
       :id="sortSelectId"
       v-model="model"
       scroll-height="20rem"

--- a/frontend/src/components/search/YearRangeFilter.vue
+++ b/frontend/src/components/search/YearRangeFilter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import PrimevueSelect from "primevue/select";
+import { Select } from "primevue";
 import YearInput from "~/components/YearInput.vue";
 import type {
   DateFilterValue,
@@ -168,7 +168,7 @@ const hasMultipleInputs = computed(() => show.value.after && show.value.before);
   <div class="flex flex-col gap-16">
     <span class="flex flex-col gap-8">
       <label :for="yearModeSelectId" class="ris-label2-regular">Zeitraum</label>
-      <PrimevueSelect
+      <Select
         :id="yearModeSelectId"
         :model-value="mode"
         :options="items"

--- a/frontend/src/components/staticContent/ConsentStatus.global.vue
+++ b/frontend/src/components/staticContent/ConsentStatus.global.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import PrimeVueButton from "primevue/button";
-import Message from "primevue/message";
+import { Button, Message } from "primevue";
 import { CONSENT_COOKIE_NAME, usePostHog } from "~/composables/usePostHog";
 import IconCheck from "~icons/ic/check";
 import IconClose from "~icons/ic/close";
@@ -69,7 +68,7 @@ async function handleSetTracking(value: boolean) {
       @submit.prevent="handleSetTracking(false)"
     >
       <input type="hidden" name="consent" value="false" />
-      <PrimeVueButton
+      <Button
         label="Cookies ablehnen"
         data-testid="settings-decline-cookie"
         type="submit"
@@ -82,7 +81,7 @@ async function handleSetTracking(value: boolean) {
       @submit.prevent="handleSetTracking(true)"
     >
       <input type="hidden" name="consent" value="true" />
-      <PrimeVueButton
+      <Button
         label="Cookies akzeptieren"
         data-testid="settings-accept-cookie"
         type="submit"

--- a/frontend/src/composables/useActionMenuItem/useCopyUrlActionItem.ts
+++ b/frontend/src/composables/useActionMenuItem/useCopyUrlActionItem.ts
@@ -1,3 +1,4 @@
+// oxlint-disable-next-line no-restricted-imports
 import { useToast } from "primevue/usetoast";
 import type { ActionMenuItem } from "~/components/documents/actionMenu/ActionMenu.vue";
 import IcBaselineCheck from "~icons/ic/baseline-check";

--- a/frontend/src/pages/advanced-search/-help.vue
+++ b/frontend/src/pages/advanced-search/-help.vue
@@ -2,7 +2,7 @@
 // This is an old version of the help page that is not currently in use, but will
 // be reworked at some point.
 
-import Select from "primevue/select";
+import { Select } from "primevue";
 import { usePrivateFeaturesFlag } from "~/composables/usePrivateFeaturesFlag";
 import {
   type FieldType,

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { Button } from "primevue";
-import Message from "primevue/message";
 import { ExternalLink, NuxtLink } from "#components";
+import { Button, Message } from "primevue";
 import bmjvLogo from "~/assets/img/BMJV_de_v1__Web_farbig.svg";
 import SimpleSearchInput from "~/components/search/SimpleSearchInput.vue";
 import { usePrivateFeaturesFlag } from "~/composables/usePrivateFeaturesFlag";

--- a/frontend/src/pages/translations/[id].vue
+++ b/frontend/src/pages/translations/[id].vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { Tab, TabList, Tabs } from "primevue";
-import Message from "primevue/message";
-import { computed } from "vue";
 import { NuxtLink } from "#components";
+import { Message, Tab, TabList, Tabs } from "primevue";
+import { computed } from "vue";
 import type { BreadcrumbItem } from "~/components/Breadcrumbs.vue";
 import DetailsList from "~/components/DetailsList.vue";
 import DetailsListEntry from "~/components/DetailsListEntry.vue";

--- a/frontend/src/plugins/risUi.ts
+++ b/frontend/src/plugins/risUi.ts
@@ -1,3 +1,4 @@
+// oxlint-disable no-restricted-imports -- PrimeVue plugins/directives are not exported from the main entry
 import "@digitalservicebund/ris-ui/fonts.css";
 import { RisUiLocale, RisUiTheme } from "@digitalservicebund/ris-ui/primevue";
 import PrimeVue from "primevue/config";

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
 import { config } from "@vue/test-utils";
+// oxlint-disable-next-line no-restricted-imports
 import PrimeVue from "primevue/config";
 import { vi } from "vitest";
 import "~/tests/cookieStoreMock";


### PR DESCRIPTION
This PR refactors imports of PrimeVue components to consistently import from `primevue` instead of `primevue/component` wherever possible, and adds a linter rule to enforce the pattern for new code. This allows us to pre-bundle the PrimeVue package during development, which should dramatically reduce flickering and erratic page reloading due to dependency optimization.

I deliberately chose not to optimize _all_ possible dependencies, despite the Nuxt dev server suggesting so, since listing everything we need in the Vite config would be annoying to maintain 😅 