### PR TITLE
RISDEV-0000 Try using dependabot for image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,3 @@ updates:
       day: "sunday"
     cooldown:
       default-days: 3
-    ignore:
-      # The chainguard images is updated separately, see: update-chainguard-image-version-cronjob.yml
-      - dependency-name: "chainguard/jre"

--- a/.github/workflows/update-chainguard-image-version-cronjob.yml
+++ b/.github/workflows/update-chainguard-image-version-cronjob.yml
@@ -1,7 +1,5 @@
 name: Update-Chainguard-Image-Version-Cronjob
 on:
-  schedule:
-    - cron: '0 18 * * 0' # Runs at 6:00pm UTC (7 winter time/8 summer time in Germany) on Sundays
   # Allow manual workflow trigger
   workflow_dispatch:
 


### PR DESCRIPTION
- it seems like dependabot is now able to update chainguard images 
- this PR disables the custom update action and enables dependabot image updates for all applications - lets see if that works

RISDEV-0000