### PR TITLE
RISDEV-11696-client-error-on-invalid-path

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 /**
@@ -32,6 +33,7 @@ public class ControllerExceptionHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(ControllerExceptionHandler.class);
 
+  public static final String CODE_FOR_400 = "bad_request";
   public static final String CODE_FOR_403 = "forbidden";
   public static final String CODE_FOR_404 = "not_found";
 
@@ -136,6 +138,26 @@ public class ControllerExceptionHandler {
     CustomErrorResponse errorResponse =
         CustomErrorResponse.builder().errors(List.of(errorDetail)).build();
     return ResponseEntity.status(HttpStatus.UNPROCESSABLE_CONTENT).body(errorResponse);
+  }
+
+  /**
+   * This ExceptionHandler maps MethodArgumentTypeMismatchExceptions that occur during type
+   * conversion of Controller arguments
+   *
+   * @param ex the {@link
+   *     org.springframework.web.method.annotation.MethodArgumentTypeMismatchException} that is
+   *     thrown during the type conversion of controller arguments
+   * @return @{@link org.springframework.http.ResponseEntity} with httpStatus 400
+   */
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<CustomErrorResponse> handleControllerParameterTypeMismatchErrors(
+      MethodArgumentTypeMismatchException ex) {
+
+    CustomError error = new CustomError(CODE_FOR_400, "The request could not be parsed", "");
+    CustomErrorResponse errorResponse =
+        CustomErrorResponse.builder().errors(List.of(error)).build();
+    logger.warn(ex.getMessage(), ex);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
   }
 
   /**

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/ErrorResponseTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/ErrorResponseTest.java
@@ -66,4 +66,17 @@ class ErrorResponseTest extends ContainersIntegrationBase {
                 Matchers.is("An unexpected error occurred. Please try again later.")))
         .andExpect(jsonPath("$.errors[0].parameter", Matchers.is("")));
   }
+
+  @Test
+  @DisplayName("Should return 400 on argument type mismatch")
+  void shouldReturn400MethodArgumentTypeMismatchException() throws Exception {
+    mockMvc
+        .perform(
+            get("/v1/legislation/eli/bund/bgbl-1/2002/s42/regelungstext-1/abschnitt/§-1629")
+                .contentType(MediaType.TEXT_HTML))
+        .andExpect(status().is(400))
+        .andExpect(jsonPath("$.errors[0].code", Matchers.is("bad_request")))
+        .andExpect(jsonPath("$.errors[0].message", Matchers.is("The request could not be parsed")))
+        .andExpect(jsonPath("$.errors[0].parameter", Matchers.is("")));
+  }
 }


### PR DESCRIPTION
This PR logs controller path parameters that cannot be parsed to their proper type as a warning and returns a 400 instead of a 500 server error.