### PR TITLE
RISDEV-10226 search pagination accessibility + page title

### DIFF
--- a/frontend/e2e/advancedSearch.spec.ts
+++ b/frontend/e2e/advancedSearch.spec.ts
@@ -104,7 +104,7 @@ test.describe("general advanced search page features", () => {
     const pagination = page.getByRole("navigation", { name: "Paginierung" });
     await expect(pagination).toHaveText(/Seite 1: Treffer 1–10 von \d+/);
 
-    await page.getByLabel("nächste Ergebnisse").click();
+    await pagination.getByRole("link", { name: "Weiter" }).click();
     await page.waitForURL(/pageIndex=1/);
 
     expect(resultCounter).toHaveText(nonZeroResultCount);
@@ -115,9 +115,55 @@ test.describe("general advanced search page features", () => {
     expect(await searchResults.count()).toBeGreaterThan(1);
     await expect(pagination).toHaveText(/Seite 2: Treffer 11–\d+ von \d+/);
 
-    await page.getByLabel("vorherige Ergebnisse").click();
+    await pagination.getByRole("link", { name: "Zurück" }).click();
     await page.waitForURL(/pageIndex=0/);
     await expect(searchResults).toHaveCount(10);
+  });
+
+  test("page title updates with page number on pagination", async ({
+    page,
+  }) => {
+    await navigate(
+      page,
+      "/advanced-search?documentKind=R&dateFilterType=period&dateFilterFrom=2023-01-01&dateFilterTo=2025-12-31&itemsPerPage=10",
+    );
+
+    await expect(page).toHaveTitle(/^Erweiterte Suche \|/);
+
+    await page
+      .getByRole("navigation", { name: "Paginierung" })
+      .getByRole("link", { name: "Weiter" })
+      .click();
+    await page.waitForURL(/pageIndex=1/);
+
+    await expect(page).toHaveTitle(/Erweiterte Suche, Seite 2/);
+
+    await page
+      .getByRole("navigation", { name: "Paginierung" })
+      .getByRole("link", { name: "Zurück" })
+      .click();
+    await page.waitForURL(/pageIndex=0/);
+
+    await expect(page).toHaveTitle(/^Erweiterte Suche \|/);
+  });
+
+  test("focuses first search result after pagination", async ({ page }) => {
+    await navigate(
+      page,
+      "/advanced-search?documentKind=R&dateFilterType=period&dateFilterFrom=2023-01-01&dateFilterTo=2025-12-31&itemsPerPage=10",
+    );
+
+    await page
+      .getByRole("navigation", { name: "Paginierung" })
+      .getByRole("link", { name: "Weiter" })
+      .click();
+    await page.waitForURL(/pageIndex=1/);
+
+    const firstResultLink = page
+      .getByRole("list", { name: "Suchergebnisse" })
+      .getByRole("link")
+      .first();
+    await expect(firstResultLink).toBeFocused();
   });
 
   test("sort by date in ascending order", async ({ page }) => {

--- a/frontend/e2e/simpleSearch.spec.ts
+++ b/frontend/e2e/simpleSearch.spec.ts
@@ -143,7 +143,7 @@ test.describe("general search page features", () => {
     const pagination = page.getByRole("navigation", { name: "Paginierung" });
     await expect(pagination).toHaveText(/Seite 1: Treffer 1–10 von \d+/);
 
-    await page.getByLabel("nächste Ergebnisse").click();
+    await pagination.getByRole("link", { name: "Weiter" }).click();
     await page.waitForURL(/pageIndex=1/);
 
     await expect(resultCounter).toHaveText(nonZeroResultCount);
@@ -154,9 +154,49 @@ test.describe("general search page features", () => {
     expect(await searchResults.count()).toBeGreaterThan(1);
     await expect(pagination).toHaveText(/Seite 2: Treffer 11–\d+ von \d+/);
 
-    await page.getByLabel("vorherige Ergebnisse").click();
+    await pagination.getByRole("link", { name: "Zurück" }).click();
     await page.waitForURL(/pageIndex=0/);
     await expect(searchResults).toHaveCount(10);
+  });
+
+  test("page title updates with page number on pagination", async ({
+    page,
+  }) => {
+    await navigate(page, "/search?query=und");
+
+    await expect(page).toHaveTitle(/und — Suche \|/);
+
+    await page
+      .getByRole("navigation", { name: "Paginierung" })
+      .getByRole("link", { name: "Weiter" })
+      .click();
+    await page.waitForURL(/pageIndex=1/);
+
+    await expect(page).toHaveTitle(/und — Suche, Seite 2/);
+
+    await page
+      .getByRole("navigation", { name: "Paginierung" })
+      .getByRole("link", { name: "Zurück" })
+      .click();
+    await page.waitForURL(/pageIndex=0/);
+
+    await expect(page).toHaveTitle(/und — Suche \|/);
+  });
+
+  test("focuses first search result after pagination", async ({ page }) => {
+    await navigate(page, "/search?query=und");
+
+    await page
+      .getByRole("navigation", { name: "Paginierung" })
+      .getByRole("link", { name: "Weiter" })
+      .click();
+    await page.waitForURL(/pageIndex=1/);
+
+    const firstResultLink = page
+      .getByRole("list", { name: "Suchergebnisse" })
+      .getByRole("link")
+      .first();
+    await expect(firstResultLink).toBeFocused();
   });
 
   test("sort by date in ascending order", async ({ page }) => {
@@ -1106,7 +1146,10 @@ noJsTest("pagination works without JavaScript", async ({ page }) => {
   await expect(getResultCounter(page)).toHaveText(nonZeroResultCount);
   await expect(getSearchResults(page)).toHaveCount(10);
 
-  await page.getByLabel("nächste Ergebnisse").click();
+  await page
+    .getByRole("navigation", { name: "Paginierung" })
+    .getByRole("link", { name: "Weiter" })
+    .click();
   await page.waitForURL(/pageIndex=1/);
 
   await expect(getResultCounter(page)).toHaveText(nonZeroResultCount);
@@ -1116,7 +1159,10 @@ noJsTest("pagination works without JavaScript", async ({ page }) => {
   // exact.
   expect(await getSearchResults(page).count()).toBeGreaterThan(1);
 
-  await page.getByLabel("vorherige Ergebnisse").click();
+  await page
+    .getByRole("navigation", { name: "Paginierung" })
+    .getByRole("link", { name: "Zurück" })
+    .click();
   expect(page).not.toHaveURL(/pageIndex=\d+/);
 
   await expect(getResultCounter(page)).toHaveText(nonZeroResultCount);

--- a/frontend/src/components/Pagination.spec.ts
+++ b/frontend/src/components/Pagination.spec.ts
@@ -89,20 +89,12 @@ describe("Pagination", () => {
   });
 
   it("renders navigation buttons when there are multiple pages", async () => {
-    const page = createMockPage();
-    await renderSuspended(Pagination, {
-      props: { page },
-    });
-
-    expect(screen.getByLabelText("vorherige Ergebnisse")).toBeInTheDocument();
-    expect(screen.getByLabelText("nächste Ergebnisse")).toBeInTheDocument();
-  });
-
-  it("disables previous button on first page", async () => {
     const page = createMockPage({
+      "@id": "/api/search?pageIndex=1&size=10",
       view: {
         first: "/api/search?pageIndex=0&size=10",
-        next: "/api/search?pageIndex=1&size=10",
+        previous: "/api/search?pageIndex=0&size=10",
+        next: "/api/search?pageIndex=2&size=10",
         last: "/api/search?pageIndex=9&size=10",
       },
     });
@@ -110,15 +102,28 @@ describe("Pagination", () => {
       props: { page },
     });
 
-    expect(
-      screen.getByRole("button", { name: "vorherige Ergebnisse" }),
-    ).toBeDisabled();
-    expect(
-      screen.getByRole("link", { name: "nächste Ergebnisse" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Zurück" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Weiter" })).toBeInTheDocument();
   });
 
-  it("disables next button on last page", async () => {
+  it("hides previous button from accessibility tree on first page", async () => {
+    const page = createMockPage({
+      view: {
+        first: "/api/search?pageIndex=0&size=10",
+        next: "/api/search?pageIndex=1&size=10",
+        last: "/api/search?pageIndex=9&size=10",
+      },
+    });
+    await renderSuspended(Pagination, { props: { page } });
+
+    expect(
+      screen.queryByRole("button", { name: "Zurück" }),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByRole("link", { name: "Weiter" })).toBeInTheDocument();
+  });
+
+  it("hides next button from accessibility tree on last page", async () => {
     const page = createMockPage({
       "@id": "/api/search?pageIndex=9&size=10",
       view: {
@@ -127,16 +132,13 @@ describe("Pagination", () => {
         last: "/api/search?pageIndex=9&size=10",
       },
     });
-    await renderSuspended(Pagination, {
-      props: { page },
-    });
+    await renderSuspended(Pagination, { props: { page } });
+
+    expect(screen.getByRole("link", { name: "Zurück" })).toBeInTheDocument();
 
     expect(
-      screen.getByRole("link", { name: "vorherige Ergebnisse" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "nächste Ergebnisse" }),
-    ).toBeDisabled();
+      screen.queryByRole("button", { name: "Weiter" }),
+    ).not.toBeInTheDocument();
   });
 
   it("next button links to correct page", async () => {
@@ -145,7 +147,7 @@ describe("Pagination", () => {
       props: { page },
     });
 
-    const nextLink = screen.getByRole("link", { name: "nächste Ergebnisse" });
+    const nextLink = screen.getByRole("link", { name: "Weiter" });
     expect(nextLink).toHaveAttribute("href", "/?pageIndex=1");
   });
 
@@ -163,9 +165,7 @@ describe("Pagination", () => {
       props: { page },
     });
 
-    const previousLink = screen.getByRole("link", {
-      name: "vorherige Ergebnisse",
-    });
+    const previousLink = screen.getByRole("link", { name: "Zurück" });
     expect(previousLink).toHaveAttribute("href", "/?pageIndex=1");
   });
 
@@ -183,9 +183,7 @@ describe("Pagination", () => {
       props: { page },
     });
 
-    const previousLink = screen.getByRole("link", {
-      name: "vorherige Ergebnisse",
-    });
+    const previousLink = screen.getByRole("link", { name: "Zurück" });
     expect(previousLink).toHaveAttribute("href", "/");
   });
 

--- a/frontend/src/components/Pagination.vue
+++ b/frontend/src/components/Pagination.vue
@@ -116,10 +116,10 @@ const itemsOnPage = computed(() => buildItemsOnPageString(props.page));
           v-if="!isOnlyPage"
           :to="previousPageRoute"
           :as="previousPageRoute ? NuxtLink : undefined"
-          aria-label="vorherige Ergebnisse"
           severity="secondary"
           label="Zurück"
           :disabled="!previousPageRoute"
+          :aria-hidden="!previousPageRoute ? 'true' : undefined"
           @click.prevent="previousPage()"
         >
           <template #icon><IconArrowBack /></template>
@@ -139,11 +139,11 @@ const itemsOnPage = computed(() => buildItemsOnPageString(props.page));
           v-if="!isOnlyPage"
           :to="nextPageRoute"
           :as="nextPageRoute ? NuxtLink : undefined"
-          aria-label="nächste Ergebnisse"
           severity="secondary"
           icon-pos="right"
           label="Weiter"
           :disabled="!nextPageRoute"
+          :aria-hidden="!nextPageRoute ? 'true' : undefined"
           @click.prevent="nextPage()"
         >
           <template #icon="slot">

--- a/frontend/src/components/search/NormSearchResult.vue
+++ b/frontend/src/components/search/NormSearchResult.vue
@@ -113,15 +113,13 @@ const getArticleUrl = (highlight: TextMatch) =>
         :key="highlight.name + index"
         class="flex flex-col"
       >
-        <div class="ris-label1-bold">
-          <NuxtLink
-            class="link-hover text-blue-800"
-            :to="getArticleUrl(highlight)"
-            @click="openResult(getArticleUrl(highlight))"
-          >
-            <h3 v-html="sanitizeSearchResult(highlight.name)" />
-          </NuxtLink>
-        </div>
+        <NuxtLink
+          class="ris-link1-bold link-hover"
+          :to="getArticleUrl(highlight)"
+          @click="openResult(getArticleUrl(highlight))"
+        >
+          <h3 v-html="sanitizeSearchResult(highlight.name)" />
+        </NuxtLink>
         <div
           v-html="highlight.text ? sanitizeSearchResult(highlight.text) : ''"
         />

--- a/frontend/src/pages/advanced-search/index.vue
+++ b/frontend/src/pages/advanced-search/index.vue
@@ -173,7 +173,7 @@ watch(searchStatus, async (newStatus, oldStatus) => {
   if (loadingSuccess && scrollToResultsOnLoad.value) {
     scrollToResultsOnLoad.value = false;
     await nextTick();
-    resultsContainerRef.value?.scrollIntoView({ behavior: "smooth" });
+    resultsContainerRef.value?.querySelector<HTMLAnchorElement>("a")?.focus();
   }
 });
 </script>

--- a/frontend/src/pages/advanced-search/index.vue
+++ b/frontend/src/pages/advanced-search/index.vue
@@ -6,8 +6,6 @@ import { DocumentKind } from "~/types/api";
 import { queryableDataFields } from "~/utils/search/dataFields";
 import { isStrictDateFilterValue } from "~/utils/search/dateFilterType";
 
-useHead({ title: "Erweiterte Suche" });
-
 definePageMeta({
   alias: "/erweiterte-suche",
   middleware: () => {
@@ -27,6 +25,14 @@ const {
   saveFilterStateToRoute,
   sort,
 } = useAdvancedSearchRouteParams();
+
+const title = computed(() => {
+  const pageSuffix =
+    pageIndex.value > 0 ? `, Seite ${pageIndex.value + 1}` : "";
+  return `Erweiterte Suche${pageSuffix}`;
+});
+
+useHead({ title });
 
 const searchFormId = useId();
 

--- a/frontend/src/pages/search/index.vue
+++ b/frontend/src/pages/search/index.vue
@@ -155,7 +155,7 @@ watch(searchStatus, async (newStatus, oldStatus) => {
   if (loadingSuccess && scrollToResultsOnLoad.value) {
     scrollToResultsOnLoad.value = false;
     await nextTick();
-    resultsContainerRef.value?.scrollIntoView({ behavior: "smooth" });
+    resultsContainerRef.value?.querySelector<HTMLAnchorElement>("a")?.focus();
   }
 });
 

--- a/frontend/src/pages/search/index.vue
+++ b/frontend/src/pages/search/index.vue
@@ -162,19 +162,22 @@ watch(searchStatus, async (newStatus, oldStatus) => {
 // Page title ---------------------------------------------
 
 const title = computed(() => {
-  if (query.value) return `${query.value} — Suche`;
+  const pageSuffix =
+    pageIndex.value > 0 ? `, Seite ${pageIndex.value + 1}` : "";
+
+  if (query.value) return `${query.value} — Suche${pageSuffix}`;
 
   switch (documentKind.value) {
     case DocumentKind.Norm:
-      return "Gesetze & Verordnungen — Suche";
+      return `Gesetze & Verordnungen — Suche${pageSuffix}`;
     case DocumentKind.CaseLaw:
-      return "Rechtsprechung — Suche";
+      return `Rechtsprechung — Suche${pageSuffix}`;
     case DocumentKind.Literature:
-      return "Literaturnachweise — Suche";
+      return `Literaturnachweise — Suche${pageSuffix}`;
     case DocumentKind.AdministrativeDirective:
-      return "Verwaltungsvorschriften — Suche";
+      return `Verwaltungsvorschriften — Suche${pageSuffix}`;
     default:
-      return "Suche";
+      return `Suche${pageSuffix}`;
   }
 });
 


### PR DESCRIPTION
- Updates the accessible labels of search pagination
- Focuses the first result after switching pages
- Inserts the page index into the title
- Fixes focus styles for norm search results