### PR TITLE
RISDEV 11570 caselaw page title

### DIFF
--- a/frontend/src/composables/useCaselawSeo.spec.ts
+++ b/frontend/src/composables/useCaselawSeo.spec.ts
@@ -1,0 +1,212 @@
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CaseLaw } from "~/types/api";
+import { useCaselawSeo } from "./useCaselawSeo";
+
+const { useSeo } = vi.hoisted(() => ({
+  useSeo: vi.fn(),
+}));
+
+mockNuxtImport("useSeo", () => useSeo);
+
+function makeCaseLaw(overrides: Partial<CaseLaw> = {}): CaseLaw {
+  return {
+    documentNumber: "KORE123456789",
+    courtName: "Bundesgerichtshof",
+    documentType: "Urteil",
+    decisionDate: "2023-06-15",
+    fileNumbers: ["VIII ZR 12/23"],
+    ...overrides,
+  } as CaseLaw;
+}
+
+describe("useCaselawSeo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("falls back to defaults when caseLaw and document is undefined", () => {
+    useCaselawSeo({});
+
+    expect(useSeo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Gerichtsentscheidung",
+        description: "Gerichtsentscheidung",
+        ogTitle: "Gerichtsentscheidung",
+      }),
+    );
+  });
+
+  describe("buildTitle", () => {
+    it("builds a full title from court, documentType, date, and fileNumber", () => {
+      useCaselawSeo({ caseLaw: makeCaseLaw() });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Bundesgerichtshof, Urteil vom 15.06.2023 - VIII ZR 12/23",
+        }),
+      );
+    });
+
+    it("falls back to 'Gerichtsentscheidung' when documentType is missing", () => {
+      useCaselawSeo({ caseLaw: makeCaseLaw({ documentType: undefined }) });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title:
+            "Bundesgerichtshof, Gerichtsentscheidung vom 15.06.2023 - VIII ZR 12/23",
+        }),
+      );
+    });
+
+    it("omits court when courtName is missing", () => {
+      useCaselawSeo({ caseLaw: makeCaseLaw({ courtName: undefined }) });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Urteil vom 15.06.2023 - VIII ZR 12/23",
+        }),
+      );
+    });
+
+    it("omits date when decisionDate is missing", () => {
+      useCaselawSeo({ caseLaw: makeCaseLaw({ decisionDate: undefined }) });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Bundesgerichtshof, Urteil - VIII ZR 12/23",
+        }),
+      );
+    });
+
+    it("omits fileNumber when fileNumbers is empty", () => {
+      useCaselawSeo({ caseLaw: makeCaseLaw({ fileNumbers: [] }) });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Bundesgerichtshof, Urteil vom 15.06.2023",
+        }),
+      );
+    });
+
+    it("uses first of multiple fileNumbers", () => {
+      useCaselawSeo({ caseLaw: { fileNumbers: ["X1", "X2"] } as CaseLaw });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Gerichtsentscheidung - X1",
+        }),
+      );
+    });
+  });
+
+  describe("buildDescription", () => {
+    it("uses guidingPrinciple's first two sentences", () => {
+      const doc = new DOMParser().parseFromString(
+        "<html lang='de'><body><section><p>Not used in this case.</p></section></body></html>",
+        "text/html",
+      );
+      const guidingPrinciple =
+        "Fist sentence. Second sentence. Third sentence should be cut off.";
+      useCaselawSeo({
+        caseLaw: makeCaseLaw({ guidingPrinciple }),
+        document: doc,
+      });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: "Fist sentence. Second sentence.",
+        }),
+      );
+    });
+
+    it("falls back to first paragraph from document when guidingPrinciple missing", () => {
+      const doc = new DOMParser().parseFromString(
+        "<html lang='de'><body><section><p>Paragraph text here.</p></section></body></html>",
+        "text/html",
+      );
+      useCaselawSeo({
+        caseLaw: makeCaseLaw({ guidingPrinciple: undefined }),
+        document: doc,
+      });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "Paragraph text here." }),
+      );
+    });
+
+    it("falls back to default when no guidingPrinciple nad no document", () => {
+      useCaselawSeo({ caseLaw: makeCaseLaw({ guidingPrinciple: undefined }) });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "Gerichtsentscheidung" }),
+      );
+    });
+
+    it("falls back to default when document has no section paragraph", () => {
+      const doc = new DOMParser().parseFromString(
+        "<html lang='de'><body><div>No section paragraph</div></body></html>",
+        "text/html",
+      );
+      useCaselawSeo({
+        caseLaw: makeCaseLaw({ guidingPrinciple: undefined }),
+        document: doc,
+      });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "Gerichtsentscheidung" }),
+      );
+    });
+  });
+
+  // TODO: Make sure the tests reflect the expected behavoir afer
+  // the buildOgTitle function has been updated
+  // oxlint-disable-next-line vitest/no-disabled-tests
+  describe.skip("buildOgTitle", () => {
+    it("builds ogTitle with court, documentType, date, and fileNumber", () => {
+      useCaselawSeo({ caseLaw: makeCaseLaw() });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ogTitle: "Bundesgerichtshof: Urteil vom 15.06.2023 – VIII ZR 12/23",
+        }),
+      );
+    });
+
+    it("uses 'Gerichtsentscheidung' as documentType fallback", () => {
+      useCaselawSeo({ caseLaw: makeCaseLaw({ documentType: undefined }) });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ogTitle:
+            "Bundesgerichtshof: Gerichtsentscheidung vom 15.06.2023 – VIII ZR 12/23",
+        }),
+      );
+    });
+
+    it("omits court when courtName is missing", () => {
+      useCaselawSeo({ caseLaw: makeCaseLaw({ courtName: undefined }) });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ogTitle: "Urteil vom 15.06.2023 – VIII ZR 12/23",
+        }),
+      );
+    });
+
+    it("truncates ogTitle at word boundary to 55 characters", () => {
+      useCaselawSeo({
+        caseLaw: makeCaseLaw({
+          courtName: "Oberverwaltungsgericht Nordrhein-Westfalen Münster",
+          documentType: "Beschluss",
+        }),
+      });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ogTitle: "Oberverwaltungsgericht Nordrhein-Westfalen Münster:",
+        }),
+      );
+    });
+  });
+});

