### PR TITLE
RISDEV-11699 store search state directly in URL, remove sync

### DIFF
--- a/frontend/e2e/advancedSearch.spec.ts
+++ b/frontend/e2e/advancedSearch.spec.ts
@@ -89,6 +89,29 @@ test.describe("general advanced search page features", () => {
     ).toBeVisible();
   });
 
+  test("browser back restores previous state", async ({ page }) => {
+    await navigate(page, "/search");
+
+    await page.getByRole("link", { name: "Erweiterte Suche" }).click();
+    const advancedSearchHeading = page.getByRole("heading", {
+      level: 1,
+      name: "Erweiterte Suche",
+    });
+    await expect(advancedSearchHeading).toBeVisible();
+
+    const searchInput = page.getByRole("searchbox");
+    await searchInput.fill("Fiktiv");
+    await page.getByRole("button", { name: "Suchen" }).click();
+    await expect(searchInput).toHaveValue("Fiktiv");
+
+    await page.goBack();
+    await expect(advancedSearchHeading).toBeVisible();
+    await expect(searchInput).toBeEmpty();
+
+    await page.goBack();
+    await expect(page).toHaveURL("/search");
+  });
+
   test("pagination switches pages", async ({ page }) => {
     await navigate(
       page,

--- a/frontend/e2e/advancedSearch.spec.ts
+++ b/frontend/e2e/advancedSearch.spec.ts
@@ -382,6 +382,20 @@ test.describe("searching legislation", () => {
     ).toBeVisible();
   });
 
+  test("does not trigger a search when selecting a date filter type without entering a date", async ({
+    page,
+  }) => {
+    await navigate(page, "/advanced-search");
+    const initialUrl = page.url();
+
+    await page.getByRole("radio", { name: "Bestimmtes Datum" }).click();
+    expect(page.url()).toBe(initialUrl);
+
+    await page.getByRole("textbox", { name: "Datum" }).fill("01.01.2001");
+    await expect(page).toHaveURL(/dateFilterType=specificDate/);
+    await expect(page).toHaveURL(/dateFilterFrom=2001-01-01/);
+  });
+
   test("searches without date restrictions, shows validity badge", async ({
     page,
   }) => {

--- a/frontend/e2e/simpleSearch.spec.ts
+++ b/frontend/e2e/simpleSearch.spec.ts
@@ -37,6 +37,26 @@ test.describe("reach search from start page", () => {
 
     await expect(page.getByRole("searchbox"), "should be reset").toBeEmpty();
   });
+
+  test("browser back restores previous state", async ({ page }) => {
+    await navigate(page, "/");
+
+    await page.getByRole("button", { name: "Suchen" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Suche", level: 1 }),
+    ).toBeVisible();
+
+    const searchInput = page.getByRole("searchbox");
+    await searchInput.fill("Fiktiv");
+    await page.getByRole("button", { name: "Suchen" }).click();
+    await expect(searchInput).toHaveValue("Fiktiv");
+
+    await page.goBack();
+    await expect(searchInput).toBeEmpty();
+
+    await page.goBack();
+    await expect(page).toHaveURL("/");
+  });
 });
 
 test.describe("links to advanced search", () => {

--- a/frontend/e2e/simpleSearch.spec.ts
+++ b/frontend/e2e/simpleSearch.spec.ts
@@ -566,6 +566,23 @@ test.describe("searching caselaw", () => {
     );
   });
 
+  test("does not trigger a search when selecting a date filter type without entering a date", async ({
+    page,
+  }) => {
+    await navigate(page, "/search?documentKind=R");
+    const initialUrl = page.url();
+
+    const resultCounter = getResultCounter(page);
+    await expect(resultCounter).toHaveText(nonZeroResultCount);
+
+    await page.getByRole("combobox", { name: "Zeitraum" }).click();
+    await page.getByRole("option", { name: "Ab einem Datum" }).click();
+    expect(page.url()).toBe(initialUrl);
+
+    await page.getByRole("textbox", { name: "Datum" }).fill("10.04.2025");
+    await expect(page).toHaveURL(/dateFilterFrom=2025-04-10/);
+  });
+
   test("searches decision date before a date", async ({ page }) => {
     await navigate(page, "/search?documentKind=R");
 

--- a/frontend/src/composables/useAdvancedSearchRouteParams.spec.ts
+++ b/frontend/src/composables/useAdvancedSearchRouteParams.spec.ts
@@ -176,7 +176,7 @@ describe("useAdvancedSearchRouteParams", () => {
       expect(dateFilter.value.from).toBe("2023-01-01");
     });
 
-    it("returns an empty string if the 'from' date is not in the query", async () => {
+    it("returns undefined if the 'from' date is not in the query", async () => {
       vi.doMock("#app", () => ({
         useRoute: vi.fn().mockReturnValue({
           query: {},
@@ -206,7 +206,7 @@ describe("useAdvancedSearchRouteParams", () => {
       expect(dateFilter.value.to).toBe("2023-12-31");
     });
 
-    it("returns an empty string if the 'to' date is not in the query", async () => {
+    it("returns undefined if the 'to' date is not in the query", async () => {
       vi.doMock("#app", () => ({
         useRoute: vi.fn().mockReturnValue({
           query: {},
@@ -333,7 +333,7 @@ describe("useAdvancedSearchRouteParams", () => {
     });
   });
 
-  describe("saveFilterStateToRoute", () => {
+  describe("navigateToSearch", () => {
     it("retains the hash when the query did not change", async () => {
       const navigateToMock = vi.fn();
 
@@ -356,34 +356,34 @@ describe("useAdvancedSearchRouteParams", () => {
       const { useAdvancedSearchRouteParams } =
         await import("./useAdvancedSearchRouteParams");
 
-      const { saveFilterStateToRoute } = useAdvancedSearchRouteParams();
+      const { navigateToSearch } = useAdvancedSearchRouteParams();
 
-      await saveFilterStateToRoute();
+      await navigateToSearch({});
 
       expect(navigateToMock).toHaveBeenCalledWith(
         expect.objectContaining({ hash: "#some-anchor" }),
+        expect.anything(),
       );
     });
 
     it("retains the hash when the query was empty", async () => {
       const navigateToMock = vi.fn();
 
-      const query = {};
-
       vi.doMock("#app", () => ({
-        useRoute: vi.fn().mockReturnValue({ query, hash: "#some-anchor" }),
+        useRoute: vi.fn().mockReturnValue({ query: {}, hash: "#some-anchor" }),
         navigateTo: navigateToMock,
       }));
 
       const { useAdvancedSearchRouteParams } =
         await import("./useAdvancedSearchRouteParams");
 
-      const { saveFilterStateToRoute } = useAdvancedSearchRouteParams();
+      const { navigateToSearch } = useAdvancedSearchRouteParams();
 
-      await saveFilterStateToRoute();
+      await navigateToSearch({});
 
       expect(navigateToMock).toHaveBeenCalledWith(
         expect.objectContaining({ hash: "#some-anchor" }),
+        expect.anything(),
       );
     });
 
@@ -401,23 +401,22 @@ describe("useAdvancedSearchRouteParams", () => {
       const { useAdvancedSearchRouteParams } =
         await import("./useAdvancedSearchRouteParams");
 
-      const { query, saveFilterStateToRoute } = useAdvancedSearchRouteParams();
+      const { navigateToSearch } = useAdvancedSearchRouteParams();
 
-      query.value = "new search";
-      await saveFilterStateToRoute();
+      await navigateToSearch({ query: "new search" });
 
       expect(navigateToMock).toHaveBeenCalledWith(
         expect.objectContaining({ hash: undefined }),
+        expect.anything(),
       );
     });
 
-    it("calls navigateTo with all filter parameters", async () => {
+    it("calls navigation with all filter parameters", async () => {
       const navigateToMock = vi.fn();
-      const existingQuery = { existingParam: "value" };
 
       vi.doMock("#app", () => ({
         useRoute: vi.fn().mockReturnValue({
-          query: existingQuery,
+          query: {},
           hash: "",
         }),
         navigateTo: navigateToMock,
@@ -426,43 +425,37 @@ describe("useAdvancedSearchRouteParams", () => {
       const { useAdvancedSearchRouteParams } =
         await import("./useAdvancedSearchRouteParams");
 
-      const {
-        query,
-        documentKind,
-        dateFilter,
-        pageIndex,
-        sort,
-        itemsPerPage,
-        saveFilterStateToRoute,
-      } = useAdvancedSearchRouteParams();
+      const { navigateToSearch } = useAdvancedSearchRouteParams();
 
-      query.value = "test search";
-      documentKind.value = DocumentKind.CaseLaw;
-      dateFilter.value = {
-        type: "allTime",
-        from: "2023-01-01",
-        to: "2023-12-31",
-      };
-      pageIndex.value = 2;
-      sort.value = "relevance";
-      itemsPerPage.value = "100";
-
-      await saveFilterStateToRoute();
-
-      expect(navigateToMock).toHaveBeenCalledWith({
-        hash: undefined,
-        query: {
-          existingParam: "value",
-          q: "test%20search",
-          documentKind: "R",
-          dateFilterType: "allTime",
-          dateFilterFrom: "2023-01-01",
-          dateFilterTo: "2023-12-31",
-          pageIndex: "2",
-          sort: "relevance",
-          itemsPerPage: "100",
+      await navigateToSearch({
+        query: "test search",
+        documentKind: DocumentKind.CaseLaw,
+        dateFilter: {
+          type: "allTime",
+          from: "2023-01-01",
+          to: "2023-12-31",
         },
+        pageIndex: 2,
+        sort: "relevance",
+        itemsPerPage: "100",
       });
+
+      expect(navigateToMock).toHaveBeenCalledWith(
+        {
+          hash: "",
+          query: {
+            q: "test%20search",
+            documentKind: "R",
+            dateFilterType: "allTime",
+            dateFilterFrom: "2023-01-01",
+            dateFilterTo: "2023-12-31",
+            pageIndex: "2",
+            sort: "relevance",
+            itemsPerPage: "100",
+          },
+        },
+        { replace: undefined },
+      );
     });
 
     it("encodes the query string", async () => {
@@ -478,16 +471,18 @@ describe("useAdvancedSearchRouteParams", () => {
       const { useAdvancedSearchRouteParams } =
         await import("./useAdvancedSearchRouteParams");
 
-      const { query, saveFilterStateToRoute } = useAdvancedSearchRouteParams();
+      const { navigateToSearch } = useAdvancedSearchRouteParams();
 
-      query.value = "DATUM:>2021-01-01";
-      await saveFilterStateToRoute();
+      await navigateToSearch({ query: "DATUM:>2021-01-01" });
 
-      expect(navigateToMock).toHaveBeenCalledWith({
-        query: expect.objectContaining({
-          q: encodeURIComponent("DATUM:>2021-01-01"),
+      expect(navigateToMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            q: encodeURIComponent("DATUM:>2021-01-01"),
+          }),
         }),
-      });
+        expect.anything(),
+      );
     });
 
     it("handles undefined date filter values by setting empty strings", async () => {
@@ -503,23 +498,107 @@ describe("useAdvancedSearchRouteParams", () => {
       const { useAdvancedSearchRouteParams } =
         await import("./useAdvancedSearchRouteParams");
 
-      const { dateFilter, saveFilterStateToRoute } =
-        useAdvancedSearchRouteParams();
+      const { navigateToSearch } = useAdvancedSearchRouteParams();
 
-      dateFilter.value = {
-        type: "allTime",
-        from: undefined,
-        to: undefined,
-      };
-
-      await saveFilterStateToRoute();
-
-      expect(navigateToMock).toHaveBeenCalledWith({
-        query: expect.objectContaining({
-          dateFilterFrom: "",
-          dateFilterTo: "",
-        }),
+      await navigateToSearch({
+        dateFilter: { type: "allTime", from: undefined, to: undefined },
       });
+
+      expect(navigateToMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dateFilterFrom: "",
+            dateFilterTo: "",
+          }),
+        }),
+        expect.anything(),
+      );
+    });
+
+    it("passes replace option to navigation", async () => {
+      const navigateToMock = vi.fn();
+
+      vi.doMock("#app", () => ({
+        useRoute: vi.fn().mockReturnValue({
+          query: {},
+        }),
+        navigateTo: navigateToMock,
+      }));
+
+      const { useAdvancedSearchRouteParams } =
+        await import("./useAdvancedSearchRouteParams");
+
+      const { navigateToSearch } = useAdvancedSearchRouteParams();
+
+      await navigateToSearch({ pageIndex: 3 }, { replace: true });
+
+      expect(navigateToMock).toHaveBeenCalledWith(expect.anything(), {
+        replace: true,
+      });
+    });
+
+    it("resets query and date filter when document kind changes", async () => {
+      const navigateToMock = vi.fn();
+
+      vi.doMock("#app", () => ({
+        useRoute: vi.fn().mockReturnValue({
+          query: {
+            documentKind: "N",
+            q: "some%20query",
+            dateFilterType: "currentlyInForce",
+          },
+        }),
+        navigateTo: navigateToMock,
+      }));
+
+      const { useAdvancedSearchRouteParams } =
+        await import("./useAdvancedSearchRouteParams");
+
+      const { navigateToSearch } = useAdvancedSearchRouteParams();
+
+      await navigateToSearch({ documentKind: DocumentKind.CaseLaw });
+
+      expect(navigateToMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            q: "",
+            documentKind: "R",
+            dateFilterType: "allTime",
+          }),
+        }),
+        expect.anything(),
+      );
+    });
+
+    it("filters by currently in force when switching to Norm", async () => {
+      const navigateToMock = vi.fn();
+
+      vi.doMock("#app", () => ({
+        useRoute: vi.fn().mockReturnValue({
+          query: {
+            documentKind: "R",
+            dateFilterType: "allTime",
+          },
+        }),
+        navigateTo: navigateToMock,
+      }));
+
+      const { useAdvancedSearchRouteParams } =
+        await import("./useAdvancedSearchRouteParams");
+
+      const { navigateToSearch } = useAdvancedSearchRouteParams();
+
+      await navigateToSearch({ documentKind: DocumentKind.Norm });
+
+      expect(navigateToMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            documentKind: "N",
+            dateFilterType: "currentlyInForce",
+          }),
+        }),
+        expect.anything(),
+      );
     });
   });
 

--- a/frontend/src/composables/useAdvancedSearchRouteParams.ts
+++ b/frontend/src/composables/useAdvancedSearchRouteParams.ts
@@ -1,122 +1,148 @@
 import { isEmpty, isEqual } from "lodash-es";
 import { navigateTo, useRoute } from "#app";
-import type { LocationQueryRaw, LocationQueryValue } from "#vue-router";
+import type { LocationQueryRaw } from "#vue-router";
 import { DocumentKind } from "~/types/api";
+import { isDocumentKind } from "~/utils/documentKind";
 import {
   type DateFilterValue,
   isFilterType,
 } from "~/utils/search/dateFilterType";
 import { searchParamToNumber, searchParamToString } from "~/utils/searchParams";
 
+export interface AdvancedSearchRouteParams {
+  query?: string;
+  documentKind?: DocumentKind;
+  dateFilter?: DateFilterValue;
+  sort?: string;
+  itemsPerPage?: string;
+  pageIndex?: number;
+}
+
 export function useAdvancedSearchRouteParams() {
   const route = useRoute();
 
   // General parameters -------------------------------------
 
-  const documentKind = ref<DocumentKind>(DocumentKind.Norm);
+  const documentKind = computed(() => {
+    const param = searchParamToString(route.query.documentKind);
+    return param && isDocumentKind(param) ? param : DocumentKind.Norm;
+  });
 
-  const query = ref<string>("");
+  const query = computed(() =>
+    decodeURIComponent(searchParamToString(route.query.q) ?? ""),
+  );
 
-  // Date filter --------------------------------------------
+  const dateFilter = computed<DateFilterValue>(() => {
+    const typeParam = searchParamToString(route.query.dateFilterType);
+    let type: DateFilterValue["type"];
 
-  function getInitialFilterTypeFromQuery(
-    init: LocationQueryValue | LocationQueryValue[] | undefined,
-  ): DateFilterValue["type"] {
-    if (typeof init !== "string" || !isFilterType(init)) {
-      // If the initial value is no valid filter, return the default filter
-      // based on the selected document kind
-      return documentKind.value === DocumentKind.Norm
-        ? "currentlyInForce"
-        : "allTime";
-    } else if (
-      init === "currentlyInForce" &&
-      documentKind.value !== DocumentKind.Norm
-    ) {
-      // If the current filter is not valid for the current selection, return
-      // a different filter
-      return "allTime";
+    if (typeof typeParam === "string" && isFilterType(typeParam)) {
+      // If the current filter is not valid for the current document kind
+      if (
+        typeParam === "currentlyInForce" &&
+        documentKind.value !== DocumentKind.Norm
+      ) {
+        type = "allTime";
+      } else {
+        type = typeParam;
+      }
+    } else {
+      // Default depends on document kind
+      type =
+        documentKind.value === DocumentKind.Norm
+          ? "currentlyInForce"
+          : "allTime";
     }
-    // Return parsed filter
-    else return init;
-  }
 
-  const dateFilter = ref<DateFilterValue>({ type: "allTime" });
+    return {
+      type,
+      from: searchParamToString(route.query.dateFilterFrom) || undefined,
+      to: searchParamToString(route.query.dateFilterTo) || undefined,
+    };
+  });
 
-  // Sort & pagination --------------------------------------
+  const sort = computed(
+    () => searchParamToString(route.query.sort) ?? "default",
+  );
 
-  const sort = ref<string>("default");
+  const itemsPerPage = computed(
+    () => searchParamToString(route.query.itemsPerPage) ?? "50",
+  );
 
-  const itemsPerPage = ref<string>("50");
+  const pageIndex = computed(() =>
+    searchParamToNumber(route.query.pageIndex, 0),
+  );
 
-  const pageIndex = ref<number>(0);
+  // Navigation helper --------------------------------------
 
-  // Saving and restoring -----------------------------------
-
-  function loadFilterStateFromRoute(routeQuery = route.query) {
-    const documentKindParam = searchParamToString(routeQuery.documentKind);
-    documentKind.value =
-      documentKindParam && isDocumentKind(documentKindParam)
-        ? documentKindParam
-        : DocumentKind.Norm;
-
-    query.value = decodeURIComponent(searchParamToString(routeQuery.q) ?? "");
-
-    dateFilter.value = {
-      type: getInitialFilterTypeFromQuery(routeQuery.dateFilterType),
-      from: searchParamToString(routeQuery.dateFilterFrom),
-      to: searchParamToString(routeQuery.dateFilterTo),
+  function navigateToSearch(
+    params: AdvancedSearchRouteParams,
+    options?: { replace?: boolean },
+  ) {
+    const merged: AdvancedSearchRouteParams = {
+      query: query.value,
+      documentKind: documentKind.value,
+      dateFilter: dateFilter.value,
+      sort: sort.value,
+      itemsPerPage: itemsPerPage.value,
+      pageIndex: pageIndex.value,
+      ...params,
     };
 
-    sort.value = searchParamToString(routeQuery.sort) ?? "default";
+    // When documentKind changes, reset query
+    if (
+      params.documentKind !== undefined &&
+      params.documentKind !== documentKind.value
+    ) {
+      if (params.query === undefined) merged.query = "";
+      if (!params.dateFilter) {
+        merged.dateFilter = {
+          type:
+            params.documentKind === DocumentKind.Norm
+              ? "currentlyInForce"
+              : "allTime",
+        };
+      }
+    }
 
-    itemsPerPage.value = searchParamToString(routeQuery.itemsPerPage) ?? "50";
-
-    pageIndex.value = searchParamToNumber(routeQuery.pageIndex, 0);
-  }
-
-  function saveFilterStateToRoute() {
     const from = { ...route.query };
 
     const to: LocationQueryRaw = {
-      ...from,
-      q: encodeURIComponent(query.value),
-      documentKind: documentKind.value,
-      dateFilterType: dateFilter.value.type,
-      dateFilterFrom: dateFilter.value.from ?? "",
-      dateFilterTo: dateFilter.value.to ?? "",
-      pageIndex: pageIndex.value.toString(),
-      sort: sort.value,
-      itemsPerPage: itemsPerPage.value,
+      q: encodeURIComponent(merged.query ?? ""),
+      documentKind: merged.documentKind ?? DocumentKind.Norm,
+      dateFilterType: merged.dateFilter?.type ?? "allTime",
+      dateFilterFrom: merged.dateFilter?.from ?? "",
+      dateFilterTo: merged.dateFilter?.to ?? "",
+      pageIndex: (merged.pageIndex ?? 0).toString(),
+      sort: merged.sort ?? "default",
+      itemsPerPage: merged.itemsPerPage ?? "50",
     };
 
     // Hash is used for skip links on the page:
     //
-    // - We'll keep it if the search params haven't change or if no search has
+    // - We'll keep it if the search params haven't changed or if no search has
     //   been performed yet (-> route change is due to hash change, so any
     //   change to the hash would break navigation)
     // - Remove it if the search params have changed (-> route change is due to
     //   search, so keeping the hash would cause unintended scrolling)
     const shouldKeepHash = isEmpty(from) || isEqual(from, to);
 
-    return navigateTo({
-      hash: shouldKeepHash ? route.hash : undefined,
-      query: to,
-    });
+    return navigateTo(
+      {
+        hash: shouldKeepHash ? route.hash : undefined,
+        query: to,
+      },
+      { replace: options?.replace },
+    );
   }
-
-  watch(
-    () => route.query,
-    (val) => loadFilterStateFromRoute(val),
-    { immediate: true },
-  );
 
   return {
     dateFilter,
     documentKind,
     itemsPerPage,
+    navigateToSearch,
     pageIndex,
     query,
-    saveFilterStateToRoute,
     sort,
   };
 }

--- a/frontend/src/composables/useAdvancedSearchRouteParams.ts
+++ b/frontend/src/composables/useAdvancedSearchRouteParams.ts
@@ -18,6 +18,19 @@ export interface AdvancedSearchRouteParams {
   pageIndex?: number;
 }
 
+export const ADVANCED_SEARCH_DEFAULTS = {
+  documentKind: DocumentKind.Norm,
+  sort: "default",
+  itemsPerPage: "50",
+  pageIndex: 0,
+} as const;
+
+export function getDefaultDateFilterType(
+  documentKind: DocumentKind,
+): DateFilterValue["type"] {
+  return documentKind === DocumentKind.Norm ? "currentlyInForce" : "allTime";
+}
+
 export function useAdvancedSearchRouteParams() {
   const route = useRoute();
 
@@ -25,7 +38,9 @@ export function useAdvancedSearchRouteParams() {
 
   const documentKind = computed(() => {
     const param = searchParamToString(route.query.documentKind);
-    return param && isDocumentKind(param) ? param : DocumentKind.Norm;
+    return param && isDocumentKind(param)
+      ? param
+      : ADVANCED_SEARCH_DEFAULTS.documentKind;
   });
 
   const query = computed(() =>
@@ -47,11 +62,7 @@ export function useAdvancedSearchRouteParams() {
         type = typeParam;
       }
     } else {
-      // Default depends on document kind
-      type =
-        documentKind.value === DocumentKind.Norm
-          ? "currentlyInForce"
-          : "allTime";
+      type = getDefaultDateFilterType(documentKind.value);
     }
 
     return {
@@ -62,15 +73,21 @@ export function useAdvancedSearchRouteParams() {
   });
 
   const sort = computed(
-    () => searchParamToString(route.query.sort) ?? "default",
+    () =>
+      searchParamToString(route.query.sort) ?? ADVANCED_SEARCH_DEFAULTS.sort,
   );
 
   const itemsPerPage = computed(
-    () => searchParamToString(route.query.itemsPerPage) ?? "50",
+    () =>
+      searchParamToString(route.query.itemsPerPage) ??
+      ADVANCED_SEARCH_DEFAULTS.itemsPerPage,
   );
 
   const pageIndex = computed(() =>
-    searchParamToNumber(route.query.pageIndex, 0),
+    searchParamToNumber(
+      route.query.pageIndex,
+      ADVANCED_SEARCH_DEFAULTS.pageIndex,
+    ),
   );
 
   // Navigation helper --------------------------------------
@@ -89,7 +106,7 @@ export function useAdvancedSearchRouteParams() {
       ...params,
     };
 
-    // When documentKind changes, reset query
+    // When documentKind changes, reset query and date filter
     if (
       params.documentKind !== undefined &&
       params.documentKind !== documentKind.value
@@ -97,10 +114,7 @@ export function useAdvancedSearchRouteParams() {
       if (params.query === undefined) merged.query = "";
       if (!params.dateFilter) {
         merged.dateFilter = {
-          type:
-            params.documentKind === DocumentKind.Norm
-              ? "currentlyInForce"
-              : "allTime",
+          type: getDefaultDateFilterType(params.documentKind),
         };
       }
     }
@@ -109,13 +123,15 @@ export function useAdvancedSearchRouteParams() {
 
     const to: LocationQueryRaw = {
       q: encodeURIComponent(merged.query ?? ""),
-      documentKind: merged.documentKind ?? DocumentKind.Norm,
-      dateFilterType: merged.dateFilter?.type ?? "allTime",
+      documentKind: merged.documentKind,
+      dateFilterType: merged.dateFilter?.type,
       dateFilterFrom: merged.dateFilter?.from ?? "",
       dateFilterTo: merged.dateFilter?.to ?? "",
-      pageIndex: (merged.pageIndex ?? 0).toString(),
-      sort: merged.sort ?? "default",
-      itemsPerPage: merged.itemsPerPage ?? "50",
+      pageIndex: (
+        merged.pageIndex ?? ADVANCED_SEARCH_DEFAULTS.pageIndex
+      ).toString(),
+      sort: merged.sort,
+      itemsPerPage: merged.itemsPerPage,
     };
 
     // Hash is used for skip links on the page:

--- a/frontend/src/composables/useAdvancedSearchRouteParams.ts
+++ b/frontend/src/composables/useAdvancedSearchRouteParams.ts
@@ -43,9 +43,14 @@ export function useAdvancedSearchRouteParams() {
       : ADVANCED_SEARCH_DEFAULTS.documentKind;
   });
 
-  const query = computed(() =>
-    decodeURIComponent(searchParamToString(route.query.q) ?? ""),
-  );
+  const query = computed(() => {
+    const raw = searchParamToString(route.query.q) ?? "";
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      return raw;
+    }
+  });
 
   const dateFilter = computed<DateFilterValue>(() => {
     const typeParam = searchParamToString(route.query.dateFilterType);

--- a/frontend/src/composables/useSimpleSearchRouteParams.spec.ts
+++ b/frontend/src/composables/useSimpleSearchRouteParams.spec.ts
@@ -382,7 +382,7 @@ describe("useSimpleSearchRouteParams", () => {
     });
   });
 
-  describe("saveFilterStateToRoute", () => {
+  describe("navigateToSearch", () => {
     it("retains the hash when the query did not change", async () => {
       const navigateToMock = vi.fn();
 
@@ -407,34 +407,34 @@ describe("useSimpleSearchRouteParams", () => {
       const { useSimpleSearchRouteParams } =
         await import("./useSimpleSearchRouteParams");
 
-      const { saveFilterStateToRoute } = useSimpleSearchRouteParams();
+      const { navigateToSearch } = useSimpleSearchRouteParams();
 
-      await saveFilterStateToRoute();
+      await navigateToSearch({});
 
       expect(navigateToMock).toHaveBeenCalledWith(
         expect.objectContaining({ hash: "#some-anchor" }),
+        expect.anything(),
       );
     });
 
     it("retains the hash when the query was empty", async () => {
       const navigateToMock = vi.fn();
 
-      const query = {};
-
       vi.doMock("#app", () => ({
-        useRoute: vi.fn().mockReturnValue({ query, hash: "#some-anchor" }),
+        useRoute: vi.fn().mockReturnValue({ query: {}, hash: "#some-anchor" }),
         navigateTo: navigateToMock,
       }));
 
       const { useSimpleSearchRouteParams } =
         await import("./useSimpleSearchRouteParams");
 
-      const { saveFilterStateToRoute } = useSimpleSearchRouteParams();
+      const { navigateToSearch } = useSimpleSearchRouteParams();
 
-      await saveFilterStateToRoute();
+      await navigateToSearch({});
 
       expect(navigateToMock).toHaveBeenCalledWith(
         expect.objectContaining({ hash: "#some-anchor" }),
+        expect.anything(),
       );
     });
 
@@ -452,23 +452,22 @@ describe("useSimpleSearchRouteParams", () => {
       const { useSimpleSearchRouteParams } =
         await import("./useSimpleSearchRouteParams");
 
-      const { query, saveFilterStateToRoute } = useSimpleSearchRouteParams();
+      const { navigateToSearch } = useSimpleSearchRouteParams();
 
-      query.value = "new search";
-      await saveFilterStateToRoute();
+      await navigateToSearch({ query: "new search" });
 
       expect(navigateToMock).toHaveBeenCalledWith(
         expect.objectContaining({ hash: undefined }),
+        expect.anything(),
       );
     });
 
-    it("calls navigateTo with all filter parameters", async () => {
+    it("calls navigation with all filter parameters", async () => {
       const navigateToMock = vi.fn();
-      const existingQuery = { existingParam: "value" };
 
       vi.doMock("#app", () => ({
         useRoute: vi.fn().mockReturnValue({
-          query: existingQuery,
+          query: {},
           hash: "",
         }),
         navigateTo: navigateToMock,
@@ -477,49 +476,41 @@ describe("useSimpleSearchRouteParams", () => {
       const { useSimpleSearchRouteParams } =
         await import("./useSimpleSearchRouteParams");
 
-      const {
-        query,
-        documentKind,
-        court,
-        typeGroup,
-        dateFilter,
-        pageIndex,
-        sort,
-        itemsPerPage,
-        saveFilterStateToRoute,
-      } = useSimpleSearchRouteParams();
+      const { navigateToSearch } = useSimpleSearchRouteParams();
 
-      query.value = "test search";
-      documentKind.value = DocumentKind.CaseLaw;
-      court.value = "BGH";
-      typeGroup.value = "example-type-group";
-      dateFilter.value = {
-        type: "allTime",
-        from: "2023-01-01",
-        to: "2023-12-31",
-      };
-      pageIndex.value = 2;
-      sort.value = "relevance";
-      itemsPerPage.value = "100";
-
-      await saveFilterStateToRoute();
-
-      expect(navigateToMock).toHaveBeenCalledWith({
-        hash: undefined,
-        query: {
-          existingParam: "value",
-          query: "test%20search",
-          court: "BGH",
-          documentKind: "R",
-          typeGroup: "example-type-group",
-          dateFilterType: "allTime",
-          dateFilterFrom: "2023-01-01",
-          dateFilterTo: "2023-12-31",
-          pageIndex: "2",
-          sort: "relevance",
-          itemsPerPage: "100",
+      await navigateToSearch({
+        query: "test search",
+        documentKind: DocumentKind.CaseLaw,
+        court: "BGH",
+        typeGroup: "example-type-group",
+        dateFilter: {
+          type: "allTime",
+          from: "2023-01-01",
+          to: "2023-12-31",
         },
+        pageIndex: 2,
+        sort: "relevance",
+        itemsPerPage: "100",
       });
+
+      expect(navigateToMock).toHaveBeenCalledWith(
+        {
+          hash: "",
+          query: {
+            query: "test%20search",
+            court: "BGH",
+            documentKind: "R",
+            typeGroup: "example-type-group",
+            dateFilterType: "allTime",
+            dateFilterFrom: "2023-01-01",
+            dateFilterTo: "2023-12-31",
+            pageIndex: "2",
+            sort: "relevance",
+            itemsPerPage: "100",
+          },
+        },
+        { replace: undefined },
+      );
     });
 
     it("encodes the query string", async () => {
@@ -535,16 +526,18 @@ describe("useSimpleSearchRouteParams", () => {
       const { useSimpleSearchRouteParams } =
         await import("./useSimpleSearchRouteParams");
 
-      const { query, saveFilterStateToRoute } = useSimpleSearchRouteParams();
+      const { navigateToSearch } = useSimpleSearchRouteParams();
 
-      query.value = "DATUM:>2021-01-01";
-      await saveFilterStateToRoute();
+      await navigateToSearch({ query: "DATUM:>2021-01-01" });
 
-      expect(navigateToMock).toHaveBeenCalledWith({
-        query: expect.objectContaining({
-          query: encodeURIComponent("DATUM:>2021-01-01"),
+      expect(navigateToMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: encodeURIComponent("DATUM:>2021-01-01"),
+          }),
         }),
-      });
+        expect.anything(),
+      );
     });
 
     it("handles undefined date filter values by setting empty strings", async () => {
@@ -560,23 +553,141 @@ describe("useSimpleSearchRouteParams", () => {
       const { useSimpleSearchRouteParams } =
         await import("./useSimpleSearchRouteParams");
 
-      const { dateFilter, saveFilterStateToRoute } =
-        useSimpleSearchRouteParams();
+      const { navigateToSearch } = useSimpleSearchRouteParams();
 
-      dateFilter.value = {
-        type: "allTime",
-        from: undefined,
-        to: undefined,
-      };
-
-      await saveFilterStateToRoute();
-
-      expect(navigateToMock).toHaveBeenCalledWith({
-        query: expect.objectContaining({
-          dateFilterFrom: "",
-          dateFilterTo: "",
-        }),
+      await navigateToSearch({
+        dateFilter: { type: "allTime", from: undefined, to: undefined },
       });
+
+      expect(navigateToMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dateFilterFrom: "",
+            dateFilterTo: "",
+          }),
+        }),
+        expect.anything(),
+      );
+    });
+
+    it("passes replace option to navigation", async () => {
+      const navigateToMock = vi.fn();
+
+      vi.doMock("#app", () => ({
+        useRoute: vi.fn().mockReturnValue({
+          query: {},
+        }),
+        navigateTo: navigateToMock,
+      }));
+
+      const { useSimpleSearchRouteParams } =
+        await import("./useSimpleSearchRouteParams");
+
+      const { navigateToSearch } = useSimpleSearchRouteParams();
+
+      await navigateToSearch({ pageIndex: 3 }, { replace: true });
+
+      expect(navigateToMock).toHaveBeenCalledWith(expect.anything(), {
+        replace: true,
+      });
+    });
+
+    it("resets date filter when document kind changes", async () => {
+      const navigateToMock = vi.fn();
+
+      vi.doMock("#app", () => ({
+        useRoute: vi.fn().mockReturnValue({
+          query: {
+            documentKind: "R",
+            dateFilterType: "period",
+            dateFilterFrom: "2024-01-01",
+            dateFilterTo: "2024-12-31",
+          },
+        }),
+        navigateTo: navigateToMock,
+      }));
+
+      const { useSimpleSearchRouteParams } =
+        await import("./useSimpleSearchRouteParams");
+
+      const { navigateToSearch } = useSimpleSearchRouteParams();
+
+      await navigateToSearch({ documentKind: DocumentKind.Norm });
+
+      expect(navigateToMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dateFilterType: "allTime",
+            dateFilterFrom: "",
+            dateFilterTo: "",
+          }),
+        }),
+        expect.anything(),
+      );
+    });
+
+    it("resets type group and court when changing from Case Law", async () => {
+      const navigateToMock = vi.fn();
+
+      vi.doMock("#app", () => ({
+        useRoute: vi.fn().mockReturnValue({
+          query: {
+            documentKind: "R",
+            typeGroup: "urteil",
+            court: "BGH",
+          },
+        }),
+        navigateTo: navigateToMock,
+      }));
+
+      const { useSimpleSearchRouteParams } =
+        await import("./useSimpleSearchRouteParams");
+
+      const { navigateToSearch } = useSimpleSearchRouteParams();
+
+      await navigateToSearch({ documentKind: DocumentKind.All });
+
+      expect(navigateToMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            typeGroup: "",
+            court: "",
+          }),
+        }),
+        expect.anything(),
+      );
+    });
+
+    it("does not reset type group and court when staying on Case Law", async () => {
+      const navigateToMock = vi.fn();
+
+      vi.doMock("#app", () => ({
+        useRoute: vi.fn().mockReturnValue({
+          query: {
+            documentKind: "R",
+            typeGroup: "urteil",
+            court: "BGH",
+          },
+        }),
+        navigateTo: navigateToMock,
+      }));
+
+      const { useSimpleSearchRouteParams } =
+        await import("./useSimpleSearchRouteParams");
+
+      const { navigateToSearch } = useSimpleSearchRouteParams();
+
+      await navigateToSearch({ query: "test" });
+
+      expect(navigateToMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            typeGroup: "urteil",
+            court: "BGH",
+          }),
+        }),
+        expect.anything(),
+      );
     });
   });
 
@@ -598,96 +709,5 @@ describe("useSimpleSearchRouteParams", () => {
     await nextTick();
 
     expect(query.value).toEqual("test after");
-  });
-
-  describe("document kind change side effects", () => {
-    it("resets dateFilter when changing document kind", async () => {
-      const routeQuery = reactive({
-        query: {
-          documentKind: DocumentKind.CaseLaw,
-          dateFilterType: "period",
-          dateFilterFrom: "2024-01-01",
-          dateFilterTo: "2024-12-31",
-        },
-      });
-
-      vi.doMock("#app", () => ({
-        useRoute: vi.fn().mockReturnValue(routeQuery),
-      }));
-
-      const { useSimpleSearchRouteParams } =
-        await import("./useSimpleSearchRouteParams");
-
-      const { documentKind, dateFilter } = useSimpleSearchRouteParams();
-
-      expect(documentKind.value).toEqual(DocumentKind.CaseLaw);
-      expect(dateFilter.value.type).toBe("period");
-
-      documentKind.value = DocumentKind.Norm;
-
-      expect(dateFilter.value.type).toBe("allTime");
-    });
-
-    it("resets typeGroup and court when changing from CaseLaw", async () => {
-      const routeQuery = reactive({
-        query: {
-          documentKind: DocumentKind.CaseLaw,
-          typeGroup: "urteil",
-          court: "BGH",
-        },
-      });
-
-      vi.doMock("#app", () => ({
-        useRoute: vi.fn().mockReturnValue(routeQuery),
-      }));
-
-      const { useSimpleSearchRouteParams } =
-        await import("./useSimpleSearchRouteParams");
-
-      const { documentKind, typeGroup, court } = useSimpleSearchRouteParams();
-
-      expect(documentKind.value).toEqual(DocumentKind.CaseLaw);
-      expect(typeGroup.value).toBe("urteil");
-      expect(court.value).toBe("BGH");
-
-      documentKind.value = DocumentKind.All;
-
-      expect(typeGroup.value).toBeUndefined();
-      expect(court.value).toBeUndefined();
-    });
-
-    it("resets all CaseLaw-specific filters when changing from CaseLaw to All", async () => {
-      const routeQuery = reactive({
-        query: {
-          documentKind: DocumentKind.CaseLaw,
-          typeGroup: "urteil",
-          court: "BGH",
-          dateFilterType: "period",
-          dateFilterFrom: "2024-01-01",
-          dateFilterTo: "2024-12-31",
-        },
-      });
-
-      vi.doMock("#app", () => ({
-        useRoute: vi.fn().mockReturnValue(routeQuery),
-      }));
-
-      const { useSimpleSearchRouteParams } =
-        await import("./useSimpleSearchRouteParams");
-
-      const { documentKind, typeGroup, court, dateFilter } =
-        useSimpleSearchRouteParams();
-
-      expect(documentKind.value).toEqual(DocumentKind.CaseLaw);
-      expect(typeGroup.value).toBe("urteil");
-      expect(court.value).toBe("BGH");
-      expect(dateFilter.value.type).toBe("period");
-
-      documentKind.value = DocumentKind.All;
-
-      expect(typeGroup.value).toBeUndefined();
-      expect(court.value).toBeUndefined();
-      expect(dateFilter.value.type).toBe("allTime");
-    });
   });
 });

--- a/frontend/src/composables/useSimpleSearchRouteParams.ts
+++ b/frontend/src/composables/useSimpleSearchRouteParams.ts
@@ -33,9 +33,14 @@ export function useSimpleSearchRouteParams() {
 
   // General parameters -------------------------------------
 
-  const query = computed(() =>
-    decodeURIComponent(searchParamToString(route.query.query) ?? ""),
-  );
+  const query = computed(() => {
+    const raw = searchParamToString(route.query.query) ?? "";
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      return raw;
+    }
+  });
 
   const documentKind = computed(() => {
     const param = searchParamToString(route.query.documentKind);

--- a/frontend/src/composables/useSimpleSearchRouteParams.ts
+++ b/frontend/src/composables/useSimpleSearchRouteParams.ts
@@ -20,6 +20,14 @@ export interface SearchRouteParams {
   pageIndex?: number;
 }
 
+export const SIMPLE_SEARCH_DEFAULTS = {
+  documentKind: DocumentKind.All,
+  sort: "default",
+  itemsPerPage: "10",
+  pageIndex: 0,
+  dateFilterType: "allTime" as const,
+} as const;
+
 export function useSimpleSearchRouteParams() {
   const route = useRoute();
 
@@ -31,7 +39,9 @@ export function useSimpleSearchRouteParams() {
 
   const documentKind = computed(() => {
     const param = searchParamToString(route.query.documentKind);
-    return param && isDocumentKind(param) ? param : DocumentKind.All;
+    return param && isDocumentKind(param)
+      ? param
+      : SIMPLE_SEARCH_DEFAULTS.documentKind;
   });
 
   const typeGroup = computed(
@@ -47,7 +57,7 @@ export function useSimpleSearchRouteParams() {
     const type =
       typeof typeParam === "string" && isFilterType(typeParam)
         ? typeParam
-        : "allTime";
+        : SIMPLE_SEARCH_DEFAULTS.dateFilterType;
     return {
       type,
       from: searchParamToString(route.query.dateFilterFrom) || undefined,
@@ -56,15 +66,18 @@ export function useSimpleSearchRouteParams() {
   });
 
   const sort = computed(
-    () => searchParamToString(route.query.sort) ?? "default",
+    () =>
+      searchParamToString(route.query.sort) ?? SIMPLE_SEARCH_DEFAULTS.sort,
   );
 
   const itemsPerPage = computed(
-    () => searchParamToString(route.query.itemsPerPage) ?? "10",
+    () =>
+      searchParamToString(route.query.itemsPerPage) ??
+      SIMPLE_SEARCH_DEFAULTS.itemsPerPage,
   );
 
   const pageIndex = computed(() =>
-    searchParamToNumber(route.query.pageIndex, 0),
+    searchParamToNumber(route.query.pageIndex, SIMPLE_SEARCH_DEFAULTS.pageIndex),
   );
 
   // Navigation helper --------------------------------------
@@ -90,7 +103,8 @@ export function useSimpleSearchRouteParams() {
       params.documentKind !== undefined &&
       params.documentKind !== documentKind.value
     ) {
-      if (!params.dateFilter) merged.dateFilter = { type: "allTime" };
+      if (!params.dateFilter)
+        merged.dateFilter = { type: SIMPLE_SEARCH_DEFAULTS.dateFilterType };
       if (params.documentKind !== DocumentKind.CaseLaw) {
         if (!params.typeGroup) merged.typeGroup = undefined;
         if (!params.court) merged.court = undefined;
@@ -102,14 +116,14 @@ export function useSimpleSearchRouteParams() {
     let to: LocationQueryRaw = {
       query: encodeURIComponent(merged.query ?? ""),
       court: merged.court ?? "",
-      documentKind: merged.documentKind ?? DocumentKind.All,
+      documentKind: merged.documentKind,
       typeGroup: merged.typeGroup ?? "",
-      dateFilterType: merged.dateFilter?.type ?? "allTime",
+      dateFilterType: merged.dateFilter?.type,
       dateFilterFrom: merged.dateFilter?.from ?? "",
       dateFilterTo: merged.dateFilter?.to ?? "",
-      pageIndex: (merged.pageIndex ?? 0).toString(),
-      sort: merged.sort ?? "default",
-      itemsPerPage: merged.itemsPerPage ?? "10",
+      pageIndex: (merged.pageIndex ?? SIMPLE_SEARCH_DEFAULTS.pageIndex).toString(),
+      sort: merged.sort,
+      itemsPerPage: merged.itemsPerPage,
     };
 
     to = Object.fromEntries(

--- a/frontend/src/composables/useSimpleSearchRouteParams.ts
+++ b/frontend/src/composables/useSimpleSearchRouteParams.ts
@@ -71,8 +71,7 @@ export function useSimpleSearchRouteParams() {
   });
 
   const sort = computed(
-    () =>
-      searchParamToString(route.query.sort) ?? SIMPLE_SEARCH_DEFAULTS.sort,
+    () => searchParamToString(route.query.sort) ?? SIMPLE_SEARCH_DEFAULTS.sort,
   );
 
   const itemsPerPage = computed(
@@ -82,7 +81,10 @@ export function useSimpleSearchRouteParams() {
   );
 
   const pageIndex = computed(() =>
-    searchParamToNumber(route.query.pageIndex, SIMPLE_SEARCH_DEFAULTS.pageIndex),
+    searchParamToNumber(
+      route.query.pageIndex,
+      SIMPLE_SEARCH_DEFAULTS.pageIndex,
+    ),
   );
 
   // Navigation helper --------------------------------------
@@ -126,7 +128,9 @@ export function useSimpleSearchRouteParams() {
       dateFilterType: merged.dateFilter?.type,
       dateFilterFrom: merged.dateFilter?.from ?? "",
       dateFilterTo: merged.dateFilter?.to ?? "",
-      pageIndex: (merged.pageIndex ?? SIMPLE_SEARCH_DEFAULTS.pageIndex).toString(),
+      pageIndex: (
+        merged.pageIndex ?? SIMPLE_SEARCH_DEFAULTS.pageIndex
+      ).toString(),
       sort: merged.sort,
       itemsPerPage: merged.itemsPerPage,
     };

--- a/frontend/src/composables/useSimpleSearchRouteParams.ts
+++ b/frontend/src/composables/useSimpleSearchRouteParams.ts
@@ -1,6 +1,6 @@
 import { isEmpty, isEqual } from "lodash-es";
 import { navigateTo, useRoute } from "#app";
-import type { LocationQueryRaw, LocationQueryValue } from "#vue-router";
+import type { LocationQueryRaw } from "#vue-router";
 import { DocumentKind } from "~/types/api";
 import { isDocumentKind } from "~/utils/documentKind";
 import {
@@ -9,14 +9,15 @@ import {
 } from "~/utils/search/dateFilterType";
 import { searchParamToNumber, searchParamToString } from "~/utils/searchParams";
 
-function getInitialFilterTypeFromQuery(
-  init: LocationQueryValue | LocationQueryValue[] | undefined,
-): DateFilterValue["type"] {
-  if (typeof init !== "string" || !isFilterType(init)) {
-    return "allTime";
-  }
-
-  return init;
+export interface SearchRouteParams {
+  query?: string;
+  documentKind?: DocumentKind;
+  typeGroup?: string;
+  court?: string;
+  dateFilter?: DateFilterValue;
+  sort?: string;
+  itemsPerPage?: string;
+  pageIndex?: number;
 }
 
 export function useSimpleSearchRouteParams() {
@@ -24,98 +25,93 @@ export function useSimpleSearchRouteParams() {
 
   // General parameters -------------------------------------
 
-  const documentKind = ref<DocumentKind>(DocumentKind.All);
-
-  watch(
-    documentKind,
-    (val, oldVal) => {
-      if (val !== oldVal) {
-        dateFilter.value = { type: "allTime" };
-      }
-
-      if (val !== DocumentKind.CaseLaw) {
-        typeGroup.value = undefined;
-        court.value = undefined;
-      }
-    },
-    {
-      // Run this watcher immediately when the documentKind changes, rather than
-      // scheduling it with the other watchers, since it has side effects on
-      // other watched properties that can cause race conditions.
-      flush: "sync",
-    },
+  const query = computed(() =>
+    decodeURIComponent(searchParamToString(route.query.query) ?? ""),
   );
 
-  const typeGroup = ref<string>();
+  const documentKind = computed(() => {
+    const param = searchParamToString(route.query.documentKind);
+    return param && isDocumentKind(param) ? param : DocumentKind.All;
+  });
 
-  const query = ref<string>("");
+  const typeGroup = computed(
+    () => searchParamToString(route.query.typeGroup) || undefined,
+  );
 
-  // Date filter --------------------------------------------
+  const court = computed(
+    () => searchParamToString(route.query.court) || undefined,
+  );
 
-  const dateFilter = ref<DateFilterValue>({ type: "allTime" });
+  const dateFilter = computed<DateFilterValue>(() => {
+    const typeParam = searchParamToString(route.query.dateFilterType);
+    const type =
+      typeof typeParam === "string" && isFilterType(typeParam)
+        ? typeParam
+        : "allTime";
+    return {
+      type,
+      from: searchParamToString(route.query.dateFilterFrom) || undefined,
+      to: searchParamToString(route.query.dateFilterTo) || undefined,
+    };
+  });
 
-  // Court filter -------------------------------------------
+  const sort = computed(
+    () => searchParamToString(route.query.sort) ?? "default",
+  );
 
-  const court = ref<string>();
+  const itemsPerPage = computed(
+    () => searchParamToString(route.query.itemsPerPage) ?? "10",
+  );
 
-  // Sort & pagination --------------------------------------
+  const pageIndex = computed(() =>
+    searchParamToNumber(route.query.pageIndex, 0),
+  );
 
-  const sort = ref<string>("default");
+  // Navigation helper --------------------------------------
 
-  const itemsPerPage = ref<string>("10");
-
-  const pageIndex = ref<number>(0);
-
-  // Saving and restoring -----------------------------------
-
-  function loadFilterStateFromRoute(routeQuery = route.query) {
-    const documentKindParam = searchParamToString(routeQuery.documentKind);
-    documentKind.value =
-      documentKindParam && isDocumentKind(documentKindParam)
-        ? documentKindParam
-        : DocumentKind.All;
-
-    query.value = decodeURIComponent(
-      searchParamToString(routeQuery.query) ?? "",
-    );
-
-    court.value = searchParamToString(routeQuery.court);
-
-    typeGroup.value = searchParamToString(routeQuery.typeGroup);
-
-    dateFilter.value = {
-      type: getInitialFilterTypeFromQuery(routeQuery.dateFilterType),
-      from: searchParamToString(routeQuery.dateFilterFrom),
-      to: searchParamToString(routeQuery.dateFilterTo),
+  function navigateToSearch(
+    params: SearchRouteParams,
+    options?: { replace?: boolean },
+  ) {
+    const merged: SearchRouteParams = {
+      query: query.value,
+      documentKind: documentKind.value,
+      typeGroup: typeGroup.value,
+      court: court.value,
+      dateFilter: dateFilter.value,
+      sort: sort.value,
+      itemsPerPage: itemsPerPage.value,
+      pageIndex: pageIndex.value,
+      ...params,
     };
 
-    sort.value = searchParamToString(routeQuery.sort) ?? "default";
+    // When documentKind changes, reset dependent filters
+    if (
+      params.documentKind !== undefined &&
+      params.documentKind !== documentKind.value
+    ) {
+      if (!params.dateFilter) merged.dateFilter = { type: "allTime" };
+      if (params.documentKind !== DocumentKind.CaseLaw) {
+        if (!params.typeGroup) merged.typeGroup = undefined;
+        if (!params.court) merged.court = undefined;
+      }
+    }
 
-    itemsPerPage.value = searchParamToString(routeQuery.itemsPerPage) ?? "10";
-
-    pageIndex.value = searchParamToNumber(routeQuery.pageIndex, 0);
-  }
-
-  function saveFilterStateToRoute() {
     const from = { ...route.query };
 
     let to: LocationQueryRaw = {
-      ...from,
-      query: encodeURIComponent(query.value),
-      court: court.value,
-      documentKind: documentKind.value,
-      typeGroup: typeGroup.value ?? "",
-      dateFilterType: dateFilter.value.type,
-      dateFilterFrom: dateFilter.value.from ?? "",
-      dateFilterTo: dateFilter.value.to ?? "",
-      pageIndex: pageIndex.value.toString(),
-      sort: sort.value,
-      itemsPerPage: itemsPerPage.value,
+      query: encodeURIComponent(merged.query ?? ""),
+      court: merged.court ?? "",
+      documentKind: merged.documentKind ?? DocumentKind.All,
+      typeGroup: merged.typeGroup ?? "",
+      dateFilterType: merged.dateFilter?.type ?? "allTime",
+      dateFilterFrom: merged.dateFilter?.from ?? "",
+      dateFilterTo: merged.dateFilter?.to ?? "",
+      pageIndex: (merged.pageIndex ?? 0).toString(),
+      sort: merged.sort ?? "default",
+      itemsPerPage: merged.itemsPerPage ?? "10",
     };
 
-    // Undefined values in the "to" query will be removed by the router
-    // automatically. Filtering them out here because we don't care about them
-    // but they might still cause comparison mismatches.
     to = Object.fromEntries(
       Object.entries(to).filter(([, val]) => {
         return val !== undefined && val !== null;
@@ -124,33 +120,30 @@ export function useSimpleSearchRouteParams() {
 
     // Hash is used for skip links on the page:
     //
-    // - We'll keep it if the search params haven't change or if no search has
+    // - We'll keep it if the search params haven't changed or if no search has
     //   been performed yet (-> route change is due to hash change, so any
     //   change to the hash would break navigation)
     // - Remove it if the search params have changed (-> route change is due to
     //   search, so keeping the hash would cause unintended scrolling)
     const shouldKeepHash = isEmpty(from) || isEqual(from, to);
 
-    return navigateTo({
-      hash: shouldKeepHash ? route.hash : undefined,
-      query: to,
-    });
+    return navigateTo(
+      {
+        hash: shouldKeepHash ? route.hash : undefined,
+        query: to,
+      },
+      { replace: options?.replace },
+    );
   }
-
-  watch(
-    () => route.query,
-    (val) => loadFilterStateFromRoute(val),
-    { immediate: true },
-  );
 
   return {
     court,
     dateFilter,
     documentKind,
     itemsPerPage,
+    navigateToSearch,
     pageIndex,
     query,
-    saveFilterStateToRoute,
     sort,
     typeGroup,
   };

--- a/frontend/src/pages/advanced-search/index.vue
+++ b/frontend/src/pages/advanced-search/index.vue
@@ -22,13 +22,15 @@ useSkipLinks([
   { label: "Zum Fußbereich", to: "#footer" },
 ]);
 
+const route = useRoute();
+
 const {
   dateFilter,
   documentKind,
   itemsPerPage,
+  navigateToSearch,
   pageIndex,
   query,
-  saveFilterStateToRoute,
   sort,
 } = useAdvancedSearchRouteParams();
 
@@ -43,10 +45,6 @@ useSearchSeo({
 });
 
 const searchFormId = useId();
-
-watch(documentKind, () => {
-  query.value = "";
-});
 
 // Stats ---------------------------------------------------
 
@@ -66,19 +64,34 @@ const count = computed(() =>
 
 // Date filter ---------------------------------------------
 
-const strictDateFilter = ref(
-  isStrictDateFilterValue(dateFilter.value) ? dateFilter.value : undefined,
+const localDateFilter = ref(dateFilter.value);
+
+watch(dateFilter, (val) => {
+  localDateFilter.value = val;
+});
+
+const strictDateFilter = computed(() =>
+  isStrictDateFilterValue(localDateFilter.value)
+    ? localDateFilter.value
+    : undefined,
 );
 
-watch(dateFilter, (newVal) => {
-  if (isStrictDateFilterValue(newVal)) strictDateFilter.value = newVal;
+// Query input ---------------------------------------------
+
+const localQuery = ref(query.value);
+
+watch(query, (val) => {
+  localQuery.value = val;
 });
 
 // Document kind -------------------------------------------
 
 const setDocumentKind: MenuItem["command"] = (e) => {
   if (!e.item.key) return;
-  documentKind.value = e.item.key as DocumentKind;
+  navigateToSearch({
+    documentKind: e.item.key as DocumentKind,
+    pageIndex: 0,
+  });
 };
 
 const documentKindMenuItems: MenuItem[] = [
@@ -127,6 +140,14 @@ const {
 // Perform initial search with any existing filter + query params
 await submitSearch();
 
+// Re-run search when URL changes
+watch(
+  () => route.query,
+  async () => {
+    await submitSearch();
+  },
+);
+
 // Watch for changes in page size, so that the page number is adjusted accordingly
 watch(
   () => searchResults.value,
@@ -141,9 +162,7 @@ watch(
       const lastPage = Math.floor((totalItems - 1) / perPage);
 
       if (requestedPage !== lastPage) {
-        pageIndex.value = lastPage;
-        await saveFilterStateToRoute();
-        await submitSearch();
+        await navigateToSearch({ pageIndex: lastPage }, { replace: true });
       }
     }
   },
@@ -154,26 +173,27 @@ const formattedResultCount = computed(() =>
   formatResultCount(totalItemCount.value),
 );
 
-// Auto reload for "discrete" actions
-watch(
-  () => [
-    documentKind.value,
-    sort.value,
-    itemsPerPage.value,
-    pageIndex.value,
-    strictDateFilter.value,
-  ],
-  () => submit(),
-);
+// User action handlers ------------------------------------
 
-async function submit() {
-  await saveFilterStateToRoute();
-  submitSearch();
+function submit() {
+  navigateToSearch({ query: localQuery.value, pageIndex: 0 });
 }
 
 function handlePageUpdate(page: number) {
   scrollToResultsOnLoad.value = true;
-  pageIndex.value = page;
+  navigateToSearch({ pageIndex: page });
+}
+
+function updateSort(value: string | undefined) {
+  navigateToSearch({ sort: value ?? "default", pageIndex: 0 });
+}
+
+function updateItemsPerPage(value: string | undefined) {
+  navigateToSearch({ itemsPerPage: value ?? "50", pageIndex: 0 });
+}
+
+function updateDateFilter(value: typeof dateFilter.value) {
+  navigateToSearch({ dateFilter: value, pageIndex: 0 });
 }
 
 watch(searchStatus, async (newStatus, oldStatus) => {
@@ -212,12 +232,16 @@ watch(searchStatus, async (newStatus, oldStatus) => {
         />
       </fieldset>
 
-      <SearchDateFilter v-model="dateFilter" :document-kind />
+      <SearchDateFilter
+        v-model="localDateFilter"
+        :document-kind
+        @update:model-value="updateDateFilter"
+      />
     </aside>
 
     <div id="search" class="row-start-2 lg:row-start-auto">
       <SearchDataFieldPicker
-        v-model="query"
+        v-model="localQuery"
         :data-fields="queryableDataFields"
         :document-kind
         :loading="searchStatus === 'pending'"
@@ -241,16 +265,21 @@ watch(searchStatus, async (newStatus, oldStatus) => {
           <span class="ris-subhead-regular mr-auto text-nowrap">
             {{ formattedResultCount }}
           </span>
-          <SearchSortSelect v-model="sort" :document-kind />
+          <SearchSortSelect
+            :model-value="sort"
+            :document-kind
+            @update:model-value="updateSort"
+          />
 
           <div class="flex items-center gap-8">
             <label :id="itemsPerPageLabelId" class="ris-label2-regular">
               Einträge pro Seite
             </label>
             <Select
-              v-model="itemsPerPage"
+              :model-value="itemsPerPage"
               :aria-labelledby="itemsPerPageLabelId"
               :options="itemsPerPageOptions"
+              @update:model-value="updateItemsPerPage"
             />
           </div>
         </div>

--- a/frontend/src/pages/advanced-search/index.vue
+++ b/frontend/src/pages/advanced-search/index.vue
@@ -199,6 +199,8 @@ function updateItemsPerPage(value: string | undefined) {
 }
 
 function updateDateFilter(value: typeof dateFilter.value) {
+  localDateFilter.value = value;
+  if (!isStrictDateFilterValue(value)) return;
   navigateToSearch({ dateFilter: value, pageIndex: 0 });
 }
 

--- a/frontend/src/pages/advanced-search/index.vue
+++ b/frontend/src/pages/advanced-search/index.vue
@@ -185,11 +185,17 @@ function handlePageUpdate(page: number) {
 }
 
 function updateSort(value: string | undefined) {
-  navigateToSearch({ sort: value ?? "default", pageIndex: 0 });
+  navigateToSearch({
+    sort: value ?? ADVANCED_SEARCH_DEFAULTS.sort,
+    pageIndex: 0,
+  });
 }
 
 function updateItemsPerPage(value: string | undefined) {
-  navigateToSearch({ itemsPerPage: value ?? "50", pageIndex: 0 });
+  navigateToSearch({
+    itemsPerPage: value ?? ADVANCED_SEARCH_DEFAULTS.itemsPerPage,
+    pageIndex: 0,
+  });
 }
 
 function updateDateFilter(value: typeof dateFilter.value) {

--- a/frontend/src/pages/search/index.vue
+++ b/frontend/src/pages/search/index.vue
@@ -180,6 +180,8 @@ function updateCourt(value: string | undefined) {
 }
 
 function updateDateFilter(value: typeof dateFilter.value) {
+  localDateFilter.value = value;
+  if (!isStrictDateFilterValue(value)) return;
   navigateToSearch({ dateFilter: value, pageIndex: 0 });
 }
 

--- a/frontend/src/pages/search/index.vue
+++ b/frontend/src/pages/search/index.vue
@@ -162,11 +162,17 @@ async function updatePage(page: number) {
 }
 
 function updateSort(value: string | undefined) {
-  navigateToSearch({ sort: value ?? "default", pageIndex: 0 });
+  navigateToSearch({
+    sort: value ?? SIMPLE_SEARCH_DEFAULTS.sort,
+    pageIndex: 0,
+  });
 }
 
 function updateItemsPerPage(value: string | undefined) {
-  navigateToSearch({ itemsPerPage: value ?? "10", pageIndex: 0 });
+  navigateToSearch({
+    itemsPerPage: value ?? SIMPLE_SEARCH_DEFAULTS.itemsPerPage,
+    pageIndex: 0,
+  });
 }
 
 function updateCourt(value: string | undefined) {

--- a/frontend/src/pages/search/index.vue
+++ b/frontend/src/pages/search/index.vue
@@ -11,15 +11,16 @@ useSkipLinks([
 ]);
 
 const filterHeadingId = useId();
+const route = useRoute();
 
 const {
   court,
   dateFilter,
   documentKind,
   itemsPerPage,
+  navigateToSearch,
   pageIndex,
   query,
-  saveFilterStateToRoute,
   sort,
   typeGroup,
 } = useSimpleSearchRouteParams();
@@ -38,32 +39,34 @@ const privateFeaturesEnabled = usePrivateFeaturesFlag();
 
 // Date filter ---------------------------------------------
 
-const strictDateFilter = ref(
-  isStrictDateFilterValue(dateFilter.value) ? dateFilter.value : undefined,
-);
+const localDateFilter = ref(dateFilter.value);
 
-watch(dateFilter, (newVal) => {
-  if (isStrictDateFilterValue(newVal)) strictDateFilter.value = newVal;
+watch(dateFilter, (val) => {
+  localDateFilter.value = val;
 });
+
+const strictDateFilter = computed(() =>
+  isStrictDateFilterValue(localDateFilter.value)
+    ? localDateFilter.value
+    : undefined,
+);
 
 // Document kind -------------------------------------------
 
-const categoryFilterValue = computed({
-  get() {
-    let val = documentKind.value.toString();
-    if (typeGroup.value) val += `.${typeGroup.value}`;
-    return val;
-  },
-  set(value) {
-    const [maybeKind, group] = value.split(".");
-
-    let kind = DocumentKind.All;
-    if (maybeKind && isDocumentKind(maybeKind)) kind = maybeKind;
-    documentKind.value = kind;
-
-    typeGroup.value = group;
-  },
+const categoryFilterValue = computed(() => {
+  let val = documentKind.value.toString();
+  if (typeGroup.value) val += `.${typeGroup.value}`;
+  return val;
 });
+
+function updateCategoryFilter(value: string) {
+  const [maybeKind, group] = value.split(".");
+
+  let kind = DocumentKind.All;
+  if (maybeKind && isDocumentKind(maybeKind)) kind = maybeKind;
+
+  navigateToSearch({ documentKind: kind, typeGroup: group, pageIndex: 0 });
+}
 
 const documentKindAndGroup = computed(() => ({
   documentKind: documentKind.value,
@@ -107,6 +110,14 @@ watch(
   { immediate: true },
 );
 
+// Re-run search when URL changes
+watch(
+  () => route.query,
+  async () => {
+    await submitSearch();
+  },
+);
+
 // Watch for changes in page size, so that the page number is adjusted accordingly
 watch(
   () => searchResults.value,
@@ -121,9 +132,7 @@ watch(
       const lastPage = Math.floor((totalItems - 1) / perPage);
 
       if (requestedPage !== lastPage) {
-        pageIndex.value = lastPage;
-        await saveFilterStateToRoute();
-        await submitSearch();
+        await navigateToSearch({ pageIndex: lastPage }, { replace: true });
       }
     }
   },
@@ -137,31 +146,35 @@ const formattedResultCount = computed(() => {
 
 const isLoading = computed(() => searchStatus.value === "pending");
 
-// Auto reload for "discrete" actions
-watch(
-  () => [
-    court.value,
-    documentKind.value,
-    itemsPerPage.value,
-    pageIndex.value,
-    sort.value,
-    strictDateFilter.value,
-    typeGroup.value,
-    query.value,
-  ],
-  async () => {
-    await submit();
-  },
-);
+// User action handlers ------------------------------------
 
-async function submit() {
-  await saveFilterStateToRoute();
-  await submitSearch();
+function updateQuery(value: string | undefined) {
+  navigateToSearch({ query: value ?? "", pageIndex: 0 });
+}
+
+function handleEmptySearch() {
+  navigateToSearch({ query: "", pageIndex: 0 });
 }
 
 async function updatePage(page: number) {
   scrollToResultsOnLoad.value = true;
-  pageIndex.value = page;
+  navigateToSearch({ pageIndex: page });
+}
+
+function updateSort(value: string | undefined) {
+  navigateToSearch({ sort: value ?? "default", pageIndex: 0 });
+}
+
+function updateItemsPerPage(value: string | undefined) {
+  navigateToSearch({ itemsPerPage: value ?? "10", pageIndex: 0 });
+}
+
+function updateCourt(value: string | undefined) {
+  navigateToSearch({ court: value, pageIndex: 0 });
+}
+
+function updateDateFilter(value: typeof dateFilter.value) {
+  navigateToSearch({ dateFilter: value, pageIndex: 0 });
 }
 
 watch(searchStatus, async (newStatus, oldStatus) => {
@@ -182,7 +195,11 @@ watch(searchStatus, async (newStatus, oldStatus) => {
   </div>
 
   <div id="search">
-    <SearchSimpleSearchInput v-model="query" />
+    <SearchSimpleSearchInput
+      :model-value="query"
+      @update:model-value="updateQuery"
+      @empty-search="handleEmptySearch"
+    />
   </div>
 
   <SkipLink to="#search-results" class="mt-8">Zu den Ergebnissen</SkipLink>
@@ -204,11 +221,15 @@ watch(searchStatus, async (newStatus, oldStatus) => {
       </h2>
 
       <div class="flex flex-col gap-24">
-        <SearchCategoryFilter v-model="categoryFilterValue" />
+        <SearchCategoryFilter
+          :model-value="categoryFilterValue"
+          @update:model-value="updateCategoryFilter"
+        />
 
         <SearchCourtFilter
           v-if="documentKind === DocumentKind.CaseLaw"
-          v-model="court"
+          :model-value="court"
+          @update:model-value="updateCourt"
         />
 
         <SearchDateRangeFilter
@@ -216,12 +237,14 @@ watch(searchStatus, async (newStatus, oldStatus) => {
             documentKind === DocumentKind.CaseLaw ||
             documentKind === DocumentKind.AdministrativeDirective
           "
-          v-model="dateFilter"
+          v-model="localDateFilter"
+          @update:model-value="updateDateFilter"
         />
 
         <SearchYearRangeFilter
           v-else-if="documentKind === DocumentKind.Literature"
-          v-model="dateFilter"
+          v-model="localDateFilter"
+          @update:model-value="updateDateFilter"
         />
       </div>
     </aside>
@@ -254,13 +277,18 @@ watch(searchStatus, async (newStatus, oldStatus) => {
                 Einträge pro Seite
               </label>
               <Select
-                v-model="itemsPerPage"
+                :model-value="itemsPerPage"
                 :aria-labelledby="itemsPerPageLabelId"
                 :options="itemsPerPageOptions"
+                @update:model-value="updateItemsPerPage"
               />
             </div>
 
-            <SearchSortSelect v-model="sort" :document-kind />
+            <SearchSortSelect
+              :model-value="sort"
+              :document-kind
+              @update:model-value="updateSort"
+            />
           </div>
         </div>
 


### PR DESCRIPTION
This PR refactors both the simple and the advanced search to store their state directly in the URL, removing the intermediary state and the syncing of that state with the URL. This addresses various issues where the browser navigation functionality was broken because of race conditions and other unhandled edge cases in the synchronization logic.

For this it:

- Replaces the logic for reading the URL state with computed properties, returning the state directly from the URL
- Removes the watchers (no longer needed thanks to the computer properties)
- Updates the logic for saving state to the URL
- Updates the simple and advanced search to use the new properties
  - In some cases where we don't want the state of some user interaction to be synced into the URL immediately, The view now contains a temporary in-between state that is saved to the URL once the interaction completes.