### PR TITLE
RISDEV-8269 date filter fassungen

### DIFF
--- a/frontend/e2e/normVersions.spec.ts
+++ b/frontend/e2e/normVersions.spec.ts
@@ -1,23 +1,5 @@
 import { expect, navigate, test } from "./utils/fixtures";
 
-const expectedVersionData = [
-  {
-    dateFrom: "04.08.2919",
-    dateTo: "-",
-    status: "Zukünftig in Kraft",
-  },
-  {
-    dateFrom: "04.08.2022",
-    dateTo: "01.01.2030",
-    status: "Aktuell gültig",
-  },
-  {
-    dateFrom: "04.08.2020",
-    dateTo: "03.08.2022",
-    status: "Außer Kraft",
-  },
-];
-
 test.beforeAll(async ({ privateFeaturesEnabled }) => {
   test.skip(
     !privateFeaturesEnabled,
@@ -25,49 +7,85 @@ test.beforeAll(async ({ privateFeaturesEnabled }) => {
   );
 });
 
-test("can browse different Fassungen of a norm", async ({ page }) => {
-  await navigate(page, "/norms/eli/bund/bgbl-1/2020/s1126/2020-08-04/1/deu");
+test.describe("fassungen tab", async () => {
+  test("displays Fassungen table in the Fassungen tab", async ({ page }) => {
+    await navigate(page, "/norms/eli/bund/bgbl-1/2020/s1126/2020-08-04/1/deu");
 
-  await page.getByRole("tab", { name: "Fassungen" }).click();
+    await page.getByRole("tab", { name: "Fassungen" }).click();
 
-  const tableBodyLocator = page.getByRole("table").getByRole("rowgroup").nth(1);
+    await expect(page.getByRole("table").getByRole("row")).toHaveText(
+      [
+        "Gültig ab Gültig bis Status",
+        "04.08.2919 - Zukünftig in Kraft",
+        "04.08.2022 01.01.2030 Aktuell gültig",
+        "04.08.2020 03.08.2022 Außer Kraft",
+      ],
+      { useInnerText: true },
+    );
+  });
 
-  for (const [index, expectedRowData] of expectedVersionData.entries()) {
-    const cellLocator = tableBodyLocator
-      .getByRole("row")
-      .nth(index)
-      .getByRole("cell");
-    await expect(cellLocator.nth(0)).toContainText(expectedRowData.dateFrom);
-    await expect(cellLocator.nth(1)).toContainText(expectedRowData.dateTo);
-    await expect(cellLocator.nth(2)).toContainText(expectedRowData.status);
-  }
-});
+  test("can navigate to a Fassung by clicking the table row", async ({
+    page,
+  }) => {
+    await navigate(
+      page,
+      "/norms/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu?view=versions",
+    );
 
-test("can navigate to a Fassung by clicking the table row", async ({
-  page,
-}) => {
-  await navigate(page, "/norms/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu");
+    await expect(
+      page.getByRole("heading", {
+        name: "Zum Testen von Fassungen - Aktuelle Fassung",
+      }),
+    ).toBeVisible();
 
-  await expect(
-    page.getByRole("heading", {
-      name: "Zum Testen von Fassungen - Aktuelle Fassung",
-    }),
-  ).toBeVisible();
-
-  await page.getByRole("tab", { name: "Fassungen" }).click();
-
-  await test.step("Navigate to future fassung", async () => {
-    const tableBodyLocator = page
-      .getByRole("table")
-      .getByRole("rowgroup")
-      .nth(1);
-    await tableBodyLocator.getByRole("row").nth(0).click();
+    await page
+      .getByRole("row", { name: "04.08.2919 - Zukünftig in Kraft" })
+      .click();
 
     await expect(
       page.getByRole("heading", {
         name: "Zum Testen von Fassungen - Zukünftige Fassung",
       }),
     ).toBeVisible();
+  });
+
+  test("can filter Fassungen by date", async ({ page }) => {
+    await navigate(
+      page,
+      "/norms/eli/bund/bgbl-1/2020/s1126/2020-08-04/1/deu?view=versions",
+    );
+
+    const tableBody = page.getByRole("table").getByRole("rowgroup").nth(1);
+
+    await expect(tableBody.getByRole("row")).toHaveCount(3);
+
+    await page.getByRole("textbox", { name: "Gültig am" }).fill("04.08.2020");
+
+    await expect(tableBody.getByRole("row")).toHaveCount(1);
+    await expect(tableBody.getByRole("row")).toHaveText(
+      "04.08.2020 03.08.2022 Außer Kraft",
+      { useInnerText: true },
+    );
+  });
+
+  test("shows no results placeholder when no Fassung found", async ({
+    page,
+  }) => {
+    await navigate(
+      page,
+      "/norms/eli/bund/bgbl-1/2020/s1126/2020-08-04/1/deu?view=versions",
+    );
+
+    const tableBody = page.getByRole("table").getByRole("rowgroup").nth(1);
+
+    await expect(tableBody.getByRole("row")).toHaveCount(3);
+
+    await page.getByRole("textbox", { name: "Gültig am" }).fill("04.08.1536");
+
+    await expect(tableBody.getByRole("row")).toHaveCount(1);
+    await expect(tableBody.getByRole("row")).toHaveText(
+      "Keine Ergebnisse gefunden",
+    );
   });
 });
 
@@ -130,56 +148,58 @@ test.describe("displays metadata correctly", async () => {
   });
 });
 
-test("shows an info about future versions on a historic norm article", async ({
-  page,
-  privateFeaturesEnabled,
-}) => {
-  test.skip(!privateFeaturesEnabled);
-
-  await navigate(
+test.describe("future or historic version info", () => {
+  test("shows an info about future versions on a historic norm article", async ({
     page,
-    "/norms/eli/bund/bgbl-1/2020/s1126/2020-08-04/1/deu/art-z1",
-  );
+    privateFeaturesEnabled,
+  }) => {
+    test.skip(!privateFeaturesEnabled);
 
-  await expect(
-    page.getByText("Sie lesen einen Paragrafen einer historischen Fassung."),
-  ).toBeVisible();
+    await navigate(
+      page,
+      "/norms/eli/bund/bgbl-1/2020/s1126/2020-08-04/1/deu/art-z1",
+    );
 
-  await page
-    .getByRole("link", { name: "Zur aktuell gültigen Fassung" })
-    .click();
+    await expect(
+      page.getByText("Sie lesen einen Paragrafen einer historischen Fassung."),
+    ).toBeVisible();
 
-  await expect(
-    page.getByRole("heading", {
-      name: "Zum Testen von Fassungen - Aktuelle Fassung",
-    }),
-  ).toBeVisible();
-});
+    await page
+      .getByRole("link", { name: "Zur aktuell gültigen Fassung" })
+      .click();
 
-test("shows an info about previous versions on a future norm article", async ({
-  page,
-  privateFeaturesEnabled,
-}) => {
-  test.skip(!privateFeaturesEnabled);
+    await expect(
+      page.getByRole("heading", {
+        name: "Zum Testen von Fassungen - Aktuelle Fassung",
+      }),
+    ).toBeVisible();
+  });
 
-  await navigate(
+  test("shows an info about previous versions on a future norm article", async ({
     page,
-    "/norms/eli/bund/bgbl-1/2020/s1126/2920-08-04/1/deu/art-z1",
-  );
+    privateFeaturesEnabled,
+  }) => {
+    test.skip(!privateFeaturesEnabled);
 
-  await expect(
-    page.getByText("Sie lesen einen Paragrafen einer zukünftigen Fassung."),
-  ).toBeVisible();
+    await navigate(
+      page,
+      "/norms/eli/bund/bgbl-1/2020/s1126/2920-08-04/1/deu/art-z1",
+    );
 
-  await page
-    .getByRole("link", { name: "Zur aktuell gültigen Fassung" })
-    .click();
+    await expect(
+      page.getByText("Sie lesen einen Paragrafen einer zukünftigen Fassung."),
+    ).toBeVisible();
 
-  await expect(
-    page.getByRole("heading", {
-      name: "Zum Testen von Fassungen - Aktuelle Fassung",
-    }),
-  ).toBeVisible();
+    await page
+      .getByRole("link", { name: "Zur aktuell gültigen Fassung" })
+      .click();
+
+    await expect(
+      page.getByRole("heading", {
+        name: "Zum Testen von Fassungen - Aktuelle Fassung",
+      }),
+    ).toBeVisible();
+  });
 });
 
 test("displays validity in breadcrumb navigation", async ({

--- a/frontend/src/components/documents/norms/NormVersionList.vue
+++ b/frontend/src/components/documents/norms/NormVersionList.vue
@@ -90,7 +90,13 @@ async function handleSelectionUpdate(newSelection: TableRowData) {
     :row-class="rowClass"
     @row-select="onRowSelect"
     @update:selection="handleSelectionUpdate"
+    :pt="{
+      emptyMessageCell: {
+        class: 'ps-16 py-12 text-left text-gray-900',
+      },
+    }"
   >
+    <template #empty>Keine Ergebnisse gefunden</template>
     <Column
       field="fromDate"
       header="Gültig ab"

--- a/frontend/src/composables/useNormVersionFilter.spec.ts
+++ b/frontend/src/composables/useNormVersionFilter.spec.ts
@@ -1,0 +1,122 @@
+import { ref } from "vue";
+import type { LegislationExpression } from "~/types/api";
+import { useNormVersionFilter } from "./useNormVersionFilter";
+
+function expressionWithCoverage(
+  temporalCoverage: string,
+): LegislationExpression {
+  return { temporalCoverage } as LegislationExpression;
+}
+
+describe("useNormVersionFilter", () => {
+  it("returns empty list when the version list is empty", () => {
+    const { dateFilterValue, filteredNormVersions } = useNormVersionFilter(
+      ref([]),
+    );
+
+    dateFilterValue.value = "2020-01-01";
+    expect(filteredNormVersions.value).toEqual([]);
+  });
+
+  it.each([[""], [undefined]])(
+    "returns the full list when the date filter is '%s'",
+    (filterValue?: string) => {
+      const versions = [
+        expressionWithCoverage("2020-01-01/2021-12-31"),
+        expressionWithCoverage("2022-01-01/2023-12-31"),
+      ];
+      const { dateFilterValue, filteredNormVersions } = useNormVersionFilter(
+        ref(versions),
+      );
+
+      dateFilterValue.value = filterValue;
+      expect(filteredNormVersions.value).toEqual(versions);
+    },
+  );
+
+  it.each([["2020-01-01"], ["2020-01-02"], ["2020-01-03"]])(
+    "returns matching expression when filter date '%s' falls within validity interval",
+    (filterValue: string) => {
+      const matchingExpression = expressionWithCoverage(
+        "2020-01-01/2020-01-03",
+      );
+      const versions = [
+        expressionWithCoverage("2019-01-01/2019-12-31"),
+        matchingExpression,
+        expressionWithCoverage("2020-01-04/2022-01-01"),
+      ];
+
+      const { dateFilterValue, filteredNormVersions } = useNormVersionFilter(
+        ref(versions),
+      );
+      dateFilterValue.value = filterValue;
+      expect(filteredNormVersions.value).toEqual([matchingExpression]);
+    },
+  );
+
+  it("matches when expression has undefined out of force date", () => {
+    const matchingExpression = expressionWithCoverage("2020-01-04/..");
+
+    const versions = [
+      expressionWithCoverage("2020-01-01/2020-01-03"),
+      matchingExpression,
+    ];
+    const { dateFilterValue, filteredNormVersions } = useNormVersionFilter(
+      ref(versions),
+    );
+
+    dateFilterValue.value = "2021-01-01";
+    expect(filteredNormVersions.value).toEqual([matchingExpression]);
+  });
+
+  it.each([["2019-12-31"], ["2021-01-01"]])(
+    "returns empty list when filter date '%s' is outside validity interval",
+    (filterValue: string) => {
+      const versions = [
+        expressionWithCoverage("2020-01-01/2020-01-03"),
+        expressionWithCoverage("2020-01-04/2020-12-31"),
+      ];
+
+      const { dateFilterValue, filteredNormVersions } = useNormVersionFilter(
+        ref(versions),
+      );
+      dateFilterValue.value = filterValue;
+      expect(filteredNormVersions.value).toEqual([]);
+    },
+  );
+
+  it("does not match if expression has undefined in force date", () => {
+    const versions = [
+      expressionWithCoverage("../2019-12-31"),
+      expressionWithCoverage("2020-01-01/2020-01-03"),
+    ];
+    const { dateFilterValue, filteredNormVersions } = useNormVersionFilter(
+      ref(versions),
+    );
+
+    dateFilterValue.value = "2018-01-01";
+    expect(filteredNormVersions.value).toEqual([]);
+  });
+
+  it("does not match if expression has undefined in force and out of force date", () => {
+    const versions = [expressionWithCoverage("../..")];
+    const { dateFilterValue, filteredNormVersions } = useNormVersionFilter(
+      ref(versions),
+    );
+
+    dateFilterValue.value = "2018-01-01";
+    expect(filteredNormVersions.value).toEqual([]);
+  });
+
+  it("reacts to changes of the date filter value", () => {
+    const match = expressionWithCoverage("2020-01-01/2023-12-31");
+    const { dateFilterValue, filteredNormVersions } = useNormVersionFilter(
+      ref([match]),
+    );
+
+    expect(filteredNormVersions.value).toEqual([match]);
+
+    dateFilterValue.value = "2025-01-01";
+    expect(filteredNormVersions.value).toEqual([]);
+  });
+});

--- a/frontend/src/composables/useNormVersionFilter.ts
+++ b/frontend/src/composables/useNormVersionFilter.ts
@@ -1,0 +1,40 @@
+import { computed, ref } from "vue";
+import type { LegislationExpression } from "~/types/api";
+import { parseDateGermanLocalTime } from "~/utils/dateFormatting";
+import { temporalCoverageToValidityInterval } from "~/utils/norm";
+
+export function useNormVersionFilter(
+  normVersions: Ref<LegislationExpression[]>,
+) {
+  const dateFilterValue = ref<string>();
+
+  const filteredNormVersions = computed<LegislationExpression[]>(() => {
+    const filterDate = parseDateGermanLocalTime(dateFilterValue.value);
+
+    if (!filterDate) return normVersions.value;
+
+    const matchingExpression = normVersions.value.find((expression) => {
+      const validityInterval = temporalCoverageToValidityInterval(
+        expression.temporalCoverage,
+      );
+
+      const inForceDate = validityInterval?.from;
+      const outOfForceDate = validityInterval?.to;
+
+      const isOnOrAfterInForce =
+        filterDate.isSame(inForceDate, "day") ||
+        filterDate.isAfter(inForceDate, "day");
+
+      const isOnOrBeforeOutOfForce =
+        filterDate.isBefore(outOfForceDate, "day") ||
+        filterDate.isSame(outOfForceDate, "day") ||
+        !outOfForceDate;
+
+      return isOnOrAfterInForce && isOnOrBeforeOutOfForce;
+    });
+
+    return matchingExpression ? [matchingExpression] : [];
+  });
+
+  return { dateFilterValue, filteredNormVersions };
+}

--- a/frontend/src/composables/useNormVersionFilter.ts
+++ b/frontend/src/composables/useNormVersionFilter.ts
@@ -1,6 +1,6 @@
+import dayjs from "dayjs";
 import { computed, ref } from "vue";
 import type { LegislationExpression } from "~/types/api";
-import { parseDateGermanLocalTime } from "~/utils/dateFormatting";
 import { temporalCoverageToValidityInterval } from "~/utils/norm";
 
 export function useNormVersionFilter(
@@ -9,7 +9,9 @@ export function useNormVersionFilter(
   const dateFilterValue = ref<string>();
 
   const filteredNormVersions = computed<LegislationExpression[]>(() => {
-    const filterDate = parseDateGermanLocalTime(dateFilterValue.value);
+    const filterDate = dateFilterValue.value
+      ? dayjs(dateFilterValue.value, "YYYY-MM-DD").tz("Europe/Berlin")
+      : undefined;
 
     if (!filterDate) return normVersions.value;
 

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { Button, Tab, TabList, Tabs } from "primevue";
-import type { ComputedRef } from "vue";
 import IcBaselineSubject from "~icons/ic/baseline-subject";
 import IconFileDownload from "~icons/ic/outline-file-download";
 import IcOutlineInfo from "~icons/ic/outline-info";
 import IcOutlineRestore from "~icons/ic/outline-settings-backup-restore";
 import { NuxtLink } from "#components";
 import type { BreadcrumbItem } from "~/components/Breadcrumbs.vue";
+import DateInput from "~/components/DateInput.vue";
 import { useNormSeo } from "~/composables/useNormSeo";
 import { DocumentKind, type LegislationExpression } from "~/types/api";
 
@@ -144,9 +144,13 @@ const currentView = computed(
   () => route.query.view?.toString() ?? views[0].path,
 );
 
+const { dateFilterValue: fassungenDateFilterValue, filteredNormVersions } =
+  useNormVersionFilter(normVersions);
+
 const textTabPanelTitleId = useId();
 const detailsTabPanelTitleId = useId();
 const fassungenTabPanelTitleId = useId();
+const fassungenDateFilterInputId = useId();
 </script>
 
 <template>
@@ -288,13 +292,24 @@ const fassungenTabPanelTitleId = useId();
             </h2>
 
             <DocumentsIncompleteDataMessage class="my-24" />
-
+            <div class="my-16 md:my-24">
+              <label
+                :for="fassungenDateFilterInputId"
+                class="ris-label2-regular"
+                >Gültig am</label
+              >
+              <DateInput
+                v-model="fassungenDateFilterValue"
+                class="mb-16 max-w-240 md:mb-24"
+                :id="fassungenDateFilterInputId"
+              />
+            </div>
             <DocumentsNormsNormVersionList
               :status="normVersionsStatus"
               :current-legislation-identifier="
                 metadata.legislationIdentifier ?? ''
               "
-              :versions="normVersions"
+              :versions="filteredNormVersions"
             />
           </template>
 


### PR DESCRIPTION
## This PR:
- adds a date filter for the fassungen table
- the clear button is not yet implemented, will be done in a separate PR

## Notes
- I really struggled with the date comparison and parsing
    - parseDateGemanLocalTime fails if the year is e.g. 0300 (not a real use case but still shouldn't throw)
    - I think the date handling in general needs a refactor as we only want to work with dates (timeless) but using dayjs makes this quite hard. We should probably consider switching to the new temporal API