--- a/frontend/src/composables/useCaselawSeo.spec.ts
+++ b/frontend/src/composables/useCaselawSeo.spec.ts
@@ -9,17 +9,6 @@ const { useSeo } = vi.hoisted(() => ({
 
 mockNuxtImport("useSeo", () => useSeo);
 
-function makeCaseLaw(overrides: Partial<CaseLaw> = {}): CaseLaw {
-  return {
-    documentNumber: "KORE123456789",
-    courtName: "Bundesgerichtshof",
-    documentType: "Urteil",
-    decisionDate: "2023-06-15",
-    fileNumbers: ["VIII ZR 12/23"],
-    ...overrides,
-  } as CaseLaw;
-}
-
 describe("useCaselawSeo", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -39,7 +28,14 @@ describe("useCaselawSeo", () => {
 
   describe("buildTitle", () => {
     it("builds a full title from court, documentType, date, and fileNumber", () => {
-      useCaselawSeo({ caseLaw: makeCaseLaw() });
+      useCaselawSeo({
+        caseLaw: {
+          courtName: "Bundesgerichtshof",
+          documentType: "Urteil",
+          decisionDate: "2023-06-15",
+          fileNumbers: ["VIII ZR 12/23"],
+        } as CaseLaw,
+      });
 
       expect(useSeo).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -49,7 +45,13 @@ describe("useCaselawSeo", () => {
     });
 
     it("falls back to 'Gerichtsentscheidung' when documentType is missing", () => {
-      useCaselawSeo({ caseLaw: makeCaseLaw({ documentType: undefined }) });
+      useCaselawSeo({
+        caseLaw: {
+          courtName: "Bundesgerichtshof",
+          decisionDate: "2023-06-15",
+          fileNumbers: ["VIII ZR 12/23"],
+        } as CaseLaw,
+      });
 
       expect(useSeo).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -60,7 +62,13 @@ describe("useCaselawSeo", () => {
     });
 
     it("omits court when courtName is missing", () => {
-      useCaselawSeo({ caseLaw: makeCaseLaw({ courtName: undefined }) });
+      useCaselawSeo({
+        caseLaw: {
+          documentType: "Urteil",
+          decisionDate: "2023-06-15",
+          fileNumbers: ["VIII ZR 12/23"],
+        } as CaseLaw,
+      });
 
       expect(useSeo).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -70,7 +78,13 @@ describe("useCaselawSeo", () => {
     });
 
     it("omits date when decisionDate is missing", () => {
-      useCaselawSeo({ caseLaw: makeCaseLaw({ decisionDate: undefined }) });
+      useCaselawSeo({
+        caseLaw: {
+          courtName: "Bundesgerichtshof",
+          documentType: "Urteil",
+          fileNumbers: ["VIII ZR 12/23"],
+        } as CaseLaw,
+      });
 
       expect(useSeo).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -79,8 +93,14 @@ describe("useCaselawSeo", () => {
       );
     });
 
-    it("omits fileNumber when fileNumbers is empty", () => {
-      useCaselawSeo({ caseLaw: makeCaseLaw({ fileNumbers: [] }) });
+    it("omits fileNumber when fileNumbers is undefined", () => {
+      useCaselawSeo({
+        caseLaw: {
+          courtName: "Bundesgerichtshof",
+          documentType: "Urteil",
+          decisionDate: "2023-06-15",
+        } as CaseLaw,
+      });
 
       expect(useSeo).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -106,10 +126,11 @@ describe("useCaselawSeo", () => {
         "<html lang='de'><body><section><p>Not used in this case.</p></section></body></html>",
         "text/html",
       );
-      const guidingPrinciple =
-        "Fist sentence. Second sentence. Third sentence should be cut off.";
       useCaselawSeo({
-        caseLaw: makeCaseLaw({ guidingPrinciple }),
+        caseLaw: {
+          guidingPrinciple:
+            "Fist sentence. Second sentence. Third sentence should be cut off.",
+        } as CaseLaw,
         document: doc,
       });
 
@@ -126,20 +147,11 @@ describe("useCaselawSeo", () => {
         "text/html",
       );
       useCaselawSeo({
-        caseLaw: makeCaseLaw({ guidingPrinciple: undefined }),
         document: doc,
       });
 
       expect(useSeo).toHaveBeenCalledWith(
         expect.objectContaining({ description: "Paragraph text here." }),
-      );
-    });
-
-    it("falls back to default when no guidingPrinciple nad no document", () => {
-      useCaselawSeo({ caseLaw: makeCaseLaw({ guidingPrinciple: undefined }) });
-
-      expect(useSeo).toHaveBeenCalledWith(
-        expect.objectContaining({ description: "Gerichtsentscheidung" }),
       );
     });
 
@@ -149,7 +161,7 @@ describe("useCaselawSeo", () => {
         "text/html",
       );
       useCaselawSeo({
-        caseLaw: makeCaseLaw({ guidingPrinciple: undefined }),
+        caseLaw: {} as CaseLaw,
         document: doc,
       });
 
@@ -164,7 +176,14 @@ describe("useCaselawSeo", () => {
   // oxlint-disable-next-line vitest/no-disabled-tests
   describe.skip("buildOgTitle", () => {
     it("builds ogTitle with court, documentType, date, and fileNumber", () => {
-      useCaselawSeo({ caseLaw: makeCaseLaw() });
+      useCaselawSeo({
+        caseLaw: {
+          courtName: "Bundesgerichtshof",
+          documentType: "Urteil",
+          decisionDate: "2023-06-15",
+          fileNumbers: ["VIII ZR 12/23"],
+        } as CaseLaw,
+      });
 
       expect(useSeo).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -174,7 +193,13 @@ describe("useCaselawSeo", () => {
     });
 
     it("uses 'Gerichtsentscheidung' as documentType fallback", () => {
-      useCaselawSeo({ caseLaw: makeCaseLaw({ documentType: undefined }) });
+      useCaselawSeo({
+        caseLaw: {
+          courtName: "Bundesgerichtshof",
+          decisionDate: "2023-06-15",
+          fileNumbers: ["VIII ZR 12/23"],
+        } as CaseLaw,
+      });
 
       expect(useSeo).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -185,7 +210,13 @@ describe("useCaselawSeo", () => {
     });
 
     it("omits court when courtName is missing", () => {
-      useCaselawSeo({ caseLaw: makeCaseLaw({ courtName: undefined }) });
+      useCaselawSeo({
+        caseLaw: {
+          documentType: "Urteil",
+          decisionDate: "2023-06-15",
+          fileNumbers: ["VIII ZR 12/23"],
+        } as CaseLaw,
+      });
 
       expect(useSeo).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -196,10 +227,10 @@ describe("useCaselawSeo", () => {
 
     it("truncates ogTitle at word boundary to 55 characters", () => {
       useCaselawSeo({
-        caseLaw: makeCaseLaw({
+        caseLaw: {
           courtName: "Oberverwaltungsgericht Nordrhein-Westfalen Münster",
           documentType: "Beschluss",
-        }),
+        } as CaseLaw,
       });
 
       expect(useSeo).toHaveBeenCalledWith(

--- a/frontend/src/composables/useCaselawSeo.ts
+++ b/frontend/src/composables/useCaselawSeo.ts
@@ -1,0 +1,78 @@
+import { type CaseLaw } from "~/types/api";
+
+export type UseCaselawSeoInput = {
+  caseLaw?: CaseLaw;
+  document?: Document;
+};
+
+export function useCaselawSeo({ caseLaw, document }: UseCaselawSeoInput) {
+  useSeo({
+    title: buildTitle(caseLaw),
+    description: buildDescription(caseLaw, document),
+    ogTitle: buildOgTitle(caseLaw),
+  });
+}
+
+function buildTitle(caseLaw?: CaseLaw) {
+  const court = caseLaw?.courtName ?? "";
+  const documentType = caseLaw?.documentType ?? "Gerichtsentscheidung";
+  const formattedDate = dateFormattedDDMMYYYY(caseLaw?.decisionDate) ?? "";
+  const fileNumber = caseLaw?.fileNumbers?.[0] || "";
+
+  let title = court;
+
+  if (documentType) title += `${court ? ", " : ""}${documentType}`;
+  if (formattedDate) title += ` vom ${formattedDate}`;
+  if (fileNumber) title += ` - ${fileNumber}`;
+
+  return title;
+}
+
+function buildDescription(
+  caseLaw: CaseLaw | undefined,
+  document: Document | undefined,
+) {
+  if (caseLaw?.guidingPrinciple) {
+    const sentences = caseLaw.guidingPrinciple
+      .split(/(?<=[.!?])\s+/)
+      .filter(Boolean);
+
+    return truncateAtWord(sentences.slice(0, 2).join(" "), 150);
+  }
+
+  if (document) {
+    const firstParagraph = document.querySelector("section p");
+    const firstParagraphText = firstParagraph?.textContent?.trim();
+    if (firstParagraphText) {
+      return truncateAtWord(firstParagraphText, 150);
+    }
+  }
+
+  return "Gerichtsentscheidung";
+}
+
+// TODO: The truncation can cause parts of the fileNumber to not be displayed
+// which is probably not the wanted behavior - this should be clarified and fixed in
+// https://digitalservicebund.atlassian.net/browse/RISDEV-11649
+function buildOgTitle(caseLaw?: CaseLaw) {
+  const fallback = "Gerichtsentscheidung";
+  if (!caseLaw) return fallback;
+
+  const court = caseLaw.courtName?.trim() || "";
+  const dtype = caseLaw.documentType || fallback;
+  const date = caseLaw.decisionDate
+    ? dateFormattedDDMMYYYY(caseLaw.decisionDate)
+    : "";
+  const file = caseLaw.fileNumbers?.[0] || "";
+
+  const parts = [
+    court && `${court}:`,
+    dtype,
+    date && `vom ${date}`,
+    file && `– ${file}`,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return truncateAtWord(parts, 55) || undefined;
+}

--- a/frontend/src/composables/useNormSeo.spec.ts
+++ b/frontend/src/composables/useNormSeo.spec.ts
@@ -10,24 +10,6 @@ const { useSeo } = vi.hoisted(() => ({
 
 mockNuxtImport("useSeo", () => useSeo);
 
-function expectPageTitle(expectedTitle: string) {
-  expect(useSeo).toHaveBeenCalledWith(
-    expect.objectContaining({ title: expectedTitle }),
-  );
-}
-
-function expectDescription(expected: string) {
-  expect(useSeo).toHaveBeenCalledWith(
-    expect.objectContaining({ description: expected }),
-  );
-}
-
-function expectOgTitle(expectedOgTitle?: string) {
-  expect(useSeo).toHaveBeenCalledWith(
-    expect.objectContaining({ ogTitle: expectedOgTitle }),
-  );
-}
-
 describe("useNormSeo", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -56,7 +38,9 @@ describe("useNormSeo", () => {
         norm: { abbreviation: "FooBar" } as LegislationExpression,
       });
 
-      expectPageTitle("FooBar");
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "FooBar" }),
+      );
     });
 
     it.each([
@@ -70,7 +54,9 @@ describe("useNormSeo", () => {
         validityInterval: { from, to },
       });
 
-      expectPageTitle(`FooBar${expected}`);
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ title: `FooBar${expected}` }),
+      );
     });
 
     it("appends validity status", () => {
@@ -79,7 +65,9 @@ describe("useNormSeo", () => {
         validityStatus: "InForce",
       });
 
-      expectPageTitle("FooBar, Aktuell gültig");
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "FooBar, Aktuell gültig" }),
+      );
     });
 
     it("validity status succeeds validity period", () => {
@@ -92,14 +80,21 @@ describe("useNormSeo", () => {
         validityStatus: "InForce",
       });
 
-      expectPageTitle("FooBar, 01.01.2025-01.01.2026, Aktuell gültig");
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "FooBar, 01.01.2025-01.01.2026, Aktuell gültig",
+        }),
+      );
     });
   });
 
   describe("norm description", () => {
     it("returns empty string if norm has no alternateName or name", () => {
       useNormSeo({ norm: {} as LegislationExpression });
-      expectDescription("");
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "" }),
+      );
     });
 
     it("uses alternateName as description", () => {
@@ -109,14 +104,20 @@ describe("useNormSeo", () => {
           alternateName: "Foo Bar Gesetz",
         } as LegislationExpression,
       });
-      expectDescription("Foo Bar Gesetz");
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "Foo Bar Gesetz" }),
+      );
     });
 
     it("falls back to name if alternateName is absent", () => {
       useNormSeo({
         norm: { name: "Gesetz über Foo und Bar" } as LegislationExpression,
       });
-      expectDescription("Gesetz über Foo und Bar");
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "Gesetz über Foo und Bar" }),
+      );
     });
 
     it("truncates description at 150 characters", () => {
@@ -125,8 +126,11 @@ describe("useNormSeo", () => {
         norm: { alternateName: longTitle } as LegislationExpression,
       });
 
-      expectDescription(
-        "Ein sehr langes Gesetz Ein sehr langes Gesetz Ein sehr langes Gesetz Ein sehr langes Gesetz Ein sehr langes Gesetz Ein sehr langes Gesetz Ein sehr",
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description:
+            "Ein sehr langes Gesetz Ein sehr langes Gesetz Ein sehr langes Gesetz Ein sehr langes Gesetz Ein sehr langes Gesetz Ein sehr langes Gesetz Ein sehr",
+        }),
       );
     });
   });
@@ -137,7 +141,9 @@ describe("useNormSeo", () => {
         norm: {} as LegislationExpression,
       });
 
-      expectOgTitle();
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ ogTitle: undefined }),
+      );
     });
 
     it("uses abbreviation as base title", () => {
@@ -148,7 +154,9 @@ describe("useNormSeo", () => {
         } as LegislationExpression,
       });
 
-      expectOgTitle("FooBar");
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ ogTitle: "FooBar" }),
+      );
     });
 
     it("falls back to alternateName if abbreviation is absent", () => {
@@ -156,7 +164,9 @@ describe("useNormSeo", () => {
         norm: { alternateName: "Foo Bar Gesetz" } as LegislationExpression,
       });
 
-      expectOgTitle("Foo Bar Gesetz");
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ ogTitle: "Foo Bar Gesetz" }),
+      );
     });
 
     it("appends validFrom date", () => {
@@ -165,7 +175,9 @@ describe("useNormSeo", () => {
         validityInterval: { from: dayjs("01-01-2025"), to: undefined },
       });
 
-      expectOgTitle("FooBar: Fassung vom 01.01.2025");
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ ogTitle: "FooBar: Fassung vom 01.01.2025" }),
+      );
     });
 
     it("does not append validTo date", () => {
@@ -174,7 +186,9 @@ describe("useNormSeo", () => {
         validityInterval: { from: undefined, to: dayjs("01-01-2026") },
       });
 
-      expectOgTitle("FooBar");
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ ogTitle: "FooBar" }),
+      );
     });
 
     it("appends validity status label", () => {
@@ -183,7 +197,9 @@ describe("useNormSeo", () => {
         validityStatus: "InForce",
       });
 
-      expectOgTitle("FooBar: Aktuell gültig");
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ ogTitle: "FooBar: Aktuell gültig" }),
+      );
     });
 
     it("appends both validFrom date and validity status", () => {
@@ -196,7 +212,11 @@ describe("useNormSeo", () => {
         validityStatus: "InForce",
       });
 
-      expectOgTitle("FooBar: Fassung vom 01.01.2025, Aktuell gültig");
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ogTitle: "FooBar: Fassung vom 01.01.2025, Aktuell gültig",
+        }),
+      );
     });
 
     it("truncates title", () => {
@@ -210,7 +230,11 @@ describe("useNormSeo", () => {
 
       // "Sehr Langes Gesetz: Fassung vom 01.01.2025, Aktuell gültig" is 58 chars
       // expect truncation at last word boundary within 55 chars
-      expectOgTitle("Sehr Langes Gesetz: Fassung vom 01.01.2025, Aktuell");
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ogTitle: "Sehr Langes Gesetz: Fassung vom 01.01.2025, Aktuell",
+        }),
+      );
     });
   });
 });

