### PR TITLE
RISDEV-10945 minor breadcrumb optimization fixes

### DIFF
--- a/frontend/e2e/administrativeDirective.spec.ts
+++ b/frontend/e2e/administrativeDirective.spec.ts
@@ -22,10 +22,7 @@ test("displays administrative directive page with metadata and text tab by defau
   const breadcrumb = page.getByRole("navigation", { name: "Pfadnavigation" });
 
   await expect(breadcrumb).toBeVisible();
-  await expect(breadcrumb.getByRole("link")).toContainText([
-    "Startseite",
-    "Suche",
-  ]);
+  await expect(breadcrumb.getByRole("link")).toContainText(["Start", "Suche"]);
   const expectedTitle =
     "Verwaltungsvorschrift für das Testen des Portals zur Darstellung von Verwaltungsvorschriften";
   await expect(breadcrumb.getByText(expectedTitle)).toBeVisible();

--- a/frontend/e2e/literature.spec.ts
+++ b/frontend/e2e/literature.spec.ts
@@ -22,10 +22,7 @@ test("displays literature page with metadata and text tab by default", async ({
   const breadcrumb = page.getByRole("navigation", { name: "Pfadnavigation" });
 
   await expect(breadcrumb).toBeVisible();
-  await expect(breadcrumb.getByRole("link")).toContainText([
-    "Startseite",
-    "Suche",
-  ]);
+  await expect(breadcrumb.getByRole("link")).toContainText(["Start", "Suche"]);
 
   // Main title
   await expect(breadcrumb.getByText("Erstes Test-Dokument ULI")).toBeVisible();

--- a/frontend/e2e/norm.spec.ts
+++ b/frontend/e2e/norm.spec.ts
@@ -317,6 +317,21 @@ test.describe("can view metadata of norms", () => {
   });
 });
 
+test("shows correct breadcrumbs for a norm", async ({
+  page,
+  privateFeaturesEnabled,
+}) => {
+  test.skip(!privateFeaturesEnabled);
+
+  await navigate(page, "/norms/eli/bund/bgbl-1/1972/s2459/1999-04-20/4/deu");
+
+  const breadcrumb = page.getByRole("navigation", { name: "Pfadnavigation" });
+
+  await expect(breadcrumb.getByRole("link", { name: "Start" })).toBeVisible();
+  await expect(breadcrumb.getByRole("link", { name: "Suche" })).toBeVisible();
+  await expect(breadcrumb.getByText("BWahlGV")).toBeVisible();
+});
+
 test("sets up meta tags for norm page when private features are enabled", async ({
   page,
   privateFeaturesEnabled,

--- a/frontend/e2e/normArticle.spec.ts
+++ b/frontend/e2e/normArticle.spec.ts
@@ -412,9 +412,7 @@ test("shows correct breadcrumbs for a nested article", async ({
 
   const breadcrumb = page.getByRole("navigation", { name: "Pfadnavigation" });
 
-  await expect(
-    breadcrumb.getByRole("link", { name: "Startseite" }),
-  ).toBeVisible();
+  await expect(breadcrumb.getByRole("link", { name: "Start" })).toBeVisible();
   await expect(breadcrumb.getByRole("link", { name: "Suche" })).toBeVisible();
   await expect(breadcrumb.getByRole("link", { name: "BWahlGV" })).toBeVisible();
   await expect(
@@ -440,9 +438,7 @@ test("shows correct breadcrumbs for an Eingangsformel", async ({
 
   const breadcrumb = page.getByRole("navigation", { name: "Pfadnavigation" });
 
-  await expect(
-    breadcrumb.getByRole("link", { name: "Startseite" }),
-  ).toBeVisible();
+  await expect(breadcrumb.getByRole("link", { name: "Start" })).toBeVisible();
   await expect(breadcrumb.getByRole("link", { name: "Suche" })).toBeVisible();
   await expect(breadcrumb.getByRole("link", { name: "MFG" })).toBeVisible();
   await expect(breadcrumb.getByText("Eingangsformel")).toBeVisible();
@@ -626,9 +622,7 @@ test.describe("mobile breadcrumbs", () => {
 
     const breadcrumb = page.getByRole("navigation", { name: "Pfadnavigation" });
 
-    await expect(
-      breadcrumb.getByRole("link", { name: "Startseite" }),
-    ).toBeVisible();
+    await expect(breadcrumb.getByRole("link", { name: "Start" })).toBeVisible();
     await expect(breadcrumb.getByText("§ 9")).toBeVisible();
 
     await page.getByRole("button", { name: "Navigiere zu" }).click();
@@ -637,9 +631,7 @@ test.describe("mobile breadcrumbs", () => {
 
     await expect(dialog).toBeVisible();
 
-    await expect(
-      dialog.getByRole("link", { name: "Startseite" }),
-    ).toBeVisible();
+    await expect(dialog.getByRole("link", { name: "Start" })).toBeVisible();
     await expect(dialog.getByRole("link", { name: "Suche" })).toBeVisible();
     await expect(dialog.getByRole("link", { name: "BWahlGV" })).toBeVisible();
     await expect(

--- a/frontend/e2e/normVersions.spec.ts
+++ b/frontend/e2e/normVersions.spec.ts
@@ -194,7 +194,7 @@ test("displays validity in breadcrumb navigation", async ({
 
   const breadcrumbLinks = breadcrumb.getByRole("listitem");
   await expect(breadcrumbLinks).toContainText([
-    "Startseite",
+    "Start",
     "", // Empty items are separators
     "Suche",
     "",

--- a/frontend/src/components/Breadcrumbs.spec.ts
+++ b/frontend/src/components/Breadcrumbs.spec.ts
@@ -9,7 +9,7 @@ const nuxtLinkStub = {
 };
 
 describe("Breadcrumbs", () => {
-  it("renders Startseite and all items except the last as links", async () => {
+  it("renders Start and all items except the last as links", async () => {
     await renderSuspended(RisBreadcrumb, {
       props: {
         items: [
@@ -20,7 +20,7 @@ describe("Breadcrumbs", () => {
       global: { stubs: { NuxtLink: nuxtLinkStub } },
     });
 
-    expect(screen.getByRole("link", { name: "Startseite" })).toBeVisible();
+    expect(screen.getByRole("link", { name: "Start" })).toBeVisible();
 
     const fooLink = screen.getByRole("link", { name: "Foo" });
     expect(fooLink).toBeVisible();
@@ -103,7 +103,7 @@ describe("Breadcrumbs", () => {
       expect(
         screen.getByRole("button", { name: "Navigiere zu" }),
       ).toBeVisible();
-      expect(screen.getByRole("link", { name: "Startseite" })).toBeVisible();
+      expect(screen.getByRole("link", { name: "Start" })).toBeVisible();
       expect(screen.getByText("Last")).toBeVisible();
       expect(screen.queryByRole("link", { name: "A" })).not.toBeInTheDocument();
       expect(screen.queryByRole("link", { name: "B" })).not.toBeInTheDocument();
@@ -127,9 +127,7 @@ describe("Breadcrumbs", () => {
 
       const dialog = screen.getByRole("dialog");
       expect(dialog).toBeVisible();
-      expect(
-        within(dialog).getByRole("link", { name: "Startseite" }),
-      ).toBeVisible();
+      expect(within(dialog).getByRole("link", { name: "Start" })).toBeVisible();
       expect(within(dialog).getByRole("link", { name: "A" })).toHaveAttribute(
         "href",
         "/a",

--- a/frontend/src/components/Breadcrumbs.vue
+++ b/frontend/src/components/Breadcrumbs.vue
@@ -22,6 +22,7 @@ const {
   collapse = false,
   items = [],
   label = "Pfadnavigation",
+  forceOneLine = true,
 } = defineProps<{
   /**
    * When set, the breadcrumbs will show a maximum of 3 items, after which
@@ -31,6 +32,8 @@ const {
   collapse?: boolean;
   items?: BreadcrumbItem[];
   label?: string;
+  /** When set, forces the breadcrumbs to always be limited to one line. */
+  forceOneLine?: boolean;
 }>();
 
 const itemsWithHome = computed(() => [
@@ -66,7 +69,12 @@ const drawerId = useId();
 </script>
 
 <template>
-  <Breadcrumb :model="effectiveItems" :aria-label="label" v-bind="$attrs">
+  <Breadcrumb
+    :model="effectiveItems"
+    :aria-label="label"
+    :class="{ '[&_ol]:flex-nowrap! overflow-hidden': forceOneLine }"
+    v-bind="$attrs"
+  >
     <template #item="slot">
       <span v-if="slot.item.command">
         <button

--- a/frontend/src/components/Breadcrumbs.vue
+++ b/frontend/src/components/Breadcrumbs.vue
@@ -34,7 +34,7 @@ const {
 }>();
 
 const itemsWithHome = computed(() => [
-  { label: "Startseite", route: { name: "index" } },
+  { label: "Start", route: { name: "index" } },
   ...items,
 ]);
 

--- a/frontend/src/components/Breadcrumbs.vue
+++ b/frontend/src/components/Breadcrumbs.vue
@@ -72,7 +72,7 @@ const drawerId = useId();
   <Breadcrumb
     :model="effectiveItems"
     :aria-label="label"
-    :class="{ '[&_ol]:flex-nowrap! overflow-hidden': forceOneLine }"
+    :class="{ 'overflow-hidden [&_ol]:flex-nowrap!': forceOneLine }"
     v-bind="$attrs"
   >
     <template #item="slot">

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -81,9 +81,6 @@ const { status: normVersionsStatus, sortedVersions: normVersions } =
   useNormVersions(metadata.value?.exampleOfWork?.legislationIdentifier ?? "");
 
 const breadcrumbItems: ComputedRef<BreadcrumbItem[]> = computed(() => {
-  const validFrom = dateFormattedDDMMYYYY(validityInterval.value?.from);
-  const validFromDisplay = validFrom ? ` vom ${validFrom}` : "";
-
   return [
     {
       label: "Suche",
@@ -91,7 +88,7 @@ const breadcrumbItems: ComputedRef<BreadcrumbItem[]> = computed(() => {
     },
     {
       route: `/norms/${metadata.value?.legislationIdentifier}`,
-      label: normBreadcrumbTitle.value + validFromDisplay,
+      label: normBreadcrumbTitle.value,
     },
   ];
 });

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { NuxtLink } from "#components";
 import type { Dayjs } from "dayjs";
-import { Tab, TabList, Tabs } from "primevue";
+import { Button, Tab, TabList, Tabs } from "primevue";
 import type { ComputedRef } from "vue";
 import type { BreadcrumbItem } from "~/components/Breadcrumbs.vue";
 import { DocumentKind, type LegislationExpression } from "~/types/api";

--- a/frontend/src/pages/search/index.vue
+++ b/frontend/src/pages/search/index.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { Message, Select } from "primevue";
 import { DocumentKind } from "~/types/api";
-import { formatDocumentKind } from "~/utils/displayValues";
 import { isStrictDateFilterValue } from "~/utils/search/dateFilterType";
 
 useStaticPageSeo("suche");


### PR DESCRIPTION
Addresses review feedback:

- limit breadcrumbs on mobile to one line
- renames home breadcrumb item to "Start"
- removes validity date from norm breadcrumbs
- minor cleanup and additional tests