### PR TITLE
Set sensible minimal default permissions for all workflows

### DIFF
--- a/.github/workflows/api-docs-pipeline.yml
+++ b/.github/workflows/api-docs-pipeline.yml
@@ -20,6 +20,9 @@ on:
 env:
   API_DOCS_ROOT: ./api-docs
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -22,6 +22,9 @@ env:
   TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
   TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
 
+permissions:
+  contents: read
+
 jobs:
   validate-gradle-wrapper:
     runs-on: ubuntu-latest
@@ -69,6 +72,9 @@ jobs:
   backend-tests-and-code-quality:
     name: Backend tests and code quality checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read # SonarQube uses GITHUB_TOKEN to read PR information for analysis decoration
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/clean-up-images.yml
+++ b/.github/workflows/clean-up-images.yml
@@ -7,6 +7,8 @@ jobs:
   clean:
     runs-on: ubuntu-latest
     name: Delete old images
+    permissions:
+      packages: write
     steps:
       - uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb # v3.0.1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ github.ref == 'refs/heads/main' }}
     concurrency:
       # Make sure that the deploy-step is always executed in series (this applies across multiple workflows)

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -13,6 +13,9 @@ on:
         type: string
         default: ghcr.io
 
+permissions:
+  contents: read
+
 jobs:
   check-frontend:
     runs-on: ubuntu-latest
@@ -106,9 +109,6 @@ jobs:
   frontend-file-scan:
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
-      packages: write
-      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/pipeline-e2e.yml
+++ b/.github/workflows/pipeline-e2e.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   RUN_ID: ${{ github.run_id }}
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,6 +15,9 @@ on:
   # Allow to run this workflow manually
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   RUN_ID: ${{ github.run_id }}
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   RUN_ID: ${{ github.run_id }}
 


### PR DESCRIPTION
- add minimal default permissions to workflows
- hopefully this resolves most of the "Workflow does not contain permissions" issues [reported by codeQL ](https://github.com/digitalservicebund/ris-search/security/code-scanning)

RISDEV-0000