--- a/frontend/src/pages/case-law/[documentNumber].vue
+++ b/frontend/src/pages/case-law/[documentNumber].vue
@@ -6,6 +6,7 @@ import { type CaseLaw, DocumentKind } from "~/types/api";
 import IcBaselineSubject from "~icons/ic/baseline-subject";
 import IcOutlineFileDownload from "~icons/ic/outline-file-download";
 import IcOutlineInfo from "~icons/ic/outline-info";
+import { useCaselawSeo } from "~/composables/useCaselawSeo";
 
 definePageMeta({ layout: false });
 
@@ -36,71 +37,7 @@ const document = computed(() => {
   }
 });
 
-// Page head ----------------------------------------------
-
-function buildOgTitle(caselawData: CaseLaw) {
-  const court = caselawData.courtName?.trim() || "";
-  const dtype = caselawData.documentType || "Gerichtsentscheidung";
-  const date = caselawData.decisionDate
-    ? dateFormattedDDMMYYYY(caselawData.decisionDate)
-    : "";
-  const file = caselawData.fileNumbers?.[0] || "";
-
-  const parts = [
-    court && `${court}:`,
-    dtype,
-    date && `vom ${date}`,
-    file && `– ${file}`,
-  ]
-    .filter(Boolean)
-    .join(" ");
-
-  return truncateAtWord(parts, 55) || undefined;
-}
-
-const ogTitle = computed(() => {
-  return caseLaw.value ? buildOgTitle(caseLaw.value) : undefined;
-});
-
-const description = computed<string>(() => {
-  if (caseLaw.value?.guidingPrinciple) {
-    const sentences = caseLaw.value.guidingPrinciple
-      .split(/(?<=[.!?])\s+/)
-      .filter(Boolean);
-
-    return truncateAtWord(sentences.slice(0, 2).join(" "), 150);
-  }
-
-  if (document.value) {
-    const firstParagraph = document.value.querySelector("section p");
-    const firstParagraphText = firstParagraph?.textContent?.trim();
-    if (firstParagraphText) {
-      return truncateAtWord(firstParagraphText, 150);
-    }
-  }
-
-  return "Gerichtsentscheidung";
-});
-
-const url = useRequestURL();
-
-const link = computed(() => [{ rel: "canonical", href: url.href }]);
-
-const meta = computed(() =>
-  [
-    { name: "description", content: description.value },
-    { property: "og:type", content: "article" },
-    { property: "og:title", content: ogTitle.value },
-    { property: "og:description", content: description.value },
-    { property: "og:url", content: url.href },
-    { name: "twitter:title", content: ogTitle.value },
-    { name: "twitter:description", content: description.value },
-  ].filter(
-    (tag) => typeof tag.content === "string" && tag.content.trim() !== "",
-  ),
-);
-
-useHead({ title: ogTitle, link, meta });
+useCaselawSeo({ caseLaw: caseLaw.value, document: document.value });
 
 // Page contents ------------------------------------------
 


### PR DESCRIPTION
- adapt construction of caselaw page title
- refactor meta tag creation and add tests
- the logic for the og description and title is rather hacky, I left it like it was for now as I didn't want to widen the scope of the ticket to much

RISDEV-11570