### PR TITLE
RISDEV 11570 single norm page title

### DIFF
--- a/frontend/e2e/normArticle.spec.ts
+++ b/frontend/e2e/normArticle.spec.ts
@@ -444,62 +444,6 @@ test("shows correct breadcrumbs for an Eingangsformel", async ({
   await expect(breadcrumb.getByText("Eingangsformel")).toBeVisible();
 });
 
-test("sets up meta tags for article page", async ({ page }) => {
-  await navigate(
-    page,
-    "/norms/eli/bund/bgbl-1/2000/s1016/2023-04-26/10/deu/art-z1",
-  );
-
-  const title = await page.title();
-  expect(title).toContain("§ 1 Anwendungsbereich");
-
-  const canonicalLink = await page
-    .locator('link[rel="canonical"]')
-    .getAttribute("href");
-  expect(canonicalLink).toMatch(/\/norms\/eli\/bund\//);
-
-  const metaDescription = await page
-    .locator('meta[name="description"]')
-    .getAttribute("content");
-  expect(metaDescription).toBe(
-    "Die in Anlage 1 aufgeführten Erzeugnisse unterliegen dieser Verordnung, soweit sie zum gewerbsmäßigen Vertrieb bestimmt sind.",
-  );
-
-  const ogType = await page
-    .locator('meta[property="og:type"]')
-    .getAttribute("content");
-  expect(ogType).toBe("article");
-
-  const ogTitle = await page
-    .locator('meta[property="og:title"]')
-    .getAttribute("content");
-  expect(ogTitle).toContain("§ 1 Anwendungsbereich");
-
-  const ogDescription = await page
-    .locator('meta[property="og:description"]')
-    .getAttribute("content");
-  expect(ogDescription).toBe(
-    "Die in Anlage 1 aufgeführten Erzeugnisse unterliegen dieser Verordnung, soweit sie zum gewerbsmäßigen Vertrieb bestimmt sind.",
-  );
-
-  const ogUrl = await page
-    .locator('meta[property="og:url"]')
-    .getAttribute("content");
-  expect(ogUrl).toMatch(/\/norms\/eli\/bund\//);
-
-  const twitterTitle = await page
-    .locator('meta[name="twitter:title"]')
-    .getAttribute("content");
-  expect(twitterTitle).toContain("§ 1 Anwendungsbereich");
-
-  const twitterDescription = await page
-    .locator('meta[name="twitter:description"]')
-    .getAttribute("content");
-  expect(twitterDescription).toBe(
-    "Die in Anlage 1 aufgeführten Erzeugnisse unterliegen dieser Verordnung, soweit sie zum gewerbsmäßigen Vertrieb bestimmt sind.",
-  );
-});
-
 test.describe("mobile table of contents", () => {
   test("floating button for the TOC is visible", async ({
     page,

--- a/frontend/src/composables/useArticleSeo.spec.ts
+++ b/frontend/src/composables/useArticleSeo.spec.ts
@@ -46,16 +46,19 @@ describe("useArticleSeo", () => {
       ["2025-01-01/..", "BGB, vom 01.01.2025"],
       ["../2026-01-01", "BGB, bis 01.01.2026"],
       ["2025-01-01/2026-01-01", "BGB, 01.01.2025-01.01.2026"],
-    ])("appends formatted validity interval", (temporalCoverage, expected) => {
-      useArticleSeo({
-        abbreviation: "BGB",
-        article: { temporalCoverage } as Article,
-      });
+    ])(
+      "appends formatted validity interval for temporalCoverage '%s'",
+      (temporalCoverage, expected) => {
+        useArticleSeo({
+          abbreviation: "BGB",
+          article: { temporalCoverage } as Article,
+        });
 
-      expect(useSeo).toHaveBeenCalledWith(
-        expect.objectContaining({ title: expected }),
-      );
-    });
+        expect(useSeo).toHaveBeenCalledWith(
+          expect.objectContaining({ title: expected }),
+        );
+      },
+    );
 
     it("combines abbreviation, article name and validity interval", () => {
       useArticleSeo({

--- a/frontend/src/composables/useArticleSeo.spec.ts
+++ b/frontend/src/composables/useArticleSeo.spec.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { useArticleSeo } from "./useArticleSeo";
+import type { Article } from "~/types/api";
+
+const { useSeo } = vi.hoisted(() => ({
+  useSeo: vi.fn(),
+}));
+
+mockNuxtImport("useSeo", () => useSeo);
+
+describe("useArticleSeo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("buildTitle", () => {
+    it("returns empty string when nothing is provided", () => {
+      useArticleSeo({});
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "" }),
+      );
+    });
+
+    it("uses abbreviation as base", () => {
+      useArticleSeo({ abbreviation: "BGB" });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "BGB" }),
+      );
+    });
+
+    it("appends paragraph number", () => {
+      useArticleSeo({
+        abbreviation: "BGB",
+        article: { name: "§ 1" } as Article,
+      });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "BGB, § 1" }),
+      );
+    });
+
+    it.each([
+      ["2025-01-01/..", "BGB, vom 01.01.2025"],
+      ["../2026-01-01", "BGB, bis 01.01.2026"],
+      ["2025-01-01/2026-01-01", "BGB, 01.01.2025-01.01.2026"],
+    ])("appends formatted validity interval", (temporalCoverage, expected) => {
+      useArticleSeo({
+        abbreviation: "BGB",
+        article: { temporalCoverage } as Article,
+      });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ title: expected }),
+      );
+    });
+
+    it("combines abbreviation, article name and validity interval", () => {
+      useArticleSeo({
+        abbreviation: "BGB",
+        article: {
+          name: "§ 1",
+          temporalCoverage: "2025-01-01/2026-01-01",
+        } as Article,
+      });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "BGB, § 1, 01.01.2025-01.01.2026" }),
+      );
+    });
+  });
+
+  describe("buildDescription", () => {
+    it("returns undefined if articleHtml is absent", () => {
+      useArticleSeo({});
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ description: undefined }),
+      );
+    });
+
+    it("returns undefined if articleHtml has no paragraph", () => {
+      useArticleSeo({ articleHtml: "<div>no paragraph here</div>" });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ description: undefined }),
+      );
+    });
+
+    it("returns undefined if the first paragraph is empty", () => {
+      useArticleSeo({ articleHtml: "<p>   </p>" });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ description: undefined }),
+      );
+    });
+
+    it("extracts text from the first paragraph", () => {
+      useArticleSeo({ articleHtml: "<p>Hello world</p><p>Second</p>" });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "Hello world" }),
+      );
+    });
+
+    it("strips HTML tags from the paragraph", () => {
+      useArticleSeo({ articleHtml: "<p>Hello <b>world</b></p>" });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "Hello world" }),
+      );
+    });
+
+    it("truncates description at 150 characters word boundary", () => {
+      const longText =
+        "This is a long text " +
+        "LongWordWithoutWhiteSpacesShouldGetTruncated".repeat(3).trim();
+      useArticleSeo({ articleHtml: `<p>${longText}</p>` });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: "This is a long text",
+        }),
+      );
+    });
+  });
+
+  describe("buildOgTitle", () => {
+    it("returns undefined if neither abbreviation nor headline is provided", () => {
+      useArticleSeo({});
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ ogTitle: undefined }),
+      );
+    });
+
+    it("uses abbreviation when no headline is provided", () => {
+      useArticleSeo({ abbreviation: "BGB" });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ ogTitle: "BGB" }),
+      );
+    });
+
+    it("uses headline when no abbreviation is provided", () => {
+      useArticleSeo({ articleHeadlineHtml: "<p>§ 1 Allgemeines</p>" });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ ogTitle: "§ 1 Allgemeines" }),
+      );
+    });
+
+    it("combines abbreviation and headline with a colon separator", () => {
+      useArticleSeo({
+        abbreviation: "BGB",
+        articleHeadlineHtml: "<p>§ 1 Allgemeines</p>",
+      });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ ogTitle: "BGB: § 1 Allgemeines" }),
+      );
+    });
+
+    it("strips HTML tags from the headline", () => {
+      useArticleSeo({
+        abbreviation: "BGB",
+        articleHeadlineHtml: "<p>§ 1 <b>Allgemeines</b></p>",
+      });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ ogTitle: "BGB: § 1 Allgemeines" }),
+      );
+    });
+
+    it("normalizes whitespace in the headline", () => {
+      useArticleSeo({
+        articleHeadlineHtml: "<p>§ 1      Allgemeines</p>",
+      });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({ ogTitle: "§ 1 Allgemeines" }),
+      );
+    });
+
+    it("truncates ogTitle at 55 characters word boundary", () => {
+      const longHeadline =
+        "A very long paragraph thisReallyLongWordWillGetTruncated";
+      useArticleSeo({
+        abbreviation: "BGB",
+        articleHeadlineHtml: `<p>${longHeadline}</p>`,
+      });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ogTitle: "BGB: A very long paragraph",
+        }),
+      );
+    });
+  });
+});

