### PR TITLE
RISDEV-8808 redesigned back to top link

### DIFF
--- a/frontend/src/components/app/BackToTopLink.spec.ts
+++ b/frontend/src/components/app/BackToTopLink.spec.ts
@@ -9,7 +9,7 @@ describe("BackToTopLink", () => {
     await renderSuspended(BackToTopLink);
 
     expect(
-      screen.getByRole("link", { name: "zum Seitenanfang" }),
+      screen.getByRole("link", { name: "Zum Seitenanfang" }),
     ).toHaveAttribute("href", expect.stringContaining("#top"));
   });
 
@@ -26,7 +26,7 @@ describe("BackToTopLink", () => {
 
     await renderSuspended(BackToTopLink);
 
-    await user.click(screen.getByRole("link", { name: "zum Seitenanfang" }));
+    await user.click(screen.getByRole("link", { name: "Zum Seitenanfang" }));
 
     expect(document.getElementById).toHaveBeenCalledWith("top");
     expect(mockScrollIntoView).toHaveBeenCalledWith({ behavior: "smooth" });
@@ -50,7 +50,7 @@ describe("BackToTopLink", () => {
       }),
     );
 
-    await user.click(screen.getByRole("link", { name: "zum Seitenanfang" }));
+    await user.click(screen.getByRole("link", { name: "Zum Seitenanfang" }));
 
     expect(hasError).toBe(false);
   });

--- a/frontend/src/components/app/BackToTopLink.vue
+++ b/frontend/src/components/app/BackToTopLink.vue
@@ -1,33 +1,57 @@
 <script setup lang="ts">
-const handleClick = () => {
-  const header = document.getElementById("top");
-  if (header) {
-    header.scrollIntoView({ behavior: "smooth" });
-  }
-};
+import { Button } from "primevue";
+import IcBaselineKeyboardArrowUp from "~icons/ic/baseline-keyboard-arrow-up";
+
+const scrollTarget = "top";
+
+function scrollToTop() {
+  document.getElementById(scrollTarget)?.scrollIntoView({ behavior: "smooth" });
+}
 </script>
 
 <template>
-  <NuxtLink
-    :to="{ hash: '#top' }"
-    aria-label="zum Seitenanfang"
-    class="outline-offset-4 outline-blue-800 focus-visible:outline-4"
-    @click.prevent="handleClick"
-  >
-    <svg
-      viewBox="0 0 42 42"
-      width="2.5rem"
-      height="2.5rem"
-      version="1.1"
-      focusable="false"
-      aria-hidden="true"
+  <div class="back-to-top-link">
+    <Button
+      :href="`#${scrollTarget}`"
+      aria-label="Zum Seitenanfang"
+      as="a"
+      rounded
+      severity="secondary"
+      @click.prevent="scrollToTop"
     >
-      <path
-        d="M21 1a20 20 0 1 0 20 20A20 20 0 0 0 21 1Zm0 38a18 18 0 1 1 18-18 18 18 0 0 1-18 18Z"
-      />
-      <path
-        d="M21.2 16.5a.3.3 0 0 0-.4 0l-6.6 6.6a.2.2 0 0 0 0 .3l1 1.1a.2.2 0 0 0 .4 0l5.4-5.4 5.4 5.4a.2.2 0 0 0 .3 0l1-1a.2.2 0 0 0 0-.4Z"
-      />
-    </svg>
-  </NuxtLink>
+      <template #icon>
+        <IcBaselineKeyboardArrowUp />
+      </template>
+    </Button>
+  </div>
 </template>
+
+<style scoped>
+@reference "~/assets/main.css";
+
+.back-to-top-link {
+  @apply fixed right-16 bottom-(--offset-bottom) [--offset-bottom:1rem];
+}
+
+:root:has([data-back-to-top-adjust="drawer"]) {
+  .back-to-top-link {
+    /* drawer height + 1rem on mobile */
+    @apply [--offset-bottom:4.875rem] md:[--offset-bottom:1rem];
+  }
+}
+
+@supports (animation-range: normal) {
+  .back-to-top-link {
+    @apply animate-[slide-in_linear_both] [animation-range:normal_8rem] [animation-timeline:scroll(root)];
+  }
+
+  @keyframes slide-in {
+    from {
+      translate: 0 calc(100% + var(--offset-bottom));
+    }
+    to {
+      translate: 0 0;
+    }
+  }
+}
+</style>

--- a/frontend/src/components/app/Footer.vue
+++ b/frontend/src/components/app/Footer.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import bmjvLogo from "~/assets/img/BMJV_de_v1__Web_farbig.svg";
-import BackToTopLink from "~/components/app/BackToTopLink.vue";
 import { usePrivateFeaturesFlag } from "~/composables/usePrivateFeaturesFlag";
 
 const route = useRoute();
@@ -120,6 +119,6 @@ const privateFeaturesEnabled = usePrivateFeaturesFlag();
       </div>
     </div>
 
-    <BackToTopLink class="absolute right-16 bottom-32" />
+    <AppBackToTopLink />
   </footer>
 </template>

--- a/frontend/src/components/documents/TableOfContents.vue
+++ b/frontend/src/components/documents/TableOfContents.vue
@@ -34,6 +34,7 @@ const drawerId = useId();
       v-if="!mobileTocVisible"
       ref="openButtonRef"
       class="shadow-gray-1000/15 fixed inset-x-0 bottom-0 z-10 flex cursor-pointer items-center justify-between gap-8 bg-white p-16 text-left shadow-[0_0_0.5rem] -outline-offset-4 outline-blue-800 focus-visible:outline-4 md:hidden"
+      data-back-to-top-adjust="drawer"
       :aria-expanded="mobileTocVisible"
       :aria-controls="drawerId"
       @click="mobileTocVisible = true"


### PR DESCRIPTION
reworked the back-to-top-link:

- in browsers with support for scroll animation timelines (currently: Chrome + Safari + FF Nightly), the button slides in over the first ~150px of scrolling
- otherwise the button is always shown
- also adds a `data-` attribute based approach for components to "nudge" the button a bit when its usual spot is occupied (e.g. bottom drawer). I chose this over a JavaScript solution to keep it simple and not cause issues with server-/client rendering, though admittedly it's a bit less explicit and relies on a small amount of global CSS