### PR TITLE
Risdev 11293 only consider roots as being deleted

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/ChangelogResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/ChangelogResponseMapper.java
@@ -50,8 +50,13 @@ public class ChangelogResponseMapper {
         path ->
             Stream.of(
                 toChangedDocument(getDocumentBaseUrl(apiPath, path), JsonldTypes.MEDIA_OBJECT)),
-        path ->
-            Stream.of(new ChangelogDeletedDocument(getDocumentBaseUrl(apiPath, path), jsonldType)));
+        path -> {
+          if (!isRootDocument(path)) {
+            return Stream.empty();
+          }
+          return Stream.of(
+              new ChangelogDeletedDocument(getDocumentBaseUrl(apiPath, path), jsonldType));
+        });
   }
 
   private static ChangelogResponse mapLegislation(Changelog changelog) {
@@ -83,10 +88,7 @@ public class ChangelogResponseMapper {
         changelog.getChanged().stream().flatMap(changeMapper).collect(Collectors.toSet());
 
     Set<ChangelogDeletedDocument> deleted =
-        changelog.getDeleted().stream()
-            .filter(ChangelogResponseMapper::isRootDocument)
-            .flatMap(deleteMapper)
-            .collect(Collectors.toSet());
+        changelog.getDeleted().stream().flatMap(deleteMapper).collect(Collectors.toSet());
 
     return new ChangelogResponse(changed, deleted, changelog.isChangeAll());
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/ChangelogResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/ChangelogResponseMapper.java
@@ -20,7 +20,9 @@ public class ChangelogResponseMapper {
 
   /**
    * Takes a Changelog representation and maps it to an api representation of its specific
-   * documentKind
+   * documentKind. It only considers a change as deleted when the root document is being deleted.
+   * For legislation the regelungstext is considered the root. For other documentTypes the the xml
+   * filename that matches the parent directory is considered the root.
    *
    * @param changelog Changelog object to be mapped
    * @param documentKind documentKind of the response
@@ -64,6 +66,7 @@ public class ChangelogResponseMapper {
                             JsonldTypes.LEGISLATION_OBJECT)),
         id ->
             EliFile.fromString(id).stream()
+                .filter(eliFile -> eliFile.fileName().startsWith("regelungstext-"))
                 .map(
                     eli ->
                         new ChangelogDeletedDocument(
@@ -80,9 +83,33 @@ public class ChangelogResponseMapper {
         changelog.getChanged().stream().flatMap(changeMapper).collect(Collectors.toSet());
 
     Set<ChangelogDeletedDocument> deleted =
-        changelog.getDeleted().stream().flatMap(deleteMapper).collect(Collectors.toSet());
+        changelog.getDeleted().stream()
+            .filter(ChangelogResponseMapper::isRootDocument)
+            .flatMap(deleteMapper)
+            .collect(Collectors.toSet());
 
     return new ChangelogResponse(changed, deleted, changelog.isChangeAll());
+  }
+
+  private static boolean isRootDocument(String path) {
+    String[] parts = path.split("/");
+
+    if (parts.length != 2) {
+      return false;
+    }
+
+    String firstId = parts[0];
+    String secondPart = parts[1];
+
+    if (!secondPart.endsWith(".xml")) {
+      return false;
+    }
+
+    // Strip the ".xml" off the second part to isolate the second ID
+    String secondId = secondPart.substring(0, secondPart.length() - 4);
+
+    // Check if the two IDs are an exact match
+    return firstId.equals(secondId);
   }
 
   private static ChangelogChangedDocument toChangedDocument(String baseUrl, String mediaType) {

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/ChangelogResponseMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/ChangelogResponseMapperTest.java
@@ -1,0 +1,65 @@
+package de.bund.digitalservice.ris.search.unit.mapper;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.SET;
+
+import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
+import de.bund.digitalservice.ris.search.mapper.ChangelogResponseMapper;
+import de.bund.digitalservice.ris.search.models.DocumentKind;
+import de.bund.digitalservice.ris.search.schema.ChangelogResponse;
+import java.util.HashSet;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class ChangelogResponseMapperTest {
+
+  @ParameterizedTest
+  @EnumSource(
+      value = DocumentKind.class,
+      names = {"CASE_LAW", "LITERATURE", "ADMINISTRATIVE_DIRECTIVE"})
+  void itIgnoresNonRootDocumentsInDeletedList(DocumentKind documentKind) {
+    Changelog changelog =
+        new Changelog(
+            new HashSet<>(List.of("ABCD00001/ABCD00001.xml")),
+            new HashSet<>(List.of("ABCD00001/ABCD00001-attachment.xml", "ABCD00001/ABCD00001.jpg")),
+            false);
+
+    ChangelogResponse actual = ChangelogResponseMapper.mapChangelog(changelog, documentKind);
+
+    assertThat(actual.deleted().isEmpty());
+    assertThat(actual.changed())
+        .asInstanceOf(SET)
+        .hasSize(1)
+        .extracting("id") // Or use the method reference: ChangelogChangedDocument::id
+        .anySatisfy(id -> assertThat(id.toString()).contains("ABCD00001"));
+  }
+
+  @Test
+  void itIgnoresNonRootDocumentsInDeletedListForLegislation() {
+    Changelog changelog =
+        new Changelog(
+            new HashSet<>(
+                List.of(
+                    "eli/bund/bgbl-1/1999/identifier/2026-01-01/1/deu/2026-01-01/regelungstext-verkuendung-1.xml")),
+            new HashSet<>(
+                List.of(
+                    "eli/bund/bgbl-1/1999/identifier/2026-01-01/1/deu/2026-01-01/anlage-1.xml")),
+            false);
+
+    ChangelogResponse actual =
+        ChangelogResponseMapper.mapChangelog(changelog, DocumentKind.LEGISLATION);
+
+    // Should ignore the anlage and non-root files, leaving deleted empty
+    assertThat(actual.deleted()).asInstanceOf(SET).isEmpty();
+    assertThat(actual.changed())
+        .asInstanceOf(SET)
+        .hasSize(1)
+        .extracting("id")
+        .anySatisfy(
+            id ->
+                assertThat(id.toString())
+                    .contains("eli/bund/bgbl-1/1999/identifier/2026-01-01/1/deu"));
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/ChangelogResponseMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/ChangelogResponseMapperTest.java
@@ -36,6 +36,25 @@ class ChangelogResponseMapperTest {
         .anySatisfy(id -> assertThat(id.toString()).contains("ABCD00001"));
   }
 
+  @ParameterizedTest
+  @EnumSource(
+      value = DocumentKind.class,
+      names = {"CASE_LAW", "LITERATURE", "ADMINISTRATIVE_DIRECTIVE"})
+  void itmarksRootDocumentsAsDeleted(DocumentKind documentKind) {
+    Changelog changelog =
+        new Changelog(
+            new HashSet<>(List.of()), new HashSet<>(List.of("ABCD00002/ABCD00002.xml")), false);
+
+    ChangelogResponse actual = ChangelogResponseMapper.mapChangelog(changelog, documentKind);
+
+    assertThat(actual.changed().isEmpty());
+    assertThat(actual.deleted())
+        .asInstanceOf(SET)
+        .hasSize(1)
+        .extracting("id") // Or use the method reference: ChangelogChangedDocument::id
+        .anySatisfy(id -> assertThat(id.toString()).contains("ABCD00002"));
+  }
+
   @Test
   void itIgnoresNonRootDocumentsInDeletedListForLegislation() {
     Changelog changelog =
@@ -54,6 +73,31 @@ class ChangelogResponseMapperTest {
     // Should ignore the anlage and non-root files, leaving deleted empty
     assertThat(actual.deleted()).asInstanceOf(SET).isEmpty();
     assertThat(actual.changed())
+        .asInstanceOf(SET)
+        .hasSize(1)
+        .extracting("id")
+        .anySatisfy(
+            id ->
+                assertThat(id.toString())
+                    .contains("eli/bund/bgbl-1/1999/identifier/2026-01-01/1/deu"));
+  }
+
+  @Test
+  void itmarksRegelungstextDocumentsAsDeleted() {
+    Changelog changelog =
+        new Changelog(
+            new HashSet<>(List.of()),
+            new HashSet<>(
+                List.of(
+                    "eli/bund/bgbl-1/1999/identifier/2026-01-01/1/deu/2026-01-01/regelungstext-verkuendung-1.xml")),
+            false);
+
+    ChangelogResponse actual =
+        ChangelogResponseMapper.mapChangelog(changelog, DocumentKind.LEGISLATION);
+
+    // Should ignore the anlage and non-root files, leaving deleted empty
+    assertThat(actual.changed()).asInstanceOf(SET).isEmpty();
+    assertThat(actual.deleted())
         .asInstanceOf(SET)
         .hasSize(1)
         .extracting("id")


### PR DESCRIPTION
The Changelogs show all changes down to a specific file. For the changelog api we want to narrow changes down to the identifier. 

We will only add files to the deleted list of an api changelog when it is the file that we consider the root document.