### PR TITLE
RISDEV-11758-handle-client-abort-exception

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
@@ -316,16 +316,19 @@ public class ControllerExceptionHandler {
    * that handler. This might happen if a client aborts a request during json serialization.
    *
    * @param exception HttpMessageNotWritableException
+   * @return standard 500 ResponseEntity or null in case of a clientAbortException
    */
   @ExceptionHandler({HttpMessageNotWritableException.class})
-  public void handleHttpMessageNotWritableException(HttpMessageNotWritableException exception)
-      throws HttpMessageNotWritableException {
+  public ResponseEntity<CustomErrorResponse> handleHttpMessageNotWritableException(
+      HttpMessageNotWritableException exception) {
     Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(exception);
 
     if (rootCause instanceof ClientAbortException clientabortexception) {
       handleClientAbortException(clientabortexception);
+      // return null since the connection is already lost
+      return null;
     }
-    throw exception;
+    return return500();
   }
 
   /**
@@ -336,11 +339,6 @@ public class ControllerExceptionHandler {
    */
   @ExceptionHandler({ClientAbortException.class})
   public void handleClientAbortException(ClientAbortException exception) {
-    // Get the absolute root cause of the exception chain
-    Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(exception);
-
-    if (rootCause instanceof ClientAbortException) {
-      logger.warn("connection closed by client", rootCause);
-    }
+    logger.warn("connection closed by client: {}", exception.getMessage());
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
@@ -328,6 +328,7 @@ public class ControllerExceptionHandler {
       // return null since the connection is already lost
       return null;
     }
+    logger.error(exception.getMessage(), exception);
     return return500();
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
@@ -11,10 +11,13 @@ import jakarta.validation.Path;
 import java.nio.file.AccessDeniedException;
 import java.util.List;
 import java.util.Objects;
+import org.apache.catalina.connector.ClientAbortException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -306,5 +309,38 @@ public class ControllerExceptionHandler {
     CustomErrorResponse errorResponse =
         CustomErrorResponse.builder().errors(List.of(error)).build();
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+  }
+
+  /**
+   * Checks if a HttpMessageNotWritableException is wrapping a ClientAbortException and delegates to
+   * that handler. This might happen if a client aborts a request during json serialization.
+   *
+   * @param exception HttpMessageNotWritableException
+   */
+  @ExceptionHandler({HttpMessageNotWritableException.class})
+  public void handleHttpMessageNotWritableException(HttpMessageNotWritableException exception)
+      throws HttpMessageNotWritableException {
+    Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(exception);
+
+    if (rootCause instanceof ClientAbortException clientabortexception) {
+      handleClientAbortException(clientabortexception);
+    }
+    throw exception;
+  }
+
+  /**
+   * Logs ClientAbortExceptions with log level warn. Does not return a ResponseEntity since the
+   * connection is lost already.
+   *
+   * @param exception ClientAbortException
+   */
+  @ExceptionHandler({ClientAbortException.class})
+  public void handleClientAbortException(ClientAbortException exception) {
+    // Get the absolute root cause of the exception chain
+    Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(exception);
+
+    if (rootCause instanceof ClientAbortException) {
+      logger.warn("connection closed by client", rootCause);
+    }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/config/TestMockEndpointsController.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/config/TestMockEndpointsController.java
@@ -1,8 +1,10 @@
 package de.bund.digitalservice.ris.search.integration.config;
 
 import java.nio.file.AccessDeniedException;
+import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,5 +24,27 @@ public class TestMockEndpointsController {
   @GetMapping("/internalError")
   public ResponseEntity<String> internalErrorResponse() throws Exception {
     throw new Exception("Unknown error");
+  }
+
+  @GetMapping("/clientAbort")
+  public ClientAbortedResponse triggerNestedAbort() {
+    return new ClientAbortedResponse();
+  }
+
+  @GetMapping("throwHttpMessageNotWritableException")
+  public void throwHttpMessageNotWritableException() {
+    throw new HttpMessageNotWritableException("message not writable");
+  }
+
+  /** A DTO designed to throw a ClientAbortException during JSON serialization */
+  public static class ClientAbortedResponse {
+    /**
+     * When Jackson invokes this getter, it simulates a broken pipe mid-stream
+     *
+     * @return String property that is never actually being returned
+     */
+    public String getBrokenStreamProperty() throws ClientAbortException {
+      throw new ClientAbortException("java.io.IOException: Broken pipe");
+    }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/ErrorResponseTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/ErrorResponseTest.java
@@ -79,4 +79,18 @@ class ErrorResponseTest extends ContainersIntegrationBase {
         .andExpect(jsonPath("$.errors[0].message", Matchers.is("The request could not be parsed")))
         .andExpect(jsonPath("$.errors[0].parameter", Matchers.is("")));
   }
+
+  @Test
+  void shouldGracefullyHandleClientAbortExceptions() throws Exception {
+    mockMvc
+        .perform(get("/clientAbort").contentType(MediaType.TEXT_HTML))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void shouldRethrowHttpMessageNotWritableExceptionThatAreNotFromClientAbort() throws Exception {
+    mockMvc
+        .perform(get("/throwHttpMessageNotWritableException").contentType(MediaType.TEXT_HTML))
+        .andExpect(status().is5xxServerError());
+  }
 }


### PR DESCRIPTION
We don't want to log errors when a client closes the connection. We also don't need to return any response, since the connection is lost already.

The ClientAbortException will be wrapped in a HttpMessageNotWritableException, so we need to parse this one in the ControllerAdvice.