### PR TITLE
RISDEV-10551 Align items per page options across searches

### DIFF
--- a/frontend/e2e/simpleSearch.spec.ts
+++ b/frontend/e2e/simpleSearch.spec.ts
@@ -96,7 +96,7 @@ test.describe("general search page features", () => {
   });
 
   test("pagination switches pages", async ({ page }) => {
-    await navigate(page, "/search?query=und");
+    await navigate(page, "/search?query=und&itemsPerPage=10");
 
     const resultCounter = getResultCounter(page);
     await expect(resultCounter).toHaveText(nonZeroResultCount);
@@ -124,7 +124,7 @@ test.describe("general search page features", () => {
   });
 
   test("focuses first search result after pagination", async ({ page }) => {
-    await navigate(page, "/search?query=und");
+    await navigate(page, "/search?query=und&itemsPerPage=10");
 
     await page
       .getByRole("navigation", { name: "Paginierung" })
@@ -167,7 +167,7 @@ test.describe("general search page features", () => {
   });
 
   test("change number of results per page", async ({ page }) => {
-    await navigate(page, "/search?query=fiktiv");
+    await navigate(page, "/search?query=fiktiv&itemsPerPage=10");
 
     const searchResults = getSearchResults(page);
 
@@ -433,7 +433,7 @@ test.describe("searching caselaw", () => {
 
     // Ensure all visible entries are of type caselaw
     await expect(searchResults).toHaveText(
-      Array(10).fill(/^(Beschluss|Urteil)/),
+      Array(13).fill(/^(Beschluss|Urteil)/),
     );
   });
 
@@ -495,7 +495,7 @@ test.describe("searching caselaw", () => {
       await expect(page).toHaveURL(/typeGroup=urteil/);
 
       await expect(getSearchResults(page)).toHaveText(
-        Array.from<RegExp>({ length: 10 }).fill(/^Urteil/),
+        Array.from<RegExp>({ length: 11 }).fill(/^Urteil/),
       );
     });
 
@@ -535,7 +535,7 @@ test.describe("searching caselaw", () => {
       await expect(page).toHaveURL(/typeGroup=($|&)/);
 
       await expect(getSearchResults(page)).toHaveText(
-        Array(10).fill(/^(Beschluss|Urteil)/),
+        Array(13).fill(/^(Beschluss|Urteil)/),
       );
     });
   });
@@ -1074,7 +1074,7 @@ noJsTest("search works without JavaScript", async ({ page }) => {
 });
 
 noJsTest("pagination works without JavaScript", async ({ page }) => {
-  await navigate(page, "/search?query=und");
+  await navigate(page, "/search?query=und&itemsPerPage=10");
 
   await expect(getResultCounter(page)).toHaveText(nonZeroResultCount);
   await expect(getSearchResults(page)).toHaveCount(10);

--- a/frontend/src/composables/useAdvancedSearch.spec.ts
+++ b/frontend/src/composables/useAdvancedSearch.spec.ts
@@ -113,16 +113,15 @@ describe("useAdvancedSearch", () => {
   });
 
   it("uses default values for pagination and sort", async () => {
-    await useAdvancedSearch(
-      "example",
-      DocumentKind.CaseLaw,
-      undefined,
-      {}
-    );
+    await useAdvancedSearch("example", DocumentKind.CaseLaw, undefined, {});
 
     expect(useRisBackendMock).toHaveBeenCalled();
     const urlQuery = useRisBackendMock.mock.calls[0]![1].query;
-    expect(urlQuery?.value).toMatchObject({ size: "25", pageIndex: 0, sort: "default" });
+    expect(urlQuery?.value).toMatchObject({
+      size: "25",
+      pageIndex: 0,
+      sort: "default",
+    });
   });
 
   it("submits pagination parameters correctly", async () => {

--- a/frontend/src/composables/useAdvancedSearch.spec.ts
+++ b/frontend/src/composables/useAdvancedSearch.spec.ts
@@ -112,6 +112,19 @@ describe("useAdvancedSearch", () => {
     expect(urlQuery?.value).toMatchObject({ query: "(test query)" });
   });
 
+  it("uses default values for pagination and sort", async () => {
+    await useAdvancedSearch(
+      "example",
+      DocumentKind.CaseLaw,
+      undefined,
+      {}
+    );
+
+    expect(useRisBackendMock).toHaveBeenCalled();
+    const urlQuery = useRisBackendMock.mock.calls[0]![1].query;
+    expect(urlQuery?.value).toMatchObject({ size: "25", pageIndex: 0, sort: "default" });
+  });
+
   it("submits pagination parameters correctly", async () => {
     await useAdvancedSearch(
       "example",

--- a/frontend/src/composables/useAdvancedSearch.ts
+++ b/frontend/src/composables/useAdvancedSearch.ts
@@ -5,6 +5,7 @@ import {
   dateFilterToQuery,
   type StrictDateFilterValue,
 } from "~/utils/search/dateFilterType";
+import { itemsPerPageDefault } from "~/utils/search/itemsPerPageOptions";
 
 /** Additional configuration for search API calls */
 type AdvancedSearchOptions = {
@@ -35,7 +36,7 @@ export async function useAdvancedSearch(
   documentKind: MaybeRefOrGetter<DocumentKind>,
   dateFilter: MaybeRefOrGetter<StrictDateFilterValue | undefined>,
   {
-    itemsPerPage = "50",
+    itemsPerPage = itemsPerPageDefault,
     pageIndex = 0,
     sort = "default",
   }: Partial<AdvancedSearchOptions>,

--- a/frontend/src/composables/useAdvancedSearchRouteParams.spec.ts
+++ b/frontend/src/composables/useAdvancedSearchRouteParams.spec.ts
@@ -282,7 +282,7 @@ describe("useAdvancedSearchRouteParams", () => {
 
       const { itemsPerPage } = useAdvancedSearchRouteParams();
 
-      expect(itemsPerPage.value).toBe("50");
+      expect(itemsPerPage.value).toBe("25");
     });
   });
 

--- a/frontend/src/composables/useAdvancedSearchRouteParams.ts
+++ b/frontend/src/composables/useAdvancedSearchRouteParams.ts
@@ -7,8 +7,8 @@ import {
   type DateFilterValue,
   isFilterType,
 } from "~/utils/search/dateFilterType";
-import { searchParamToNumber, searchParamToString } from "~/utils/searchParams";
 import { itemsPerPageDefault } from "~/utils/search/itemsPerPageOptions";
+import { searchParamToNumber, searchParamToString } from "~/utils/searchParams";
 
 export interface AdvancedSearchRouteParams {
   query?: string;

--- a/frontend/src/composables/useAdvancedSearchRouteParams.ts
+++ b/frontend/src/composables/useAdvancedSearchRouteParams.ts
@@ -8,6 +8,7 @@ import {
   isFilterType,
 } from "~/utils/search/dateFilterType";
 import { searchParamToNumber, searchParamToString } from "~/utils/searchParams";
+import { itemsPerPageDefault } from "~/utils/search/itemsPerPageOptions";
 
 export interface AdvancedSearchRouteParams {
   query?: string;
@@ -21,7 +22,7 @@ export interface AdvancedSearchRouteParams {
 export const ADVANCED_SEARCH_DEFAULTS = {
   documentKind: DocumentKind.Norm,
   sort: "default",
-  itemsPerPage: "50",
+  itemsPerPage: itemsPerPageDefault,
   pageIndex: 0,
 } as const;
 

--- a/frontend/src/composables/usePostHog.spec.ts
+++ b/frontend/src/composables/usePostHog.spec.ts
@@ -168,7 +168,7 @@ describe("usePostHog", () => {
 
     const params: PostHogSearchParams = {
       searchTerm: "test query",
-      size: "10",
+      size: "25",
       pageIndex: 0,
       sort: "default",
       documentKind: DocumentKind.CaseLaw,
@@ -176,7 +176,7 @@ describe("usePostHog", () => {
 
     const previousParams: PostHogSearchParams = {
       searchTerm: "old query",
-      size: "10",
+      size: "25",
       pageIndex: 0,
       sort: "default",
       documentKind: DocumentKind.CaseLaw,
@@ -193,7 +193,7 @@ describe("usePostHog", () => {
         dateAfter: undefined,
         dateBefore: undefined,
         dateSearchMode: "",
-        itemsPerPage: 10,
+        itemsPerPage: 25,
         pageNumber: 0,
         query: "test query",
         sort: "default",
@@ -205,7 +205,7 @@ describe("usePostHog", () => {
         dateAfter: undefined,
         dateBefore: undefined,
         dateSearchMode: "",
-        itemsPerPage: 10,
+        itemsPerPage: 25,
         pageNumber: 0,
         query: "old query",
         sort: "default",
@@ -219,7 +219,7 @@ describe("usePostHog", () => {
     userConsent.value = false;
     searchPerformed("simple", {
       searchTerm: "test query",
-      size: "10",
+      size: "25",
       pageIndex: 0,
       sort: "default",
       documentKind: DocumentKind.CaseLaw,
@@ -247,7 +247,7 @@ describe("usePostHog", () => {
 
     const params: PostHogSearchParams = {
       searchTerm: "test query",
-      size: "10",
+      size: "25",
       pageIndex: 0,
       sort: "default",
       documentKind: DocumentKind.CaseLaw,
@@ -263,7 +263,7 @@ describe("usePostHog", () => {
         dateAfter: undefined,
         dateBefore: undefined,
         dateSearchMode: "",
-        itemsPerPage: 10,
+        itemsPerPage: 25,
         pageNumber: 0,
         query: "test query",
         sort: "default",

--- a/frontend/src/composables/usePostHog.ts
+++ b/frontend/src/composables/usePostHog.ts
@@ -6,6 +6,7 @@ import {
   isStringEmpty,
   stringToBoolean,
 } from "~/utils/textFormatting";
+import { itemsPerPageDefault } from "~/utils/search/itemsPerPageOptions";
 
 export const CONSENT_COOKIE_NAME = "consent_given";
 
@@ -47,7 +48,7 @@ function mapTrackingParamsToLegacyFormat(
     dateAfter: q.dateFrom,
     dateBefore: q.dateTo,
     dateSearchMode: "", // This has never been tracked properly and only exist for compatibility
-    itemsPerPage: searchParamToNumber(q.size, 10),
+    itemsPerPage: searchParamToNumber(q.size, Number(itemsPerPageDefault)),
     pageNumber: q.pageIndex,
     query: q.searchTerm,
     sort: q.sort,

--- a/frontend/src/composables/usePostHog.ts
+++ b/frontend/src/composables/usePostHog.ts
@@ -1,12 +1,12 @@
 import type { PostHog } from "posthog-js";
 import { posthog } from "posthog-js";
 import type { DocumentKind } from "~/types/api";
+import { itemsPerPageDefault } from "~/utils/search/itemsPerPageOptions";
 import {
   getStringOrUndefined,
   isStringEmpty,
   stringToBoolean,
 } from "~/utils/textFormatting";
-import { itemsPerPageDefault } from "~/utils/search/itemsPerPageOptions";
 
 export const CONSENT_COOKIE_NAME = "consent_given";
 

--- a/frontend/src/composables/useSimpleSearch.spec.ts
+++ b/frontend/src/composables/useSimpleSearch.spec.ts
@@ -223,7 +223,7 @@ describe("useSimpleSearch", () => {
 
       expect(useRisBackendMock).toHaveBeenCalled();
       expect(getQueryValue()).toMatchObject({
-        size: "10",
+        size: "25",
         pageIndex: 0,
         sort: "default",
       });

--- a/frontend/src/composables/useSimpleSearch.ts
+++ b/frontend/src/composables/useSimpleSearch.ts
@@ -6,6 +6,7 @@ import {
   dateFilterToSimpleSearchParams,
   type StrictDateFilterValue,
 } from "~/utils/search/dateFilterType";
+import { itemsPerPageDefault } from "~/utils/search/itemsPerPageOptions";
 
 /** Additional configuration for search API calls */
 type SimpleSearchOptions = {
@@ -49,7 +50,7 @@ export async function useSimpleSearch(
   dateFilter: MaybeRefOrGetter<StrictDateFilterValue | undefined>,
   court: MaybeRefOrGetter<string | undefined>,
   {
-    itemsPerPage = "10",
+    itemsPerPage = itemsPerPageDefault,
     pageIndex = 0,
     sort = "default",
   }: Partial<SimpleSearchOptions>,

--- a/frontend/src/composables/useSimpleSearchRouteParams.spec.ts
+++ b/frontend/src/composables/useSimpleSearchRouteParams.spec.ts
@@ -331,7 +331,7 @@ describe("useSimpleSearchRouteParams", () => {
 
       const { itemsPerPage } = useSimpleSearchRouteParams();
 
-      expect(itemsPerPage.value).toBe("10");
+      expect(itemsPerPage.value).toBe("25");
     });
   });
 

--- a/frontend/src/composables/useSimpleSearchRouteParams.ts
+++ b/frontend/src/composables/useSimpleSearchRouteParams.ts
@@ -8,6 +8,7 @@ import {
   type DateFilterValue,
 } from "~/utils/search/dateFilterType";
 import { searchParamToNumber, searchParamToString } from "~/utils/searchParams";
+import { itemsPerPageDefault } from "~/utils/search/itemsPerPageOptions";
 
 export interface SearchRouteParams {
   query?: string;
@@ -23,7 +24,7 @@ export interface SearchRouteParams {
 export const SIMPLE_SEARCH_DEFAULTS = {
   documentKind: DocumentKind.All,
   sort: "default",
-  itemsPerPage: "10",
+  itemsPerPage: itemsPerPageDefault,
   pageIndex: 0,
   dateFilterType: "allTime" as const,
 } as const;

--- a/frontend/src/composables/useSimpleSearchRouteParams.ts
+++ b/frontend/src/composables/useSimpleSearchRouteParams.ts
@@ -7,8 +7,8 @@ import {
   isFilterType,
   type DateFilterValue,
 } from "~/utils/search/dateFilterType";
-import { searchParamToNumber, searchParamToString } from "~/utils/searchParams";
 import { itemsPerPageDefault } from "~/utils/search/itemsPerPageOptions";
+import { searchParamToNumber, searchParamToString } from "~/utils/searchParams";
 
 export interface SearchRouteParams {
   query?: string;

--- a/frontend/src/pages/advanced-search/index.vue
+++ b/frontend/src/pages/advanced-search/index.vue
@@ -5,6 +5,7 @@ import type { Statistics } from "~/types/api";
 import { DocumentKind } from "~/types/api";
 import { queryableDataFields } from "~/utils/search/dataFields";
 import { isStrictDateFilterValue } from "~/utils/search/dateFilterType";
+import { itemsPerPageOptions } from "~/utils/search/itemsPerPageOptions";
 
 definePageMeta({
   alias: "/erweiterte-suche",
@@ -122,8 +123,6 @@ const documentKindMenuItems: MenuItem[] = [
 const itemsPerPageLabelId = useId();
 const resultsContainerRef = ref<HTMLElement | null>(null);
 const scrollToResultsOnLoad = ref(false);
-
-const itemsPerPageOptions = ["10", "50", "100"];
 
 const {
   searchError,

--- a/frontend/src/pages/search/index.vue
+++ b/frontend/src/pages/search/index.vue
@@ -3,6 +3,7 @@ import { Message, Select } from "primevue";
 import { useSearchSeo } from "~/composables/useSearchSeo";
 import { DocumentKind } from "~/types/api";
 import { isStrictDateFilterValue } from "~/utils/search/dateFilterType";
+import { itemsPerPageOptions } from "~/utils/search/itemsPerPageOptions";
 
 useSkipLinks([
   { label: "Zur Suche", to: "#search" },
@@ -78,8 +79,6 @@ const documentKindAndGroup = computed(() => ({
 const itemsPerPageLabelId = useId();
 const resultsContainerRef = ref<HTMLElement | null>(null);
 const scrollToResultsOnLoad = ref(false);
-
-const itemsPerPageOptions = ["10", "50", "100"];
 
 const {
   searchError,

--- a/frontend/src/utils/search/itemsPerPageOptions.ts
+++ b/frontend/src/utils/search/itemsPerPageOptions.ts
@@ -1,2 +1,2 @@
-export const itemsPerPageDefault = "25"
+export const itemsPerPageDefault = "25";
 export const itemsPerPageOptions = [itemsPerPageDefault, "50", "100"];

--- a/frontend/src/utils/search/itemsPerPageOptions.ts
+++ b/frontend/src/utils/search/itemsPerPageOptions.ts
@@ -1,0 +1,2 @@
+export const itemsPerPageDefault = "25"
+export const itemsPerPageOptions = [itemsPerPageDefault, "50", "100"];


### PR DESCRIPTION
- align items per page options across searches
- set options to 25, 50 and 100

RISDEV-10551