### PR TITLE
RISDEV-10940 further improvements to sentry integration in the frontend

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -233,7 +233,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            NUXT_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             SENTRY_RELEASE=${{ env.SENTRY_RELEASE }}
           secrets: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/backend/src/main/resources/application-production.yaml
+++ b/backend/src/main/resources/application-production.yaml
@@ -30,7 +30,6 @@ management:
         include: health,info,prometheus
 
 sentry:
-  environment: production
   traces-sample-rate: 0.01
   logging:
     minimum-event-level: error

--- a/backend/src/main/resources/application-prototype.yaml
+++ b/backend/src/main/resources/application-prototype.yaml
@@ -33,7 +33,6 @@ management:
         include: health,info,prometheus
 
 sentry:
-  environment: prototype
   traces-sample-rate: 0.01
 
 logging:

--- a/backend/src/main/resources/application-staging.yaml
+++ b/backend/src/main/resources/application-staging.yaml
@@ -22,7 +22,6 @@ swagger:
     description: Public staging server
 
 sentry:
-  environment: staging-backend
   traces-sample-rate: 0.01
   logging:
     minimum-event-level: error

--- a/backend/src/main/resources/application-uat.yaml
+++ b/backend/src/main/resources/application-uat.yaml
@@ -21,7 +21,6 @@ swagger:
     description: Public uat server
 
 sentry:
-  environment: uat-backend
   traces-sample-rate: 0.01
   logging:
     minimum-event-level: error

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -91,6 +91,7 @@ local:
 
 sentry:
   release: "${SENTRY_RELEASE:default_release}"
+  environment: "${SENTRY_ENVIRONMENT:}"
 
 app:
   security:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:24.16.0-alpine3.22@sha256:191c9f0080fcbbc6547a85dc0ff7988072214a355aabdc1d2ec55a7dae5eea8a AS build
-ARG NUXT_PUBLIC_SENTRY_DSN
 ARG SENTRY_RELEASE
 RUN apk update && apk upgrade
 RUN corepack enable
@@ -17,7 +16,6 @@ RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,required=false \
   pnpm run prepare && NODE_OPTIONS="--max-old-space-size=4096" pnpm build
 
 FROM node:24.16.0-alpine3.22@sha256:191c9f0080fcbbc6547a85dc0ff7988072214a355aabdc1d2ec55a7dae5eea8a
-ARG NUXT_PUBLIC_SENTRY_DSN
 ARG SENTRY_RELEASE
 RUN apk update && apk upgrade && apk add dumb-init && apk cache clean
 USER node
@@ -29,7 +27,6 @@ COPY start.sh ./
 EXPOSE 3000
 ENV HOST=0.0.0.0 \
   PORT=3000 \
-  NUXT_PUBLIC_SENTRY_DSN=${NUXT_PUBLIC_SENTRY_DSN} \
   SENTRY_RELEASE=${SENTRY_RELEASE}
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["sh", "./start.sh"]

--- a/frontend/config/runtimeConfig.ts
+++ b/frontend/config/runtimeConfig.ts
@@ -31,6 +31,7 @@ export const runtimeConfig: NuxtConfig["runtimeConfig"] = {
     risBackendUrl: "",
     privateFeaturesEnabled: false,
     sentryDSN: "",
+    sentryEnvironment: "",
     analytics: {
       posthogKey: "",
       posthogHost: "",

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -5,6 +5,7 @@ const config = useRuntimeConfig();
 if (config.public.sentryDSN) {
   Sentry.init({
     dsn: config.public.sentryDSN,
+    environment: config.public.sentryEnvironment,
     tracesSampleRate: 1,
   });
 }

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/nuxt";
 if (process.env.NUXT_PUBLIC_SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.NUXT_PUBLIC_SENTRY_DSN,
+    environment: process.env.NUXT_PUBLIC_SENTRY_ENVIRONMENT,
     sampleRate: 0.5,
   });
 }


### PR DESCRIPTION
This PR simplifies Sentry setup by:

- loading the Sentry environment name from the env for both frontend and backend
- removing the Sentry DSN from the frontend image (and this repository)

Both the environment name and the DSN will be set in our infrastructure.

This PR is intended to be merged together with https://github.com/digitalservicebund/ris-search-infra/pull/8

Follow up tasks once both are done:

- [ ] Remove any environments we no longer need from Sentry via their UI
- [ ] Delete the DSN from this repository's secrets