### PR TITLE
RISDEV-11642-dont-error-log-lucene-parser-errors

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
@@ -110,6 +110,7 @@ public class ControllerExceptionHandler {
   @ExceptionHandler(CustomValidationException.class)
   public ResponseEntity<CustomErrorResponse> handleCustomValidationException(
       CustomValidationException exception) {
+    logger.warn(exception.getMessage());
     var errorResponse = CustomErrorResponse.builder().errors(exception.getErrors()).build();
     return ResponseEntity.status(HttpStatus.UNPROCESSABLE_CONTENT).body(errorResponse);
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/LuceneQueryTools.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/LuceneQueryTools.java
@@ -5,8 +5,6 @@ import de.bund.digitalservice.ris.search.models.errors.CustomError;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
@@ -15,19 +13,9 @@ import org.springframework.data.elasticsearch.UncategorizedElasticsearchExceptio
 /** Class to store the Lucene query tools */
 public class LuceneQueryTools {
 
-  private static final Logger logger = LogManager.getLogger(LuceneQueryTools.class);
-
   private static final StandardAnalyzer analyzer = new StandardAnalyzer();
 
   private LuceneQueryTools() {}
-
-  private static final CustomValidationException invalidQueryException =
-      new CustomValidationException(
-          CustomError.builder()
-              .code("invalid_lucene_query")
-              .parameter("query")
-              .message("Invalid lucene query")
-              .build());
 
   /**
    * Method to validate the parameters of a Lucene query
@@ -43,8 +31,12 @@ public class LuceneQueryTools {
       QueryParser queryParser = new QueryParser("", analyzer);
       queryParser.parse(query);
     } catch (ParseException e) {
-      logger.error("Validation error(s): {}", invalidQueryException.getErrors());
-      throw invalidQueryException;
+      throw new CustomValidationException(
+          CustomError.builder()
+              .code("invalid_lucene_query")
+              .parameter("query")
+              .message(e.getMessage())
+              .build());
     }
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/AdvancedSearchControllerApiTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/AdvancedSearchControllerApiTest.java
@@ -423,20 +423,8 @@ class AdvancedSearchControllerApiTest extends ContainersIntegrationBase {
         .perform(get(url).contentType(MediaType.APPLICATION_JSON))
         .andDo(print())
         .andExpect(status().isUnprocessableContent())
-        .andExpect(
-            content()
-                .json(
-                    """
-                                                        {
-                                                          "errors": [
-                                                            {
-                                                              "code": "invalid_lucene_query",
-                                                              "parameter": "query",
-                                                              "message": "Invalid lucene query"
-                                                            }
-                                                          ]
-                                                        }
-                                                    """));
+        .andExpect(jsonPath("$.errors[0].code").value("invalid_lucene_query"))
+        .andExpect(jsonPath("$.errors[0].parameter").value("query"));
   }
 
   private static Stream<Arguments> provideSortTestData() {


### PR DESCRIPTION
This PR stops logging lucene parser messages as errors by default. Instead of logging and returning a static error message we return the actual message of the parser exception.