--- a/frontend/src/composables/useArticleSeo.ts
+++ b/frontend/src/composables/useArticleSeo.ts
@@ -1,0 +1,55 @@
+import { normalizeSpaces } from "~/utils/textFormatting";
+import type { Article } from "~/types/api";
+import { buildValidityTitleLabel } from "~/composables/useNormSeo";
+import { temporalCoverageToValidityInterval } from "~/utils/norm";
+
+export type UseArticleSeoInput = {
+  abbreviation?: string;
+  article?: Article;
+  articleHeadlineHtml?: string;
+  articleHtml?: string;
+};
+
+export function useArticleSeo({
+  abbreviation,
+  article,
+  articleHeadlineHtml,
+  articleHtml,
+}: UseArticleSeoInput) {
+  useSeo({
+    title: buildTitle(abbreviation, article),
+    description: buildDescription(articleHtml),
+    ogTitle: buildOgTitle(abbreviation, articleHeadlineHtml),
+  });
+}
+
+function buildTitle(abbreviation?: string, article?: Article) {
+  const paragraphNumber = article?.name ? `, ${article.name}` : "";
+  const validityIntervalLabel = buildValidityTitleLabel(
+    temporalCoverageToValidityInterval(article?.temporalCoverage),
+  );
+  return `${abbreviation ?? ""}${paragraphNumber}${validityIntervalLabel}`;
+}
+
+function buildDescription(articleHtml?: string) {
+  if (!articleHtml) return undefined;
+  const doc = parseDocument(articleHtml);
+  const firstParagraph = doc.querySelector("p");
+  const text = firstParagraph?.textContent?.trim();
+  return text ? truncateAtWord(text, 150) : undefined;
+}
+
+function buildOgTitle(abbreviation?: string, articleHeadlineHtml?: string) {
+  const headline = articleHeadlineHtml
+    ? normalizeSpaces(
+        parseDocument(articleHeadlineHtml).body?.textContent ?? "",
+      )
+    : undefined;
+
+  const base = abbreviation || headline;
+  if (!base) return undefined;
+
+  const full = abbreviation && headline ? `${abbreviation}: ${headline}` : base;
+
+  return truncateAtWord(full, 55) || undefined;
+}

