### PR TITLE
RISDEV-9453 rename tab bar

### DIFF
--- a/frontend/src/layouts/document.spec.ts
+++ b/frontend/src/layouts/document.spec.ts
@@ -137,7 +137,7 @@ describe("document", () => {
       },
     });
 
-    expect(screen.getByRole("navigation", { name: "Tab-Liste" })).toBeVisible();
+    expect(screen.getByRole("navigation", { name: "Tab" })).toBeVisible();
     expect(screen.getByRole("tab", { name: /Text/ })).toBeVisible();
     expect(screen.getByRole("tab", { name: /Details/ })).toBeVisible();
   });

--- a/frontend/src/layouts/document.vue
+++ b/frontend/src/layouts/document.vue
@@ -59,7 +59,7 @@ const currentView = computed(
       <div v-else>
         <!-- Tabs -->
         <div class="border-b border-gray-400">
-          <nav class="container -mb-1" aria-label="Tab-Liste">
+          <nav class="container -mb-1" aria-label="Tab">
             <Tabs :value="currentView" :show-navigators="false">
               <TabList>
                 <!-- Note that we need to override aria-controls manually,

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -214,7 +214,7 @@ const fassungenTabPanelTitleId = useId();
     </div>
 
     <div class="border-b border-gray-400">
-      <nav class="container -mb-1 overflow-x-auto pt-1" aria-label="Tab-Liste">
+      <nav class="container -mb-1 overflow-x-auto pt-1" aria-label="Tab">
         <Tabs :value="currentView" :show-navigators="false">
           <TabList>
             <Tab


### PR DESCRIPTION
Singular "Tab" so it gets read by screen readers as "Tab Navigation"