### PR TITLE
RISDEV-8269 Simplify DateInput component error logic

### DIFF
--- a/frontend/src/components/DateInput.spec.ts
+++ b/frontend/src/components/DateInput.spec.ts
@@ -3,7 +3,6 @@ import { render, screen } from "@testing-library/vue";
 import { InputText } from "primevue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
-import type { ValidationError } from "./DateInput.vue";
 import DateInput from "./DateInput.vue";
 
 beforeEach(() => {
@@ -20,7 +19,6 @@ afterEach(() => {
 
 function renderComponent(options?: {
   modelValue?: string;
-  validationError?: ValidationError;
   isReadOnly?: boolean;
   showClear?: boolean;
   stubs?: Record<string, object>;
@@ -29,7 +27,6 @@ function renderComponent(options?: {
   const props = {
     id: "identifier",
     modelValue: options?.modelValue,
-    validationError: options?.validationError,
     isReadOnly: options?.isReadOnly,
     showClear: options?.showClear,
   };
@@ -110,7 +107,7 @@ describe("DateInput", () => {
   });
 
   it("removes validation errors on backspace delete", async () => {
-    const { emitted } = renderComponent({
+    renderComponent({
       modelValue: "2022-05-13",
       stubs: {
         InputMask: InputText,
@@ -121,9 +118,11 @@ describe("DateInput", () => {
     await userEvent.clear(input);
     await userEvent.type(input, "40.05.2022");
     expect(input).toHaveValue("40.05.2022");
+    const errorLabel = screen.getByText("Kein valides Datum");
+    expect(errorLabel).toBeVisible();
     await userEvent.type(input, "{backspace}");
 
-    expect(emitted("update:validationError")).toBeTruthy();
+    expect(errorLabel).not.toBeInTheDocument();
   });
 
   it("does not allow invalid dates", async () => {
@@ -137,16 +136,8 @@ describe("DateInput", () => {
     await nextTick();
 
     expect(input).toHaveValue("29.02.2001");
-
     expect(emitted("update:modelValue")).not.toBeTruthy();
-
-    expect(emitted("update:validationError")).toBeTruthy();
-
-    const array: ValidationError[][] = emitted("update:validationError");
-
-    expect(
-      array.find((element) => element[0] !== undefined)?.[0]?.message,
-    ).toBe("Kein valides Datum");
+    expect(screen.getByText("Kein valides Datum")).toBeVisible();
   });
 
   it("does not allow letters", async () => {
@@ -168,15 +159,7 @@ describe("DateInput", () => {
     await nextTick();
 
     expect(emitted("update:modelValue")).not.toBeTruthy();
-    const validationErrors = emitted()[
-      "update:validationError"
-    ] as ValidationError[][];
-
-    expect(
-      validationErrors
-        .filter((element) => element[0] !== undefined)
-        .some((element) => element[0]?.message === "Unvollständiges Datum"),
-    ).toBe(true);
+    expect(screen.getByText("Unvollständiges Datum")).toBeVisible();
   });
 
   it("sets the input to readonly", () => {
@@ -187,33 +170,6 @@ describe("DateInput", () => {
   it("sets the input to editable", () => {
     renderComponent({ isReadOnly: false });
     expect(screen.getByRole("textbox")).not.toHaveAttribute("readonly");
-  });
-
-  it("shows error message block for external validation errors", async () => {
-    const validationError = {
-      message: "Externer Fehler",
-      instance: "identifier",
-    };
-    renderComponent({ validationError });
-
-    const errorBlock = screen.getByText("Externer Fehler");
-    expect(errorBlock).toBeInTheDocument();
-  });
-
-  it("shows error message block for internal validation errors", async () => {
-    renderComponent({
-      stubs: {
-        InputMask: InputText,
-      },
-    });
-
-    const input = screen.getByRole("textbox");
-    await userEvent.type(input, "29.02.2001");
-    await nextTick();
-
-    expect(input).toHaveValue("29.02.2001");
-
-    expect(screen.getByText("Ungültige Eingabe")).toBeInTheDocument();
   });
 
   describe("clear button", () => {
@@ -250,6 +206,24 @@ describe("DateInput", () => {
 
       expect(screen.getByRole("textbox")).toHaveValue("");
       expect(emitted("update:modelValue")).toContainEqual([undefined]);
+    });
+
+    it("resets the error message when clicked", async () => {
+      renderComponent({
+        showClear: true,
+        stubs: { InputMask: InputText },
+      });
+
+      const input = screen.getByRole("textbox");
+      await userEvent.type(input, "29.02.2025");
+
+      const errorLabel = screen.getByText("Kein valides Datum");
+      expect(errorLabel).toBeVisible();
+
+      await userEvent.click(screen.getByRole("button", { name: "Entfernen" }));
+      await nextTick();
+
+      expect(errorLabel).not.toBeVisible();
     });
   });
 });

--- a/frontend/src/components/DateInput.vue
+++ b/frontend/src/components/DateInput.vue
@@ -126,7 +126,7 @@ defineExpose({ focus });
         ref="inputMaskEl"
         v-model="inputValue"
         :auto-clear="false"
-        :invalid="errorMessage != undefined"
+        :invalid="errorMessage !== undefined"
         :readonly="isReadOnly"
         :disabled="isReadOnly"
         class="w-full"

--- a/frontend/src/components/DateInput.vue
+++ b/frontend/src/components/DateInput.vue
@@ -6,18 +6,6 @@ import { computed, nextTick, ref, useTemplateRef, watch } from "vue";
 import IconErrorOutline from "~icons/ic/baseline-error-outline";
 import WithClearButton from "./WithClearButton.vue";
 
-/** Form field validation error. */
-export type ValidationError = {
-  /** Error code (intended for differentiating types in code). */
-  code?: string;
-
-  /** Error message (intended for displaying to the user). */
-  message: string;
-
-  /** Identifier that can be used for connecting the error with a UI control. */
-  instance: string;
-};
-
 const props = withDefaults(
   defineProps<{
     /** HTML element ID of the form field. */
@@ -35,9 +23,6 @@ const props = withDefaults(
     /** Label of the form field. */
     label?: string;
 
-    /** Validation error and message to display. */
-    validationError?: ValidationError;
-
     /** Whether to show a clear button. */
     showClear?: boolean;
   }>(),
@@ -46,7 +31,6 @@ const props = withDefaults(
     size: "small",
     isReadOnly: false,
     label: undefined,
-    validationError: undefined,
     showClear: false,
   },
 );
@@ -58,12 +42,6 @@ const emit = defineEmits<{
    * (e.g. partial dates while typing) are handled internally and not emitted.
    */
   "update:modelValue": [value?: string];
-
-  /**
-   * Emitted when the form field enters an invalid state based on user inputs
-   * (e.g. the date is invalid).
-   */
-  "update:validationError": [value?: ValidationError];
 }>();
 
 const HUMAN_READABLE_FORMAT = "DD.MM.YYYY";
@@ -87,12 +65,17 @@ watch(
 );
 
 watch(inputValue, (is) => {
-  if (is === "") emit("update:modelValue", undefined);
-  else if (isValidDate.value) {
+  errorMessage.value = undefined;
+
+  if (is === "") {
+    emit("update:modelValue", undefined);
+  } else if (dayjs(is, HUMAN_READABLE_FORMAT, true).isValid()) {
     emit(
       "update:modelValue",
       dayjs(is, HUMAN_READABLE_FORMAT, true).format(MACHINE_FORMAT),
     );
+  } else if (inputCompleted.value) {
+    errorMessage.value = "Kein valides Datum";
   }
 });
 
@@ -101,71 +84,14 @@ const inputCompleted = computed(() => {
   return datePattern.test(inputValue.value || "");
 });
 
-const localValidationError = ref<ValidationError | undefined>(undefined);
-
-const internalHasError = computed(() => {
-  return inputCompleted.value && !isValidDate.value;
-});
-
-const effectiveHasError = computed(() => {
-  return internalHasError.value || !!localValidationError.value;
-});
-
-watch(
-  () => props.validationError,
-  (newVal) => {
-    localValidationError.value = newVal;
-  },
-  { immediate: true },
-);
-
-const errorMessage = computed(() => {
-  if (internalHasError.value && !localValidationError.value) {
-    return "Ungültige Eingabe";
-  } else if (localValidationError.value) {
-    return localValidationError.value.message ?? "Ungültige Eingabe";
-  } else return undefined;
-});
-
-const isValidDate = computed(() => {
-  return dayjs(inputValue.value, HUMAN_READABLE_FORMAT, true).isValid();
-});
-
+const errorMessage = ref<string | undefined>(undefined);
 const key = ref<string>();
 
-function validateInput() {
-  if (inputCompleted.value) {
-    if (isValidDate.value) {
-      emit("update:validationError", undefined);
-    } else {
-      const validationError = {
-        message: "Kein valides Datum",
-        instance: props.id,
-      };
-      emit("update:validationError", validationError);
-    }
-  } else if (inputValue.value) {
-    const validationError = {
-      message: "Unvollständiges Datum",
-      instance: props.id,
-    };
-    emit("update:validationError", validationError);
-  } else {
-    emit("update:validationError", undefined);
+function onBlur() {
+  if (!inputCompleted.value && inputValue.value) {
+    errorMessage.value = "Unvollständiges Datum";
   }
 }
-
-function backspaceDelete() {
-  emit("update:validationError", undefined);
-}
-
-function onBlur() {
-  validateInput();
-}
-
-watch(inputCompleted, (is) => {
-  if (is) validateInput();
-});
 
 const inputMaskEl = useTemplateRef("inputMaskEl");
 
@@ -176,6 +102,7 @@ function focus() {
 
 async function clear() {
   inputValue.value = "";
+  errorMessage.value = undefined;
   // Setting v-model to "" alone is apparently not enough to reset InputMask's internal
   // buffer. Changing :key forces Vue to fully unmount and remount the component,
   // which makes sure the input is actually cleared when the user starts typing again.
@@ -199,7 +126,7 @@ defineExpose({ focus });
         ref="inputMaskEl"
         v-model="inputValue"
         :auto-clear="false"
-        :invalid="effectiveHasError"
+        :invalid="errorMessage != undefined"
         :readonly="isReadOnly"
         :disabled="isReadOnly"
         class="w-full"
@@ -207,7 +134,6 @@ defineExpose({ focus });
         mask="99.99.9999"
         placeholder="TT.MM.JJJJ"
         @blur="onBlur"
-        @keydown="backspaceDelete"
       />
     </WithClearButton>
 

--- a/frontend/src/components/search/DateRangeFilter.vue
+++ b/frontend/src/components/search/DateRangeFilter.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { Select } from "primevue";
-import type { ValidationError } from "~/components/DateInput.vue";
 import type {
   DateFilterValue,
   FilterType,
@@ -12,9 +11,6 @@ const filter = defineModel<DateFilterValue>({ required: true });
 const dateModeLabelId = useId();
 const fromDateId = useId();
 const toDateId = useId();
-
-const fromValidationError = ref<ValidationError | undefined>();
-const toValidationError = ref<ValidationError | undefined>();
 
 const items: { label: string; value: FilterType }[] = [
   { label: "Keine zeitliche Begrenzung", value: "allTime" },
@@ -96,12 +92,7 @@ const toDate = computed({
         <template v-if="hasMultipleInputs">Ab dem Datum</template>
         <template v-else>Datum</template>
       </label>
-      <DateInput
-        :id="fromDateId"
-        :key
-        v-model="fromDate"
-        v-model:validation-error="fromValidationError"
-      />
+      <DateInput :id="fromDateId" :key v-model="fromDate" />
     </div>
 
     <div v-if="showToField" class="flex flex-col gap-8">
@@ -109,12 +100,7 @@ const toDate = computed({
         <template v-if="hasMultipleInputs">Bis zum Datum</template>
         <template v-else>Datum</template>
       </label>
-      <DateInput
-        :id="toDateId"
-        :key
-        v-model="toDate"
-        v-model:validation-error="toValidationError"
-      />
+      <DateInput :id="toDateId" :key v-model="toDate" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
- remove validation error model as it was not used anywhere to set the error from outside the component and made the whole logic more complex
- this resolves a bug where typing after entering an invalid date changed the error message from "Kein valides Datum" to "Ungültige Eingabe"

RISDEV-8269