--- a/frontend/src/composables/useCaselawSeo.spec.ts
+++ b/frontend/src/composables/useCaselawSeo.spec.ts
@@ -169,6 +169,19 @@ describe("useCaselawSeo", () => {
         expect.objectContaining({ description: "Gerichtsentscheidung" }),
       );
     });
+
+    it("truncates description at 150 characters word boundary", () => {
+      const guidingPrinciple =
+        "This is a long text " +
+        "LongWordWithoutWhiteSpacesShouldGetTruncated".repeat(3).trim();
+      useCaselawSeo({ caseLaw: { guidingPrinciple } as CaseLaw });
+
+      expect(useSeo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: "This is a long text",
+        }),
+      );
+    });
   });
 
   // TODO: Make sure the tests reflect the expected behavoir afer

--- a/frontend/src/composables/useNormSeo.spec.ts
+++ b/frontend/src/composables/useNormSeo.spec.ts
@@ -252,10 +252,7 @@ describe("buildValidityTitleLabel", () => {
     [dayjs("2025-01-01"), undefined, ", vom 01.01.2025"],
     [undefined, dayjs("2026-01-01"), ", bis 01.01.2026"],
     [dayjs("2025-01-01"), dayjs("2026-01-01"), ", 01.01.2025-01.01.2026"],
-  ])(
-    "formats the validity interval correctly",
-    (from, to, expected) => {
-      expect(buildValidityTitleLabel({ from, to })).toBe(expected);
-    },
-  );
+  ])("formats the validity interval correctly", (from, to, expected) => {
+    expect(buildValidityTitleLabel({ from, to })).toBe(expected);
+  });
 });

--- a/frontend/src/composables/useNormSeo.spec.ts
+++ b/frontend/src/composables/useNormSeo.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
-import { useNormSeo } from "./useNormSeo";
+import { buildValidityTitleLabel, useNormSeo } from "./useNormSeo";
 import { type LegislationExpression } from "~/types/api";
 import dayjs from "dayjs";
 
