### PR TITLE
RISDEV-10395 clean up and simplify search result teasers

### DIFF
--- a/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
+++ b/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
@@ -3,21 +3,23 @@ import RuleIcon from "~icons/ic/outline-rule";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
 import { usePostHog } from "~/composables/usePostHog";
 import type { AdministrativeDirective, SearchResult } from "~/types/api";
-
-const { searchResultClicked } = usePostHog();
-const router = useRouter();
+import { getMatch, getTitleWithFallback } from "~/utils/search/searchResults";
 
 const { searchResult, order } = defineProps<{
   searchResult: SearchResult<AdministrativeDirective>;
   order: number;
 }>();
 
-const detailPageRoute = computed(() => ({
-  name: "administrative-directives-documentNumber",
-  params: {
-    documentNumber: searchResult.item.documentNumber,
-  },
-}));
+const { searchResultClicked } = usePostHog();
+
+const router = useRouter();
+
+const headline = computed(() =>
+  getTitleWithFallback(
+    getMatch("headline", searchResult.textMatches),
+    searchResult.item.headline,
+  ),
+);
 
 const resultTypeId = useId();
 
@@ -31,19 +33,18 @@ const headerItems = computed<SearchResultHeaderItem[]>(() => {
   ].filter((i): i is SearchResultHeaderItem => i.value !== undefined);
 });
 
