### PR TITLE
RISDEV-9453 fix skip link focus after navigation events

### DIFF
--- a/frontend/e2e/skipLinks.spec.ts
+++ b/frontend/e2e/skipLinks.spec.ts
@@ -1,4 +1,4 @@
-import { navigate, test } from "./utils/fixtures";
+import { expect, navigate, test } from "./utils/fixtures";
 import {
   expectPageSkipLinks,
   type SkipLinkExpectation,
@@ -109,6 +109,77 @@ const scenarios: Scenario[] = [
     ],
   },
 ];
+
+test("skip links are focused after client-side navigation", async ({
+  page,
+  isMobileTest,
+}) => {
+  test.skip(isMobileTest);
+
+  await navigate(page, "/");
+
+  await page.keyboard.press("Tab");
+  await expect(
+    page.getByRole("navigation", { name: "Sprunglinks" }).getByRole("link", {
+      name: "Zum Inhalt",
+    }),
+  ).toBeFocused();
+
+  await page
+    .getByRole("navigation")
+    .getByRole("link", { name: "Suche" })
+    .click();
+
+  await expect(
+    page.getByRole("heading", { name: "Suche", level: 1, exact: true }),
+  ).toBeVisible();
+
+  const skipLinks = page.getByRole("navigation", { name: "Sprunglinks" });
+  skipLinks.waitFor({ state: "attached" });
+
+  await page.keyboard.press("Tab");
+  await expect(
+    skipLinks.getByRole("link", { name: "Zur Suche" }),
+  ).toBeFocused();
+});
+
+test.describe("mobile", () => {
+  test.beforeEach(({ isMobileTest }) => {
+    test.skip(!isMobileTest);
+  });
+
+  test("skip links are focused after client-side navigation", async ({
+    page,
+  }) => {
+    await navigate(page, "/");
+
+    await page.keyboard.press("Tab");
+    await expect(
+      page.getByRole("navigation", { name: "Sprunglinks" }).getByRole("link", {
+        name: "Zum Inhalt",
+      }),
+    ).toBeFocused();
+
+    await page.getByRole("button", { name: "Menü" }).click();
+
+    await page
+      .getByRole("navigation")
+      .getByRole("link", { name: "Suche" })
+      .click();
+
+    await expect(
+      page.getByRole("heading", { name: "Suche", level: 1, exact: true }),
+    ).toBeVisible();
+
+    const skipLinks = page.getByRole("navigation", { name: "Sprunglinks" });
+    skipLinks.waitFor({ state: "attached" });
+
+    await page.keyboard.press("Tab");
+    await expect(
+      skipLinks.getByRole("link", { name: "Zur Suche" }),
+    ).toBeFocused();
+  });
+});
 
 for (const { name, url, skipLinks, requiresPrivateFeatures } of scenarios) {
   test(`skip links work on the ${name}`, async ({

--- a/frontend/src/components/app/SkipLinks.spec.ts
+++ b/frontend/src/components/app/SkipLinks.spec.ts
@@ -1,7 +1,7 @@
 import { renderSuspended } from "@nuxt/test-utils/runtime";
 import { screen } from "@testing-library/vue";
 import { defineComponent, h } from "vue";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import AppSkipLinks from "./SkipLinks.vue";
 
 const RegisterSkipLinks = defineComponent({
@@ -28,5 +28,29 @@ describe("SkipLinks", () => {
 
     expect(screen.getByRole("link", { name: "Zum Inhalt" })).toBeVisible();
     expect(screen.getByRole("link", { name: "Zum Fußbereich" })).toBeVisible();
+  });
+
+  it("focuses nav when navigating to a different path", async () => {
+    await renderSuspended(SkipLinksDummy, { route: "/search" });
+    const nav = screen.getByRole("navigation", { name: "Sprunglinks" });
+    const focusSpy = vi.spyOn(nav, "focus");
+
+    const router = useRouter();
+    await router.push("/about");
+
+    expect(focusSpy).toHaveBeenCalled();
+    focusSpy.mockRestore();
+  });
+
+  it("does not focus nav when navigating to the same path with different query params", async () => {
+    await renderSuspended(SkipLinksDummy, { route: "/search?q=foo" });
+    const nav = screen.getByRole("navigation", { name: "Sprunglinks" });
+    const focusSpy = vi.spyOn(nav, "focus");
+
+    const router = useRouter();
+    await router.push("/search?q=bar");
+
+    expect(focusSpy).not.toHaveBeenCalled();
+    focusSpy.mockRestore();
   });
 });

--- a/frontend/src/components/app/SkipLinks.vue
+++ b/frontend/src/components/app/SkipLinks.vue
@@ -1,11 +1,23 @@
 <script setup lang="ts">
 const links = useSkipLinks();
+
+const router = useRouter();
+
+const wrapper = useTemplateRef("wrapper");
+
+const unregister = router.afterEach((to, from) => {
+  if (to.path !== from.path) wrapper.value?.focus();
+});
+
+onUnmounted(unregister);
 </script>
 
 <template>
   <nav
     v-if="links?.length"
+    ref="wrapper"
     aria-label="Sprunglinks"
+    tabindex="-1"
     class="pointer-events-none fixed inset-x-0 top-8 z-10 flex justify-center gap-8 px-8"
   >
     <SkipLink

--- a/frontend/src/composables/useAdvancedSearchRouteParams.spec.ts
+++ b/frontend/src/composables/useAdvancedSearchRouteParams.spec.ts
@@ -349,9 +349,29 @@ describe("useAdvancedSearchRouteParams", () => {
       };
 
       vi.doMock("#app", () => ({
-        useRoute: vi
-          .fn()
-          .mockReturnValue({ query: query, hash: "#some-anchor" }),
+        useRoute: vi.fn().mockReturnValue({ query, hash: "#some-anchor" }),
+        navigateTo: navigateToMock,
+      }));
+
+      const { useAdvancedSearchRouteParams } =
+        await import("./useAdvancedSearchRouteParams");
+
+      const { saveFilterStateToRoute } = useAdvancedSearchRouteParams();
+
+      await saveFilterStateToRoute();
+
+      expect(navigateToMock).toHaveBeenCalledWith(
+        expect.objectContaining({ hash: "#some-anchor" }),
+      );
+    });
+
+    it("retains the hash when the query was empty", async () => {
+      const navigateToMock = vi.fn();
+
+      const query = {};
+
+      vi.doMock("#app", () => ({
+        useRoute: vi.fn().mockReturnValue({ query, hash: "#some-anchor" }),
         navigateTo: navigateToMock,
       }));
 

--- a/frontend/src/composables/useAdvancedSearchRouteParams.ts
+++ b/frontend/src/composables/useAdvancedSearchRouteParams.ts
@@ -1,6 +1,6 @@
 import { navigateTo, useRoute } from "#app";
 import type { LocationQueryRaw, LocationQueryValue } from "#vue-router";
-import { isEqual } from "lodash-es";
+import { isEmpty, isEqual } from "lodash-es";
 import { DocumentKind } from "~/types/api";
 import {
   type DateFilterValue,
@@ -89,9 +89,17 @@ export function useAdvancedSearchRouteParams() {
       itemsPerPage: itemsPerPage.value,
     };
 
+    // Hash is used for skip links on the page:
+    //
+    // - We'll keep it if the search params haven't change or if no search has
+    //   been performed yet (-> route change is due to hash change, so any
+    //   change to the hash would break navigation)
+    // - Remove it if the search params have changed (-> route change is due to
+    //   search, so keeping the hash would cause unintended scrolling)
+    const shouldKeepHash = isEmpty(from) || isEqual(from, to);
+
     return navigateTo({
-      // Reset hash when the query changes to prevent unintended scrolling
-      hash: isEqual(from, to) ? route.hash : undefined,
+      hash: shouldKeepHash ? route.hash : undefined,
       query: to,
     });
   }

--- a/frontend/src/composables/useSimpleSearchRouteParams.spec.ts
+++ b/frontend/src/composables/useSimpleSearchRouteParams.spec.ts
@@ -400,10 +400,29 @@ describe("useSimpleSearchRouteParams", () => {
       };
 
       vi.doMock("#app", () => ({
-        useRoute: vi.fn().mockReturnValue({
-          query: query,
-          hash: "#some-anchor",
-        }),
+        useRoute: vi.fn().mockReturnValue({ query, hash: "#some-anchor" }),
+        navigateTo: navigateToMock,
+      }));
+
+      const { useSimpleSearchRouteParams } =
+        await import("./useSimpleSearchRouteParams");
+
+      const { saveFilterStateToRoute } = useSimpleSearchRouteParams();
+
+      await saveFilterStateToRoute();
+
+      expect(navigateToMock).toHaveBeenCalledWith(
+        expect.objectContaining({ hash: "#some-anchor" }),
+      );
+    });
+
+    it("retains the hash when the query was empty", async () => {
+      const navigateToMock = vi.fn();
+
+      const query = {};
+
+      vi.doMock("#app", () => ({
+        useRoute: vi.fn().mockReturnValue({ query, hash: "#some-anchor" }),
         navigateTo: navigateToMock,
       }));
 

--- a/frontend/src/composables/useSimpleSearchRouteParams.ts
+++ b/frontend/src/composables/useSimpleSearchRouteParams.ts
@@ -1,6 +1,6 @@
 import { navigateTo, useRoute } from "#app";
-import type { LocationQueryValue, LocationQueryRaw } from "#vue-router";
-import { isEqual } from "lodash-es";
+import type { LocationQueryRaw, LocationQueryValue } from "#vue-router";
+import { isEmpty, isEqual } from "lodash-es";
 import { DocumentKind } from "~/types/api";
 import { isDocumentKind } from "~/utils/documentKind";
 import {
@@ -122,9 +122,17 @@ export function useSimpleSearchRouteParams() {
       }),
     );
 
+    // Hash is used for skip links on the page:
+    //
+    // - We'll keep it if the search params haven't change or if no search has
+    //   been performed yet (-> route change is due to hash change, so any
+    //   change to the hash would break navigation)
+    // - Remove it if the search params have changed (-> route change is due to
+    //   search, so keeping the hash would cause unintended scrolling)
+    const shouldKeepHash = isEmpty(from) || isEqual(from, to);
+
     return navigateTo({
-      // Reset hash when the query changes to prevent unintended scrolling
-      hash: isEqual(from, to) ? route.hash : undefined,
+      hash: shouldKeepHash ? route.hash : undefined,
       query: to,
     });
   }


### PR DESCRIPTION
- skip links no longer break on search pages when search query is completely empty (usually happens right after initial page load)
- ensures skip links are focused first after client-side navigation