@@ -237,4 +237,25 @@ describe("useNormSeo", () => {
       );
     });
   });
+});
+
+describe("buildValidityTitleLabel", () => {
+  it("returns empty string when no interval is provided", () => {
+    expect(buildValidityTitleLabel()).toBe("");
+  });
+
+  it("returns empty string when interval has no dates", () => {
+    expect(buildValidityTitleLabel({})).toBe("");
+  });
+
+  it.each([
+    [dayjs("2025-01-01"), undefined, ", vom 01.01.2025"],
+    [undefined, dayjs("2026-01-01"), ", bis 01.01.2026"],
+    [dayjs("2025-01-01"), dayjs("2026-01-01"), ", 01.01.2025-01.01.2026"],
+  ])(
+    "formats the validity interval correctly",
+    (from, to, expected) => {
+      expect(buildValidityTitleLabel({ from, to })).toBe(expected);
+    },
+  );
 });

--- a/frontend/src/composables/useNormSeo.ts
+++ b/frontend/src/composables/useNormSeo.ts
@@ -25,22 +25,33 @@ function buildTitle(
   validityInterval?: ValidityInterval,
   validityStatus?: ValidityStatus,
 ) {
-  const validFrom = dateFormattedDDMMYYYY(validityInterval?.from);
-  const validTo = dateFormattedDDMMYYYY(validityInterval?.to);
-  let validityIntervalPart = "";
-  if (validFrom && validTo) {
-    validityIntervalPart = `, ${validFrom}-${validTo}`;
-  } else if (validFrom) {
-    validityIntervalPart = `, vom ${validFrom}`;
-  } else if (validTo) {
-    validityIntervalPart = `, bis ${validTo}`;
-  }
-
+  const validityIntervalPart = buildValidityTitleLabel(validityInterval);
   const validityStatusPart = validityStatus
     ? `, ${getValidityStatusLabel(validityStatus)}`
     : "";
 
   return `${norm.abbreviation ?? ""}${validityIntervalPart}${validityStatusPart}`;
+}
+
+/**
+ * Build a label to be used as part of a page title. If both dates are available
+ * it returns a range e.g. `, 01.01.2025-01.01.2026`. If only one of the dates exists,
+ * the date prefixed with a `vom` or `bis` is returned.
+ * NOTE: the string is prefixed with a `, ` so it can directly be inserted in to a title string.
+ * @param validityInterval
+ */
+export function buildValidityTitleLabel(validityInterval?: ValidityInterval) {
+  const validFrom = dateFormattedDDMMYYYY(validityInterval?.from);
+  const validTo = dateFormattedDDMMYYYY(validityInterval?.to);
+  if (validFrom && validTo) {
+    return `, ${validFrom}-${validTo}`;
+  } else if (validFrom) {
+    return `, vom ${validFrom}`;
+  } else if (validTo) {
+    return `, bis ${validTo}`;
+  }
+
+  return "";
 }
 
 function buildDescription(norm: LegislationExpression) {

--- a/frontend/src/composables/useSeo.spec.ts
+++ b/frontend/src/composables/useSeo.spec.ts
@@ -58,7 +58,7 @@ describe("useSeo composable", () => {
       );
     });
 