-const headline = computed(() =>
-  sanitizeSearchResult(
-    getMatch("headline") ||
-      searchResult.item.headline ||
-      "Titelzeile nicht vorhanden",
-  ),
-);
+const detailPageRoute = computed(() => ({
+  name: "administrative-directives-documentNumber",
+  params: {
+    documentNumber: searchResult.item.documentNumber,
+  },
+}));
 
 const text = computed(() => {
-  const shortReportMatch = getMatch("shortReport");
+  const shortReportMatch = getMatch("shortReport", searchResult.textMatches);
   if (!shortReportMatch) return undefined;
 
-  const plainShortReportMatch = sanitizeSearchResult(shortReportMatch, []);
+  const plainShortReportMatch = stripAllHtml(shortReportMatch);
   const fullShortReport = searchResult.item.shortReport;
   const sanitizedShortReport = sanitizeSearchResult(shortReportMatch);
 
@@ -54,10 +55,6 @@ const text = computed(() => {
 
   return `${prefix}${sanitizedShortReport}${postfix}`;
 });
-
-function getMatch(name: string) {
-  return searchResult.textMatches.find((match) => match.name === name)?.text;
-}
 
 function trackResultClick() {
   const url = router.resolve(detailPageRoute.value).href;

--- a/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
+++ b/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
@@ -3,7 +3,6 @@ import RuleIcon from "~icons/ic/outline-rule";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
 import { usePostHog } from "~/composables/usePostHog";
 import type { AdministrativeDirective, SearchResult } from "~/types/api";
-import { sanitizeSearchResult } from "~/utils/sanitize";
 
 const { searchResultClicked } = usePostHog();
 const router = useRouter();

--- a/frontend/src/components/search/CaselawSearchResult.vue
+++ b/frontend/src/components/search/CaselawSearchResult.vue
@@ -3,11 +3,7 @@ import { partition } from "lodash-es";
 import GavelIcon from "~icons/ic/outline-gavel";
 import type { RouteLocationRaw } from "#vue-router";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
-import { usePostHog } from "~/composables/usePostHog";
 import type { CaseLaw, SearchResult, TextMatch } from "~/types/api";
-import { dateFormattedDDMMYYYY } from "~/utils/dateFormatting";
-import { sanitizeSearchResult } from "~/utils/sanitize";
-import { addEllipsis, removeOuterParentheses } from "~/utils/textFormatting";
 
 const { searchResultClicked } = usePostHog();
 

--- a/frontend/src/components/search/CaselawSearchResult.vue
+++ b/frontend/src/components/search/CaselawSearchResult.vue
@@ -1,33 +1,22 @@
 <script setup lang="ts">
 import { partition } from "lodash-es";
 import GavelIcon from "~icons/ic/outline-gavel";
-import type { RouteLocationRaw } from "#vue-router";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
 import type { CaseLaw, SearchResult, TextMatch } from "~/types/api";
+import {
+  getMatch,
+  getMatches,
+  getTitleWithFallback,
+} from "~/utils/search/searchResults";
 
-const { searchResultClicked } = usePostHog();
-
-const props = defineProps<{
+const { searchResult, order } = defineProps<{
   searchResult: SearchResult<CaseLaw>;
   order: number;
 }>();
 
-type CaseLawMetadata = {
-  headline: string;
-  route: RouteLocationRaw;
-  url: string;
-  decisionName: string;
-};
+const { searchResultClicked } = usePostHog();
 
-function getMatch(match: string, matches: TextMatch[]) {
-  return matches.find((highlight) => highlight.name === match)?.text;
-}
-
-function getMatches(match: string, matches: TextMatch[]) {
-  return matches
-    .filter((highlight) => highlight.name === match)
-    .map((highlight) => highlight.text);
-}
+const router = useRouter();
 
 type Key =
   | "guidingPrinciple"
@@ -45,7 +34,6 @@ interface FieldDisplayProperties {
 
 type ExtendedTextMatch = TextMatch & FieldDisplayProperties;
 
-// field definitions. A Map is used to preserve order, with the first present item
 const fields: Map<Key, FieldDisplayProperties> = new Map([
   ["guidingPrinciple", { id: "leitsatz", title: "Leitsatz" }],
   ["headnote", { id: "orientierungssatz", title: "Orientierungssatz" }],
@@ -65,81 +53,19 @@ const fields: Map<Key, FieldDisplayProperties> = new Map([
   ],
 ]);
 
-function getFileNumbers(item: CaseLaw) {
-  const matches = getMatches("fileNumbers", props.searchResult.textMatches);
-  if (matches.length) {
-    const replaced = [...item.fileNumbers];
-    for (const match of matches) {
-      const stripped = sanitizeSearchResult(match, []);
-      const index = item.fileNumbers.indexOf(stripped);
-      if (index !== -1) {
-        replaced[index] = match;
-      }
-    }
-    return replaced.join(", ");
-  }
-  return item.fileNumbers?.join(", ");
-}
+const headline = computed(() =>
+  getTitleWithFallback(
+    removeOuterParentheses(getMatch("headline", searchResult.textMatches)),
+    removeOuterParentheses(searchResult.item.headline),
+  ),
+);
 
-const metadata = computed(() => {
-  const item = props.searchResult.item;
-  return {
-    headline:
-      getMatch("headline", props.searchResult.textMatches) ||
-      item.headline ||
-      "Titelzeile nicht vorhanden",
-    route: {
-      name: "case-law-documentNumber",
-      params: { documentNumber: props.searchResult.item.documentNumber },
-    },
-    // The URL is currently needed for PostHog tracking but should not be used
-    // for navigation. Use `route` for navigation instead.
-    url: `/case-law/${props.searchResult.item.documentNumber}`,
-    decisionName: item.decisionName?.at(0),
-  } as CaseLawMetadata;
-});
-
-const previewSections = computed<ExtendedTextMatch[]>(() => {
-  const textMatches = props.searchResult.textMatches;
-  const foundFields = new Set<Key>();
-  const relevantMatches = textMatches
-    .filter((match) => fields.has(match.name as Key))
-    .map((match) => {
-      foundFields.add(match.name as Key);
-      return {
-        ...match,
-        text: addEllipsis(match.text),
-        ...fields.get(match.name as Key),
-      } as ExtendedTextMatch;
-    });
-
-  // always show the most relevant field, regardless of highlight status
-  const firstFieldName = [...fields.keys()].find((key) => foundFields.has(key));
-  const [firstFields, otherFields] = partition(
-    relevantMatches,
-    (match) => match.name === firstFieldName,
-  );
-
-  // show up to 4 fields
-  const slice: ExtendedTextMatch[] = [...firstFields, ...otherFields]
-    .slice(0, 4)
-    .filter((i) => !!i);
-
-  if (slice.length === 0) return [];
-
-  const haveHighlight = slice.some((field) => field.text.includes("<mark>"));
-
-  // if no fields have a highlight, show only the first one
-  // casting because TypeScript doesn't realize we already ensured it's not undefined
-  if (!haveHighlight) return [slice[0] as ExtendedTextMatch];
-
-  return slice;
-});
+const decisionName = computed(() => searchResult.item.decisionName?.at(0));
 
 const resultTypeId = useId();
 
 const headerItems = computed(() => {
-  const item = props.searchResult.item;
+  const item = searchResult.item;
 
   const items: SearchResultHeaderItem[] = [
     { value: item.documentType || "Entscheidung", id: resultTypeId },
@@ -156,12 +82,71 @@ const headerItems = computed(() => {
   return items;
 });
 
-const headline = computed(() =>
-  sanitizeSearchResult(removeOuterParentheses(metadata.value.headline)),
-);
+function getFileNumbers(item: CaseLaw) {
+  const matches = getMatches("fileNumbers", searchResult.textMatches);
 
-function trackResultClick(url: string) {
-  searchResultClicked(url, props.order);
+  if (matches.length) {
+    const replaced = [...item.fileNumbers];
+    for (const match of matches) {
+      const stripped = stripAllHtml(match);
+      const index = item.fileNumbers.indexOf(stripped);
+      if (index !== -1) {
+        replaced[index] = match;
+      }
+    }
+
+    return replaced.join(", ");
+  }
+
+  return item.fileNumbers?.join(", ");
+}
+
+const detailPageRoute = computed(() => ({
+  name: "case-law-documentNumber",
+  params: { documentNumber: searchResult.item.documentNumber },
+}));
+
+const previewSections = computed<ExtendedTextMatch[]>(() => {
+  const textMatches = searchResult.textMatches;
+  const foundFields = new Set<Key>();
+
+  const relevantMatches = textMatches
+    .filter((match) => fields.has(match.name as Key))
+    .map<ExtendedTextMatch>((match) => {
+      foundFields.add(match.name as Key);
+      return {
+        ...match,
+        text: sanitizeSearchResult(addEllipsis(match.text) ?? ""),
+        ...fields.get(match.name as Key)!, // always defined since we filtered above
+      };
+    });
+
+  // always show the most relevant field, regardless of highlight status
+  const firstFieldName = [...fields.keys()].find((key) => foundFields.has(key));
+  const [firstFields, otherFields] = partition(
+    relevantMatches,
+    (match) => match.name === firstFieldName,
+  );
+
+  // show up to 4 fields
+  const slice: ExtendedTextMatch[] = [...firstFields, ...otherFields]
+    .slice(0, 4)
+    .filter((i) => !!i);
+
+  if (slice.length === 0) return [];
+
+  const highlighted = slice.some((field) => field.text.includes("<mark>"));
+
+  // if no fields have a highlight, show only the first one casting because
+  // TypeScript doesn't realize we already ensured it's not undefined
+  if (!highlighted) return [slice[0] as ExtendedTextMatch];
+
+  return slice;
+});
+
+function trackResultClick() {
+  const url = router.resolve(detailPageRoute.value).href;
+  searchResultClicked(url, order);
 }
 </script>
 
@@ -169,15 +154,13 @@ function trackResultClick(url: string) {
   <div class="my-36 flex flex-col gap-8 hyphens-auto">
     <SearchResultHeader :icon="GavelIcon" :items="headerItems" />
     <NuxtLink
-      :to="metadata.route"
+      :to="detailPageRoute"
       :aria-describedby="resultTypeId"
       class="ris-heading3-bold! ris-link1-regular link-hover block"
-      @click="trackResultClick(metadata.url)"
+      @click="trackResultClick()"
     >
       <h2>
-        <span v-if="!!metadata.decisionName">
-          {{ metadata.decisionName }} —
-        </span>
+        <span v-if="!!decisionName"> {{ decisionName }} — </span>
         <span v-html="headline" />
       </h2>
     </NuxtLink>
@@ -185,17 +168,17 @@ function trackResultClick(url: string) {
     <div class="flex w-full flex-col gap-6">
       <div v-for="section in previewSections" :key="section?.id">
         <NuxtLink
-          :to="{ path: `${metadata.url}`, hash: `#${section?.id}` }"
+          :to="{ ...detailPageRoute, hash: `#${section?.id}` }"
           class="ris-link1-bold link-hover"
           external
-          @click="trackResultClick(`${metadata.url}#${section?.id}`)"
+          @click="trackResultClick()"
           >{{ section?.title }}:</NuxtLink
         >{{ " " }}
         <span
           v-if="section.text"
           data-testid="highlighted-field"
           class="ris-label1-regular"
-          v-html="sanitizeSearchResult(section.text)"
+          v-html="section.text"
         />
       </div>
     </div>

--- a/frontend/src/components/search/LiteratureSearchResult.vue
+++ b/frontend/src/components/search/LiteratureSearchResult.vue
@@ -1,11 +1,7 @@
 <script setup lang="ts">
 import OutlineBookIcon from "~icons/ic/outline-book";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
-import { usePostHog } from "~/composables/usePostHog";
 import type { Literature, SearchResult, TextMatch } from "~/types/api";
-import { LITERATURE_TITLE_PLACEHOLDER } from "~/utils/literature";
-import { sanitizeSearchResult } from "~/utils/sanitize";
-import { addEllipsis } from "~/utils/textFormatting";
 
 const { searchResultClicked } = usePostHog();
 const router = useRouter();

--- a/frontend/src/components/search/LiteratureSearchResult.vue
+++ b/frontend/src/components/search/LiteratureSearchResult.vue
@@ -1,70 +1,31 @@
 <script setup lang="ts">
 import OutlineBookIcon from "~icons/ic/outline-book";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
-import type { Literature, SearchResult, TextMatch } from "~/types/api";
+import type { Literature, SearchResult } from "~/types/api";
+import { getMatch, getTitleWithFallback } from "~/utils/search/searchResults";
 
-const { searchResultClicked } = usePostHog();
-const router = useRouter();
-
-const props = defineProps<{
+const { searchResult, order } = defineProps<{
   searchResult: SearchResult<Literature>;
   order: number;
 }>();
 
-type LiteratureMetadata = {
-  headline: string;
-  alternativeHeadline: string;
-  shortReport: string;
-};
+const { searchResultClicked } = usePostHog();
 
-function getMatch(match: string, highlights: TextMatch[]) {
-  return highlights.find((highlight) => highlight.name === match)?.text;
-}
+const router = useRouter();
 
-function getShortReportSnippet(
-  shortReport: string | undefined,
-  textMatches: TextMatch[],
-): string | undefined {
-  if (!shortReport) return undefined;
-
-  // Find the relevant highlight for "shortReport"
-  const match = textMatches.find(
-    (hl) => hl.name === "shortReport" && hl.text?.includes("<mark>"),
-  );
-
-  if (!match) {
-    // No highlight — just return the whole text, will be truncated with line-clamp because of 3 lines wanted and not only 2
-    return shortReport;
-  }
-
-  // Return the highlighted text (with ellipsis if needed)
-  return addEllipsis(match.text);
-}
-
-const detailPageRoute = computed(() => ({
-  name: "literature-documentNumber",
-  params: { documentNumber: props.searchResult.item.documentNumber },
-}));
-
-const metadata = computed(() => {
-  const item = props.searchResult.item;
-  return {
-    headline:
-      getMatch("mainTitle", props.searchResult.textMatches) || item.headline,
-    alternativeHeadline:
-      getMatch("documentaryTitle", props.searchResult.textMatches) ||
-      item.alternativeHeadline,
-    shortReport: getShortReportSnippet(
-      item.shortReport,
-      props.searchResult.textMatches,
-    ),
-  } as LiteratureMetadata;
-});
+const headline = computed(() =>
+  getTitleWithFallback(
+    getMatch("mainTitle", searchResult.textMatches),
+    searchResult.item.headline,
+    getMatch("documentaryTitle", searchResult.textMatches),
+    searchResult.item.alternativeHeadline,
+  ),
+);
 
 const resultTypeId = useId();
 
 const headerItems = computed<SearchResultHeaderItem[]>(() => {
-  const item = props.searchResult.item;
+  const item = searchResult.item;
   const reference =
     item.dependentReferences?.[0] ?? item.independentReferences?.[0];
   return [
@@ -74,25 +35,39 @@ const headerItems = computed<SearchResultHeaderItem[]>(() => {
   ].filter((i): i is SearchResultHeaderItem => i.value !== undefined);
 });
 
-const sanitizedHeadline = computed(() =>
-  sanitizeSearchResult(
-    metadata.value.headline ||
-      metadata.value.alternativeHeadline ||
-      LITERATURE_TITLE_PLACEHOLDER,
-  ),
-);
+const detailPageRoute = computed(() => ({
+  name: "literature-documentNumber",
+  params: { documentNumber: searchResult.item.documentNumber },
+}));
+
+const shortReport = computed(() => {
+  const fullText = searchResult.item.shortReport;
+  if (!fullText) return undefined;
+
+  // Find the relevant highlight for "shortReport"
+  const match = searchResult.textMatches.find(
+    (hl) => hl.name === "shortReport" && hl.text?.includes("<mark>"),
+  );
+
+  // No highlight — just return the whole text, will be truncated with
+  // line-clamp because of 3 lines wanted and not only 2
+  if (!match) return fullText;
+
+  // Return the highlighted text (with ellipsis if needed)
+  return addEllipsis(match.text);
+});
 
 const shortReportIncludesHighlight = computed(
-  () => metadata.value.shortReport?.includes("<mark>") ?? false,
+  () => shortReport.value?.includes("<mark>") ?? false,
 );
 
 const sanitizedShortReport = computed(() =>
-  sanitizeSearchResult(metadata.value.shortReport),
+  sanitizeSearchResult(shortReport.value ?? ""),
 );
 
 function trackResultClick() {
   const url = router.resolve(detailPageRoute.value).href;
-  searchResultClicked(url, props.order);
+  searchResultClicked(url, order);
 }
 </script>
 
@@ -106,7 +81,7 @@ function trackResultClick() {
       @click="trackResultClick()"
     >
       <h2>
-        <span v-html="sanitizedHeadline" />
+        <span v-html="headline" />
       </h2>
     </NuxtLink>
 

--- a/frontend/src/components/search/NormSearchResult.vue
+++ b/frontend/src/components/search/NormSearchResult.vue
@@ -1,81 +1,70 @@
 <script setup lang="ts">
+import type { Dayjs } from "dayjs";
 import IcBaselineBalance from "~icons/ic/baseline-balance";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
-import type {
-  LegislationExpression,
-  SearchResult,
-  TextMatch,
-} from "~/types/api";
+import type { LegislationExpression, SearchResult } from "~/types/api";
+import { getMatch, getTitleWithFallback } from "~/utils/search/searchResults";
 
-const props = defineProps<{
+const { searchResult, order } = defineProps<{
   searchResult: SearchResult<LegislationExpression>;
   order: number;
 }>();
 
 const { searchResultClicked } = usePostHog();
 
-const item = computed(() => props.searchResult.item);
-
-const textMatches: ComputedRef<TextMatch[]> = computed(
-  () => props.searchResult.textMatches,
-);
-
-const headline = computed(() => {
-  const match =
-    getMatch("name", textMatches.value) ||
-    item.value.name ||
-    "Titelzeile nicht vorhanden";
-
-  return sanitizeSearchResult(match);
-});
-
-function getMatch(match: string, highlights: TextMatch[]) {
-  return highlights.find((highlight) => highlight.name === match)?.text;
-}
-
-const link = computed(() => {
-  const prefix = "/norms/";
-  const expressionEli = item.value.legislationIdentifier;
-  if (!expressionEli) return null;
-  return prefix + expressionEli;
-});
-
 const privateFeaturesEnabled = usePrivateFeaturesFlag();
 
-const formattedDate = computed(() => {
-  const date = privateFeaturesEnabled
-    ? temporalCoverageToValidityInterval(item.value?.temporalCoverage)?.from
-    : item.value?.exampleOfWork.legislationDate;
-
-  return dateFormattedDDMMYYYY(date);
-});
-
-const relevantHighlights = computed(() => {
-  return textMatches.value
-    .filter((highlight) => highlight.name != "name")
-    .map((hl) => ({ ...hl, text: addEllipsis(hl.text) }) as TextMatch);
-});
-
-function openResult(url: string) {
-  searchResultClicked(url, props.order);
-}
-
-const validityStatus = computed(() => {
-  return formatNormValidity(item.value.temporalCoverage);
-});
+const headline = computed(() =>
+  getTitleWithFallback(
+    getMatch("name", searchResult.textMatches),
+    searchResult.item.name,
+  ),
+);
 
 const resultTypeId = useId();
 
 const headerItems = computed<SearchResultHeaderItem[]>(() => {
+  let date: string | Dayjs | undefined =
+    searchResult.item?.exampleOfWork.legislationDate;
+
+  if (privateFeaturesEnabled) {
+    const coverage = temporalCoverageToValidityInterval(
+      searchResult.item?.temporalCoverage,
+    );
+    date = coverage?.from;
+  }
+
   return [
     { value: "Norm", id: resultTypeId },
-    { value: item.value.abbreviation },
-    { value: formattedDate.value },
+    { value: searchResult.item.abbreviation },
+    { value: dateFormattedDDMMYYYY(date) },
   ].filter((i): i is SearchResultHeaderItem => i.value !== undefined);
 });
 
-const getArticleUrl = (highlight: TextMatch) =>
-  `${link.value}/${highlight.location ?? ""}`;
+const validityStatus = computed(() =>
+  formatNormValidity(searchResult.item.temporalCoverage),
+);
+
+const detailPageUrl = computed(() => {
+  const prefix = "/norms/";
+  const expressionEli = searchResult.item.legislationIdentifier;
+  if (!expressionEli) return null;
+  return prefix + expressionEli;
+});
+
+const relevantHighlights = computed(() =>
+  searchResult.textMatches
+    .filter((highlight) => highlight.name != "name")
+    .map((hl) => ({
+      name: sanitizeSearchResult(hl.name),
+      text: sanitizeSearchResult(addEllipsis(hl.text) ?? ""),
+      location: hl.location,
+    })),
+);
+
+function getArticleLink(highlight: { location?: string | null }) {
+  return `${detailPageUrl.value}/${highlight.location ?? ""}`;
+}
 </script>
 
 <template>
@@ -90,11 +79,11 @@ const getArticleUrl = (highlight: TextMatch) =>
       </template>
     </SearchResultHeader>
     <NuxtLink
-      v-if="!!link"
-      :to="link"
+      v-if="!!detailPageUrl"
+      :to="detailPageUrl"
       :aria-describedby="resultTypeId"
       class="ris-heading3-bold! ris-link1-regular link-hover block"
-      @click="openResult(link)"
+      @click="searchResultClicked(detailPageUrl, order)"
     >
       <h2 v-html="headline" />
     </NuxtLink>
@@ -107,14 +96,12 @@ const getArticleUrl = (highlight: TextMatch) =>
       >
         <NuxtLink
           class="ris-link1-bold link-hover"
-          :to="getArticleUrl(highlight)"
-          @click="openResult(getArticleUrl(highlight))"
+          :to="getArticleLink(highlight)"
+          @click="searchResultClicked(getArticleLink(highlight), order)"
         >
-          <span v-html="sanitizeSearchResult(highlight.name)" />
+          <span v-html="highlight.name" />
         </NuxtLink>
-        <div
-          v-html="highlight.text ? sanitizeSearchResult(highlight.text) : ''"
-        />
+        <div v-html="highlight.text" />
       </div>
     </div>
   </div>

--- a/frontend/src/components/search/NormSearchResult.vue
+++ b/frontend/src/components/search/NormSearchResult.vue
@@ -1,19 +1,11 @@
 <script setup lang="ts">
 import IcBaselineBalance from "~icons/ic/baseline-balance";
-import Badge from "~/components/Badge.vue";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
-import { usePostHog } from "~/composables/usePostHog";
-import { usePrivateFeaturesFlag } from "~/composables/usePrivateFeaturesFlag";
 import type {
   LegislationExpression,
   SearchResult,
   TextMatch,
 } from "~/types/api";
-import { dateFormattedDDMMYYYY } from "~/utils/dateFormatting";
-import { formatNormValidity } from "~/utils/displayValues";
-import { temporalCoverageToValidityInterval } from "~/utils/norm";
-import { sanitizeSearchResult } from "~/utils/sanitize";
-import { addEllipsis } from "~/utils/textFormatting";
 
 const props = defineProps<{
   searchResult: SearchResult<LegislationExpression>;

--- a/frontend/src/components/search/SearchResult.spec.ts
+++ b/frontend/src/components/search/SearchResult.spec.ts
@@ -21,13 +21,13 @@ describe("SearchResult", () => {
       },
       global: {
         stubs: {
-          CaselawSearchResult: true,
+          SearchCaselawSearchResult: true,
         },
       },
     });
 
     expect(
-      container.querySelector("caselaw-search-result-stub"),
+      container.querySelector("search-caselaw-search-result-stub"),
     ).toBeInTheDocument();
   });
 
@@ -41,13 +41,13 @@ describe("SearchResult", () => {
       },
       global: {
         stubs: {
-          NormSearchResult: true,
+          SearchNormSearchResult: true,
         },
       },
     });
 
     expect(
-      container.querySelector("norm-search-result-stub"),
+      container.querySelector("search-norm-search-result-stub"),
     ).toBeInTheDocument();
   });
 
@@ -61,13 +61,13 @@ describe("SearchResult", () => {
       },
       global: {
         stubs: {
-          LiteratureSearchResult: true,
+          SearchLiteratureSearchResult: true,
         },
       },
     });
 
     expect(
-      container.querySelector("literature-search-result-stub"),
+      container.querySelector("search-literature-search-result-stub"),
     ).toBeInTheDocument();
   });
 
@@ -81,13 +81,15 @@ describe("SearchResult", () => {
       },
       global: {
         stubs: {
-          AdministrativeDirectiveSearchResult: true,
+          SearchAdministrativeDirectiveSearchResult: true,
         },
       },
     });
 
     expect(
-      container.querySelector("administrative-directive-search-result-stub"),
+      container.querySelector(
+        "search-administrative-directive-search-result-stub",
+      ),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/search/SearchResult.vue
+++ b/frontend/src/components/search/SearchResult.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-import AdministrativeDirectiveSearchResult from "~/components/search/AdministrativeDirectiveSearchResult.vue";
-import CaselawSearchResult from "~/components/search/CaselawSearchResult.vue";
-import LiteratureSearchResult from "~/components/search/LiteratureSearchResult.vue";
-import NormSearchResult from "~/components/search/NormSearchResult.vue";
 import type {
   AdministrativeDirective,
   AnyDocument,
@@ -11,41 +7,35 @@ import type {
   Literature,
   SearchResult,
 } from "~/types/api";
-import {
-  isCaselaw,
-  isLegislation,
-  isLiterature,
-  isAdministrativeDirective,
-} from "~/utils/anyDocument";
 
-const props = defineProps<{
+defineProps<{
   searchResult: SearchResult<AnyDocument>;
   order: number;
 }>();
 </script>
 
 <template>
-  <CaselawSearchResult
-    v-if="isCaselaw(props.searchResult.item)"
-    :search-result="props.searchResult as SearchResult<CaseLaw>"
-    :order="props.order"
+  <SearchCaselawSearchResult
+    v-if="isCaselaw(searchResult.item)"
+    :search-result="searchResult as SearchResult<CaseLaw>"
+    :order="order"
   />
 
-  <NormSearchResult
-    v-else-if="isLegislation(props.searchResult.item)"
-    :search-result="props.searchResult as SearchResult<LegislationExpression>"
-    :order="props.order"
+  <SearchNormSearchResult
+    v-else-if="isLegislation(searchResult.item)"
+    :search-result="searchResult as SearchResult<LegislationExpression>"
+    :order="order"
   />
 
-  <LiteratureSearchResult
-    v-else-if="isLiterature(props.searchResult.item)"
-    :search-result="props.searchResult as SearchResult<Literature>"
-    :order="props.order"
+  <SearchLiteratureSearchResult
+    v-else-if="isLiterature(searchResult.item)"
+    :search-result="searchResult as SearchResult<Literature>"
+    :order="order"
   />
 
-  <AdministrativeDirectiveSearchResult
-    v-else-if="isAdministrativeDirective(props.searchResult.item)"
-    :search-result="props.searchResult as SearchResult<AdministrativeDirective>"
-    :order="props.order"
+  <SearchAdministrativeDirectiveSearchResult
+    v-else-if="isAdministrativeDirective(searchResult.item)"
+    :search-result="searchResult as SearchResult<AdministrativeDirective>"
+    :order="order"
   />
 </template>

--- a/frontend/src/utils/literature.ts
+++ b/frontend/src/utils/literature.ts
@@ -1,8 +1,6 @@
 import type { MetadataItem } from "~/components/Metadata.vue";
 import type { Literature } from "~/types/api";
 
-export const LITERATURE_TITLE_PLACEHOLDER = "Titelzeile nicht vorhanden";
-
 export function getTitle(literature?: Partial<Literature>) {
   return [
     literature?.headline,

--- a/frontend/src/utils/sanitize.ts
+++ b/frontend/src/utils/sanitize.ts
@@ -6,3 +6,8 @@ export function sanitizeSearchResult(
 ) {
   return sanitizeHtml(html, { allowedTags: allowedTags });
 }
+
+/** Strips all HTML tags from the given string, returning plain text. */
+export function stripAllHtml(html: string): string {
+  return sanitizeHtml(html, { allowedTags: [] });
+}

--- a/frontend/src/utils/search/searchResults.spec.ts
+++ b/frontend/src/utils/search/searchResults.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { TextMatch } from "~/types/api";
+import {
+  TITLE_FALLBACK,
+  getMatch,
+  getMatches,
+  getTitleWithFallback,
+} from "./searchResults";
+
+const matches: TextMatch[] = [
+  { name: "headline", text: "The <mark>Main</mark> Title" },
+  { name: "headline", text: "Second headline" },
+  { name: "grounds", text: "<b>Bold</b> grounds text" },
+  { name: "fileNumbers", text: "AZ <mark>123</mark>" },
+  { name: "fileNumbers", text: "AZ <mark>456</mark>" },
+];
+
+describe("searchResults", () => {
+  describe("getMatch", () => {
+    it("returns the sanitized text of the first match for a given name", () => {
+      expect(getMatch("headline", matches)).toBe("The <mark>Main</mark> Title");
+    });
+
+    it("sanitizes disallowed tags from the matched text", () => {
+      const m: TextMatch[] = [
+        { name: "field", text: "<div><mark>hit</mark></div>" },
+      ];
+      expect(getMatch("field", m)).toBe("<mark>hit</mark>");
+    });
+
+    it("returns undefined when no match is found", () => {
+      expect(getMatch("missing", matches)).toBeUndefined();
+    });
+
+    it("returns undefined for an empty matches array", () => {
+      expect(getMatch("headline", [])).toBeUndefined();
+    });
+  });
+
+  describe("getMatches", () => {
+    it("returns all sanitized texts for a given name", () => {
+      expect(getMatches("fileNumbers", matches)).toEqual([
+        "AZ <mark>123</mark>",
+        "AZ <mark>456</mark>",
+      ]);
+    });
+
+    it("returns only the sanitized texts for the requested name", () => {
+      expect(getMatches("headline", matches)).toEqual([
+        "The <mark>Main</mark> Title",
+        "Second headline",
+      ]);
+    });
+
+    it("sanitizes disallowed tags from each match", () => {
+      const m: TextMatch[] = [
+        { name: "field", text: "<img src='x'/><mark>hit</mark>" },
+        { name: "field", text: "<script>alert(1)</script>clean" },
+      ];
+      expect(getMatches("field", m)).toEqual(["<mark>hit</mark>", "clean"]);
+    });
+
+    it("returns an empty array when no matches are found", () => {
+      expect(getMatches("missing", matches)).toEqual([]);
+    });
+
+    it("returns an empty array for an empty matches array", () => {
+      expect(getMatches("headline", [])).toEqual([]);
+    });
+  });
+
+  describe("getTitleWithFallback", () => {
+    it("returns the first truthy candidate", () => {
+      expect(getTitleWithFallback("Plain title", "Other")).toBe("Plain title");
+    });
+
+    it("skips falsy candidates and returns the first truthy one", () => {
+      expect(getTitleWithFallback(undefined, null, "", "Fallback title")).toBe(
+        "Fallback title",
+      );
+    });
+
+    it("sanitizes disallowed tags from the resolved value", () => {
+      expect(
+        getTitleWithFallback("<div><mark>Highlighted</mark> title</div>"),
+      ).toBe("<mark>Highlighted</mark> title");
+    });
+
+    it("returns fallback when all candidates are falsy", () => {
+      expect(getTitleWithFallback(undefined, null, "")).toBe(TITLE_FALLBACK);
+    });
+
+    it("returns fallback when called with no arguments", () => {
+      expect(getTitleWithFallback()).toBe(TITLE_FALLBACK);
+    });
+  });
+});

--- a/frontend/src/utils/search/searchResults.ts
+++ b/frontend/src/utils/search/searchResults.ts
@@ -12,7 +12,7 @@ export function getMatch(
   textMatches: TextMatch[],
 ): string | undefined {
   const text = textMatches.find((m) => m.name === name)?.text;
-  return text !== undefined ? sanitizeSearchResult(text) : undefined;
+  return typeof text === "string" ? sanitizeSearchResult(text) : undefined;
 }
 
 /** Returns the sanitized texts of all TextMatches with the given name. */

--- a/frontend/src/utils/search/searchResults.ts
+++ b/frontend/src/utils/search/searchResults.ts
@@ -1,0 +1,34 @@
+import type { TextMatch } from "~/types/api";
+import { sanitizeSearchResult } from "~/utils/sanitize";
+
+export const TITLE_FALLBACK = "Titelzeile nicht vorhanden";
+
+/**
+ * Returns the sanitized text of the first TextMatch with the given name, or
+ * undefined if no match is found.
+ */
+export function getMatch(
+  name: string,
+  textMatches: TextMatch[],
+): string | undefined {
+  const text = textMatches.find((m) => m.name === name)?.text;
+  return text !== undefined ? sanitizeSearchResult(text) : undefined;
+}
+
+/** Returns the sanitized texts of all TextMatches with the given name. */
+export function getMatches(name: string, textMatches: TextMatch[]): string[] {
+  return textMatches
+    .filter((m) => m.name === name)
+    .map((m) => sanitizeSearchResult(m.text));
+}
+
+/**
+ * Returns the first truthy candidate, falling back to TITLE_FALLBACK. Sanitizes
+ * the chosen value.
+ */
+export function getTitleWithFallback(
+  ...candidates: (string | undefined | null)[]
+): string {
+  const value = candidates.find((c) => !!c) ?? TITLE_FALLBACK;
+  return sanitizeSearchResult(value);
+}


### PR DESCRIPTION
In preparation of RISDEV-10395, this PR tidies the search result teasers:

- extracted shared search result logic for matches and headings into a new module `utils/search/searchResults.ts`
- added a shorthand `stripAllHtml` sanitizer for when all HTML should be removed
- all props now use prop destructuring for more concise code
- removed unnecessary `props.` prefix from template code
- moved computed properties into a consistent, more logical order
- moved all sanitization into the setup script instead of mixing it between templates and script
- removed intermediary `metadata` computed objects, flattening them to simple computed properties
- switched to autoimports where possible
- reduced API surface by merging all reactive properties that were only referenced by other reactive properties
- removed `...as SomeType` casts in favor of typed mapping in some places; fixes some issues where the cast would mask that a value may be `undefined`