### PR TITLE
RISDEV-11775 prototype on-page text search

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -42,6 +42,11 @@ mark {
   @apply bg-yellow-200;
 }
 
+::highlight(norm-search) {
+  background-color: #fde047; /* yellow-300 */
+  color: inherit;
+}
+
 input[type="search"] {
   &[data-size="large"] {
     &::-webkit-search-cancel-button {

--- a/frontend/src/components/documents/norms/NormTextSearchBar.vue
+++ b/frontend/src/components/documents/norms/NormTextSearchBar.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { InputText } from "primevue"
+import IcOutlineClose from "~icons/ic/outline-close"
+import IcSearch from "~icons/ic/search"
+
+const model = defineModel<string>({ default: "" })
+
+const props = defineProps<{
+  matchCount?: number
+}>()
+
+const inputId = useId()
+
+function onClear() {
+  model.value = ""
+}
+</script>
+
+<template>
+  <div class="flex items-center gap-8">
+    <label :for="inputId" class="sr-only">Im Gesetzestext suchen</label>
+    <div class="relative flex items-center">
+      <IcSearch
+        class="absolute left-8 text-gray-600"
+        aria-hidden="true"
+      />
+      <InputText
+        :id="inputId"
+        v-model="model"
+        placeholder="Im Text suchen …"
+        type="search"
+        class="pl-32 pr-32"
+        aria-label="Im Gesetzestext suchen"
+      />
+      <button
+        v-if="model"
+        type="button"
+        class="absolute right-8 text-gray-600 hover:text-gray-900"
+        aria-label="Suche leeren"
+        @click="onClear"
+      >
+        <IcOutlineClose aria-hidden="true" />
+      </button>
+    </div>
+    <span
+      v-if="model"
+      class="ris-body2-regular whitespace-nowrap text-gray-700"
+      aria-live="polite"
+    >
+      {{ matchCount }} Treffer
+    </span>
+  </div>
+</template>

--- a/frontend/src/composables/useNormTextSearch.ts
+++ b/frontend/src/composables/useNormTextSearch.ts
@@ -1,0 +1,71 @@
+/**
+ * Composable for searching within the norm text content and highlighting
+ * matches using the CSS Custom Highlight API.
+ *
+ * @param contentRef - A ref pointing to the DOM element containing the norm text.
+ */
+export function useNormTextSearch(contentRef: Ref<HTMLElement | null>) {
+  const HIGHLIGHT_NAME = "norm-search"
+
+  const query = ref("")
+  const matchCount = ref(0)
+
+  function highlight() {
+    if (!CSS.highlights) return
+
+    CSS.highlights.delete(HIGHLIGHT_NAME)
+    matchCount.value = 0
+
+    const container = contentRef.value
+    const str = query.value.trim().toLowerCase()
+    if (!container || !str) return
+
+    // Collect all text nodes inside the container
+    const walker = document.createTreeWalker(
+      container,
+      NodeFilter.SHOW_TEXT,
+    )
+    const textNodes: Text[] = []
+    let node: Node | null
+    while ((node = walker.nextNode())) {
+      textNodes.push(node as Text)
+    }
+
+    // Find all matches and create Range objects
+    const ranges: Range[] = []
+    for (const textNode of textNodes) {
+      const text = textNode.textContent?.toLowerCase() ?? ""
+      let startPos = 0
+      while (startPos < text.length) {
+        const index = text.indexOf(str, startPos)
+        if (index === -1) break
+        const range = new Range()
+        range.setStart(textNode, index)
+        range.setEnd(textNode, index + str.length)
+        ranges.push(range)
+        startPos = index + str.length
+      }
+    }
+
+    matchCount.value = ranges.length
+    if (ranges.length > 0) {
+      CSS.highlights.set(HIGHLIGHT_NAME, new Highlight(...ranges))
+    }
+  }
+
+  function clear() {
+    query.value = ""
+    if (CSS.highlights) {
+      CSS.highlights.delete(HIGHLIGHT_NAME)
+    }
+    matchCount.value = 0
+  }
+
+  // Re-run the highlight whenever the query changes
+  watch(query, highlight)
+
+  // Clean up when the component using this composable is unmounted
+  onUnmounted(clear)
+
+  return { query, matchCount, clear }
+}

--- a/frontend/src/pages/administrative-directives/[documentNumber].vue
+++ b/frontend/src/pages/administrative-directives/[documentNumber].vue
@@ -48,6 +48,10 @@ const views: TabView[] = [
 const textSectionId = useId();
 const detailsSectionId = useId();
 
+const textContentRef = ref<HTMLElement | null>(null);
+const { query: searchQuery, matchCount: searchMatchCount } =
+  useNormTextSearch(textContentRef);
+
 const title = computed(() => data.value?.headline);
 
 const document = html.value ? parseDocument(html.value) : undefined;
@@ -121,8 +125,14 @@ const detailItems = computed(() =>
           <section role="tabpanel" :aria-labelledby="textSectionId">
             <h2 :id="textSectionId" class="sr-only">Text</h2>
             <DocumentsIncompleteDataMessage />
+            <DocumentsNormsNormTextSearchBar
+              v-model="searchQuery"
+              :match-count="searchMatchCount"
+              class="mb-16 print:hidden"
+            />
             <div
               v-if="document"
+              ref="textContentRef"
               class="administrative-directive"
               v-html="document.body.innerHTML"
             ></div>

--- a/frontend/src/pages/case-law/[documentNumber].vue
+++ b/frontend/src/pages/case-law/[documentNumber].vue
@@ -104,6 +104,10 @@ const detailsMetadata = computed(() => {
 
 const textSectionId = useId();
 const detailsSectionId = useId();
+
+const textContentRef = ref<HTMLElement | null>(null);
+const { query: searchQuery, matchCount: searchMatchCount } =
+  useNormTextSearch(textContentRef);
 </script>
 
 <template>
@@ -164,8 +168,14 @@ const detailsSectionId = useId();
           <section role="tabpanel" :aria-labelledby="textSectionId">
             <h2 :id="textSectionId" class="sr-only">Text</h2>
             <DocumentsIncompleteDataMessage />
+            <DocumentsNormsNormTextSearchBar
+              v-model="searchQuery"
+              :match-count="searchMatchCount"
+              class="mb-16 print:hidden"
+            />
             <div
               v-if="document"
+              ref="textContentRef"
               class="case-law"
               v-html="document.body.innerHTML"
             ></div>

--- a/frontend/src/pages/literature/[documentNumber].vue
+++ b/frontend/src/pages/literature/[documentNumber].vue
@@ -54,6 +54,10 @@ const views: TabView[] = [
 const textSectionId = useId();
 const detailsSectionId = useId();
 
+const textContentRef = ref<HTMLElement | null>(null);
+const { query: searchQuery, matchCount: searchMatchCount } =
+  useNormTextSearch(textContentRef);
+
 const title = computed(() => getTitle(literature.value));
 const document = html.value ? parseDocument(html.value) : undefined;
 const isEmptyDocument = computed(() => isDocumentEmpty(document));
@@ -123,8 +127,14 @@ const detailItems = computed(() => getLiteratureDetailItems(literature.value));
           <section role="tabpanel" :aria-labelledby="textSectionId">
             <h2 :id="textSectionId" class="sr-only">Text</h2>
             <DocumentsIncompleteDataMessage />
+            <DocumentsNormsNormTextSearchBar
+              v-model="searchQuery"
+              :match-count="searchMatchCount"
+              class="mb-16 print:hidden"
+            />
             <div
               v-if="document"
+              ref="textContentRef"
               class="literature"
               v-html="document.body.innerHTML"
             ></div>

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -147,6 +147,10 @@ const textTabPanelTitleId = useId();
 const detailsTabPanelTitleId = useId();
 const fassungenTabPanelTitleId = useId();
 const fassungenDateFilterInputId = useId();
+
+const normTextContentRef = ref<HTMLElement | null>(null);
+const { query: searchQuery, matchCount: searchMatchCount } =
+  useNormTextSearch(normTextContentRef);
 </script>
 
 <template>
@@ -184,12 +188,18 @@ const fassungenDateFilterInputId = useId();
           <section role="tabpanel" :aria-labelledby="textTabPanelTitleId">
             <SidebarLayout class="wrapper">
               <template #content>
+                <div class="container pt-16 pb-4 print:hidden">
+                  <DocumentsNormsNormTextSearchBar
+                    v-model="searchQuery"
+                    :match-count="searchMatchCount"
+                  />
+                </div>
                 <h2 :id="textTabPanelTitleId" class="sr-only">Text</h2>
                 <DocumentsIncompleteDataMessage />
                 <DocumentsNormsLegislationContent
                   :official-toc="htmlParts.officialToc"
                 >
-                  <div v-html="htmlParts.body" />
+                  <div ref="normTextContentRef" v-html="htmlParts.body" />
                 </DocumentsNormsLegislationContent>
               </template>
 

--- a/frontend/src/pages/translations/[id].vue
+++ b/frontend/src/pages/translations/[id].vue
@@ -88,6 +88,10 @@ const views: OneOrMore<TabView> = [
 
 const textSectionId = useId();
 const detailsTabPanelTitleId = useId();
+
+const textContentRef = ref<HTMLElement | null>(null);
+const { query: searchQuery, matchCount: searchMatchCount } =
+  useNormTextSearch(textContentRef);
 </script>
 
 <template>
@@ -145,7 +149,12 @@ const detailsTabPanelTitleId = useId();
             :aria-labelledby="textSectionId"
           >
             <h2 :id="textSectionId" class="sr-only">Text</h2>
-            <section class="max-w-prose" v-html="html" />
+            <DocumentsNormsNormTextSearchBar
+              v-model="searchQuery"
+              :match-count="searchMatchCount"
+              class="mb-16 print:hidden"
+            />
+            <section class="max-w-prose" ref="textContentRef" v-html="html" />
           </section>
         </template>
 


### PR DESCRIPTION
This PR demonstrates what a basic implementation of a <kbd>ctrl + f</kbd>-style text search on the page could look like. Don't merge pls 🙇‍♂️

Based on the search example in the [Custom CSS Highlights API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API#:~:text=white%3B%0A%7D-,Result,-The%20result%20is) docs on MDN.