-    it("dose not set descriptions if undefined", () => {
+    it("dose not set descriptions if description is undefined", () => {
       useSeo({ title: "Test Title" });
 
       expect(useSeoMeta).toHaveBeenCalledWith(

--- a/frontend/src/composables/useSeo.spec.ts
+++ b/frontend/src/composables/useSeo.spec.ts
@@ -57,6 +57,24 @@ describe("useSeo composable", () => {
         }),
       );
     });
+
+    it("dose not set descriptions if undefined", () => {
+      useSeo({ title: "Test Title" });
+
+      expect(useSeoMeta).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Test Title",
+          ogType: "article",
+          ogTitle: "Test Title",
+          ogUrl: TEST_URL,
+          twitterTitle: "Test Title",
+        }),
+      );
+
+      expect(useHead).toHaveBeenCalledWith({
+        link: [{ rel: "canonical", href: TEST_URL }],
+      });
+    });
   });
 
   describe("dynamic (computed/ref) usage", () => {

--- a/frontend/src/composables/useSeo.ts
+++ b/frontend/src/composables/useSeo.ts
@@ -2,7 +2,7 @@ import { type MaybeRefOrGetter } from "vue";
 
 export type SeoInput = {
   title: MaybeRefOrGetter<string>;
-  description: MaybeRefOrGetter<string>;
+  description?: MaybeRefOrGetter<string>;
   /** Falls back to title if omitted */
   ogTitle?: MaybeRefOrGetter<string>;
 };

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -8,6 +8,7 @@ import {
 } from "~/types/api";
 import IcBaselineArrowBack from "~icons/ic/baseline-arrow-back";
 import IcBaselineArrowForward from "~icons/ic/baseline-arrow-Forward";
+import { useArticleSeo } from "~/composables/useArticleSeo";
 
 definePageMeta({
   // expression ELI + article eId
@@ -60,6 +61,10 @@ const tableOfContents = computed(() => {
   );
 });
 
+const singleViewParts = computed(() =>
+  getPartsLeafNodes(norm.value?.hasPart ?? []),
+);
+
 const article: Ref<Article | undefined> = computed(() =>
   // The eId is taken from the router, which always automatically decodes URIs.
   // However some eIds are pre-encoded in the XML data (e.g. "art-z§§ 1 bis 3"
@@ -71,16 +76,19 @@ const article: Ref<Article | undefined> = computed(() =>
   ),
 );
 
+useArticleSeo({
+  abbreviation: norm.value.abbreviation,
+  article: article.value,
+  articleHeadlineHtml: data.value.articleHeading,
+  articleHtml: data.value.htmlBody,
+});
+
 const previousArticleUrl: Ref<RouteLocationRaw | undefined> = computed(() =>
   getRouteForSiblingArticle(article.value, -1),
 );
 
 const nextArticleUrl: Ref<RouteLocationRaw | undefined> = computed(() =>
   getRouteForSiblingArticle(article.value, 1),
-);
-
-const singleViewParts = computed(() =>
-  getPartsLeafNodes(norm.value?.hasPart ?? []),
 );
 
 // Get all leaf nodes from the hasPart Tree.
@@ -171,34 +179,6 @@ const inForceNormLink = computed(() => {
   return `/norms/${validVersion?.item.legislationIdentifier}`;
 });
 
-const buildOgTitleForArticle = (
-  normAbbreviation?: string,
-  articleHeadlineHtml?: string,
-): string | undefined => {
-  const headlineText = (() => {
-    if (!articleHeadlineHtml) return "";
-    const doc = parseDocument(articleHeadlineHtml);
-    const text = doc.body?.textContent ?? "";
-    return text.replaceAll(/\s+/g, " ").trim();
-  })();
-
-  const base = normAbbreviation || headlineText;
-  if (!base) return undefined;
-
-  const full =
-    normAbbreviation && headlineText
-      ? `${normAbbreviation}: ${headlineText}`
-      : base;
-
-  return truncateAtWord(full, 55) || undefined;
-};
-
-const title = computed(() =>
-  norm.value
-    ? buildOgTitleForArticle(norm.value.abbreviation?.trim(), htmlTitle.value)
-    : "",
-);
-
 const metadataItems = computed(() => {
   const interval = temporalCoverageToValidityInterval(
     article.value?.temporalCoverage,
@@ -214,16 +194,6 @@ const metadataItems = computed(() => {
     },
   ];
 });
-
-const description = computed<string | undefined>(() => {
-  if (!articleHtml.value) return undefined;
-  const doc = parseDocument(articleHtml.value);
-  const firstParagraph = doc.querySelector("p");
-  const text = firstParagraph?.textContent?.trim();
-  return text ? truncateAtWord(text, 150) : undefined;
-});
-
-useDynamicSeo({ title, description });
 </script>
 
 <template>

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -77,10 +77,10 @@ const article: Ref<Article | undefined> = computed(() =>
 );
 
 useArticleSeo({
-  abbreviation: norm.value.abbreviation,
+  abbreviation: norm.value?.abbreviation,
   article: article.value,
-  articleHeadlineHtml: data.value.articleHeading,
-  articleHtml: data.value.htmlBody,
+  articleHeadlineHtml: data.value?.articleHeading,
+  articleHtml: data.value?.htmlBody,
 });
 
 const previousArticleUrl: Ref<RouteLocationRaw | undefined> = computed(() =>


### PR DESCRIPTION
- adapt single norm page title to requirements
- refactor meta tag creation be reusing `useSeo` component
- extract common logic into a utility function
- add tests and remove e2e test (redundant)

RISDEV-11570