### PR TITLE
RISDEV-10395 teaser snippet only appear in search when results exist

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/AdministrativeDirectiveSearchSchemaMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/AdministrativeDirectiveSearchSchemaMapper.java
@@ -100,6 +100,7 @@ public class AdministrativeDirectiveSearchSchemaMapper {
         .documentNumber(doc.documentNumber())
         .headline(doc.headline())
         .shortReport(doc.shortReport())
+        .outline(doc.tableOfContentsEntries())
         .entryIntoForceDate(doc.entryIntoEffectDate())
         .referenceNumbers(doc.referenceNumbers())
         .legislationAuthority(doc.legislationAuthority())

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/AdministrativeDirectiveSearchSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/AdministrativeDirectiveSearchSchema.java
@@ -38,6 +38,7 @@ public record AdministrativeDirectiveSearchSchema(
         String documentNumber,
     @Nullable @Schema(description = "Haupttitel") String headline,
     @Nullable @Schema(description = "Kurzreferat") String shortReport,
+    @Nullable @Schema(description = "Gliederung") List<String> outline,
     @Schema(
             description = "Dokumenttyp",
             example = "VV",

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/AdministrativeDirectiveSimpleSearchType.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/AdministrativeDirectiveSimpleSearchType.java
@@ -20,7 +20,7 @@ public class AdministrativeDirectiveSimpleSearchType implements SimpleSearchType
 
   @Override
   public List<String> getExcludedFields() {
-    return List.of();
+    return List.of(AdministrativeDirective.Fields.OUTLINE);
   }
 
   @Override
@@ -31,7 +31,8 @@ public class AdministrativeDirectiveSimpleSearchType implements SimpleSearchType
   public static List<HighlightBuilder.Field> getHighlightedFieldsStatic() {
     return List.of(
         new HighlightBuilder.Field(AdministrativeDirective.Fields.HEADLINE).numOfFragments(0),
-        new HighlightBuilder.Field(AdministrativeDirective.Fields.SHORT_REPORT));
+        new HighlightBuilder.Field(AdministrativeDirective.Fields.SHORT_REPORT),
+        new HighlightBuilder.Field(AdministrativeDirective.Fields.OUTLINE));
   }
 
   /**

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/AdministrativeDirectiveSearchSchemaMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/AdministrativeDirectiveSearchSchemaMapperTest.java
@@ -28,6 +28,7 @@ class AdministrativeDirectiveSearchSchemaMapperTest {
             .referenceNumbers(List.of("RNR"))
             .legislationAuthority("legislationAuthority")
             .entryIntoEffectDate(LocalDate.of(2024, Month.JANUARY, 1))
+            .tableOfContentsEntries(List.of("outline entry"))
             .build();
 
     AdministrativeDirectiveSearchSchema expected =
@@ -36,6 +37,7 @@ class AdministrativeDirectiveSearchSchemaMapperTest {
             .documentNumber("KN0000")
             .headline("headline")
             .shortReport("shortReport")
+            .outline(List.of("outline entry"))
             .documentType("VV")
             .referenceNumbers(List.of("RNR"))
             .legislationAuthority("legislationAuthority")

--- a/frontend/e2e/advancedSearch.spec.ts
+++ b/frontend/e2e/advancedSearch.spec.ts
@@ -673,7 +673,7 @@ test.describe("searching literature", () => {
     await navigate(page, "/advanced-search");
 
     await searchFor(page, {
-      q: 'main_title:"Erstes Test-Dokument ULI"',
+      q: 'main_title:"Erstes Test-Dokument ULI" "einfaches Test-Dokument"',
       documentKind: "Literaturnachweise",
     });
 
@@ -683,9 +683,6 @@ test.describe("searching literature", () => {
     await expect(searchResult).toHaveText(/FooBar, 1982, 123-123/);
     await expect(searchResult).toHaveText(/2024/);
     await expect(searchResult).toHaveText(/Erstes Test-Dokument ULI/);
-    await expect(searchResult).toHaveText(
-      /Dies ist ein einfaches Test-Dokument./,
-    );
 
     // Result detail link
     await expect(
@@ -693,7 +690,12 @@ test.describe("searching literature", () => {
     ).toBeVisible();
 
     // Highlights
-    // TODO: Highlights?
+    await expect(
+      searchResult.getByRole("link", { name: "Kurzreferat:" }),
+    ).toBeVisible();
+    await expect(
+      searchResult.getByText(/einfaches Test-Dokument/),
+    ).toBeVisible();
   });
 
   test("navigates to the document detail page", async ({ page }) => {
@@ -801,6 +803,9 @@ test.describe("searching administrative directive", () => {
     ).toHaveText(/Beschluss über den Beschluss/);
 
     // Text preview (only checking the first two sentences)
+    await expect(
+      searchResult.getByRole("link", { name: "Kurzreferat:" }),
+    ).toBeVisible();
     await expect(searchResult).toHaveText(
       /Beschlossen wurde, das Beschlüsse beschlossen werden müssen. /,
     );

--- a/frontend/e2e/simpleSearch.spec.ts
+++ b/frontend/e2e/simpleSearch.spec.ts
@@ -746,7 +746,10 @@ test.describe("searching literature", () => {
   });
 
   test("shows the search result contents", async ({ page }) => {
-    await navigate(page, "/search?query=FooBar,+1982,+123-123&documentKind=L");
+    await navigate(
+      page,
+      "/search?query=FooBar,+1982,+123-123+einfaches+Test-Dokument&documentKind=L",
+    );
 
     const searchResult = getSearchResults(page).first();
 
@@ -761,15 +764,6 @@ test.describe("searching literature", () => {
         name: "Erstes Test-Dokument ULI",
       }),
     ).toBeVisible();
-  });
-
-  test("shows highlighted short report in search results", async ({ page }) => {
-    await navigate(
-      page,
-      "/search?query=einfaches+Test-Dokument&documentKind=L",
-    );
-
-    const searchResult = getSearchResults(page).first();
 
     // Highlights
     await expect(

--- a/frontend/e2e/simpleSearch.spec.ts
+++ b/frontend/e2e/simpleSearch.spec.ts
@@ -761,8 +761,20 @@ test.describe("searching literature", () => {
         name: "Erstes Test-Dokument ULI",
       }),
     ).toBeVisible();
+  });
+
+  test("shows highlighted short report in search results", async ({ page }) => {
+    await navigate(
+      page,
+      "/search?query=einfaches+Test-Dokument&documentKind=L",
+    );
+
+    const searchResult = getSearchResults(page).first();
 
     // Highlights
+    await expect(
+      searchResult.getByRole("link", { name: "Kurzreferat:" }),
+    ).toBeVisible();
     await expect(
       searchResult.getByText(/Dies ist ein einfaches Test-Dokument./),
     ).toBeVisible();
@@ -926,10 +938,9 @@ test.describe("searching administrative directives", () => {
 
     // Highlights
     await expect(
-      searchResult.getByText(
-        /… Beschlossen wurde, das Beschlüsse beschlossen werden müssen./,
-      ),
+      searchResult.getByRole("link", { name: "Kurzreferat:" }),
     ).toBeVisible();
+    await expect(searchResult.getByText(/Beschlossen wurde/)).toBeVisible();
   });
 
   test("shows placeholder headline for search result items without headline", async ({

--- a/frontend/src/components/search/AdministrativeDirectiveSearchResult.spec.ts
+++ b/frontend/src/components/search/AdministrativeDirectiveSearchResult.spec.ts
@@ -16,20 +16,7 @@ const searchResult: SearchResult<AdministrativeDirective> = {
     referenceNumbers: ["Foo - 123", "Bar - 123"],
     entryIntoForceDate: "2025-07-01",
   } as AdministrativeDirective,
-  textMatches: [
-    {
-      "@type": "SearchResultMatch",
-      name: "shortReport",
-      text: "Inhalt eines Kurzreferats.",
-      location: undefined,
-    },
-    {
-      "@type": "SearchResultMatch",
-      name: "headline",
-      text: "Verwaltungsvorschrift Überschrift",
-      location: undefined,
-    },
-  ],
+  textMatches: [],
 };
 
 async function renderComponent({
@@ -138,82 +125,56 @@ describe("AdministrativeDirectiveSearchResult", () => {
     });
   });
 
-  describe("shortReport", () => {
-    it("renders shortReport match without ellipses", async () => {
-      await renderComponent();
-      expect(screen.getByText("Inhalt eines Kurzreferats.")).toBeVisible();
-    });
-
-    it("renders shortReport match with ellipses at start", async () => {
+  describe("preview sections", () => {
+    it("renders matches", async () => {
       await renderComponent({
-        item: {
-          ...searchResult.item,
-          shortReport: "Dies ist der lange Inhalt eines Kurzreferats.",
-        },
-      });
-      expect(screen.getByText("… Inhalt eines Kurzreferats.")).toBeVisible();
-    });
-
-    it("renders shortReport match with ellipses at end", async () => {
-      await renderComponent({
-        item: {
-          ...searchResult.item,
-          shortReport: "Inhalt eines Kurzreferats. Weitere Inhalt.",
-        },
-      });
-      expect(screen.getByText("Inhalt eines Kurzreferats. …")).toBeVisible();
-    });
-
-    it("renders shortReport match with ellipses at start and end", async () => {
-      await renderComponent({
-        item: {
-          ...searchResult.item,
-          shortReport:
-            "Dies ist der lange Inhalt eines Kurzreferats. Weitere Inhalt.",
-        },
-      });
-      expect(screen.getByText("… Inhalt eines Kurzreferats. …")).toBeVisible();
-    });
-
-    it("renders shortReport match with markup", async () => {
-      await renderComponent({
-        item: {
-          ...searchResult.item,
-          shortReport: "Inhalt eines Kurzreferats. Weiterer Inhalt.",
-        },
         textMatches: [
           {
             "@type": "SearchResultMatch",
             name: "shortReport",
-            text: "<b>Inhalt</b> <i>eines</i> <mark>Kurzreferats.</mark> <a>Weiterer Inhalt.</a>",
+            text: "testing <mark>highlighted Text</mark> is here",
+            location: undefined,
+          },
+          {
+            "@type": "SearchResultMatch",
+            name: "tableOfContentsEntries",
+            text: "<mark>I. Einführung</mark>",
             location: undefined,
           },
         ],
       });
-      expect(screen.getByText("Inhalt").tagName).toBe("B");
-      expect(screen.getByText("eines").tagName).toBe("I");
-      expect(screen.getByText("Kurzreferats.").tagName).toBe("MARK");
-      // Does not render other tags
-      expect(screen.getByText("Weiterer Inhalt.").tagName).not.toBe("A");
+
+      expect(
+        screen.getByRole("link", { name: "Kurzreferat:" }),
+      ).toBeInTheDocument();
+      const linkMark = screen.getByText("highlighted Text");
+      expect(linkMark.tagName).toBe("MARK");
+
+      expect(screen.getByRole("link", { name: "Inhalt:" })).toBeInTheDocument();
+      const shortReportMark = screen.getByText("I. Einführung");
+      expect(shortReportMark.tagName).toBe("MARK");
     });
 
-    it("renders shortReport match with markup and ellipses", async () => {
+    it("filters HTML tags except mark, i, b", async () => {
+      const text =
+        '<mark>mark</mark> <i>i</i> <b>b</b> <img src="" alt="do not show"> <div>div</div> plain_text.';
+      const expectedSanitized =
+        "<mark>mark</mark> <i>i</i> <b>b</b>  div plain_text.";
+
       await renderComponent({
-        item: {
-          ...searchResult.item,
-          shortReport: "Inhalt eines Kurzreferats. Weiterer Inhalt.",
-        },
         textMatches: [
           {
             "@type": "SearchResultMatch",
             name: "shortReport",
-            text: "<mark>Inhalt</mark> eines Kurzreferats.",
+            text,
             location: undefined,
           },
         ],
       });
-      expect(screen.getByText("Inhalt").tagName).toBe("MARK");
-      expect(screen.getByText("eines Kurzreferats. …")).toBeVisible();
+
+      const items = screen.getAllByTestId("highlighted-field");
+      expect(items).toHaveLength(1);
+      expect(items[0]?.innerHTML).toBe(expectedSanitized);
     });
   });
 });

--- a/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
+++ b/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import RuleIcon from "~icons/ic/outline-rule";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
-import { usePostHog } from "~/composables/usePostHog";
 import type { AdministrativeDirective, SearchResult } from "~/types/api";
 import { getMatch, getTitleWithFallback } from "~/utils/search/searchResults";
 
@@ -13,6 +12,11 @@ const { searchResult, order } = defineProps<{
 const { searchResultClicked } = usePostHog();
 
 const router = useRouter();
+
+const fields = new Map([
+  ["tableOfContentsEntries", { id: "inhalt", title: "Inhalt" }],
+  ["shortReport", { id: "kurzreferat", title: "Kurzreferat" }],
+]);
 
 const headline = computed(() =>
   getTitleWithFallback(
@@ -40,21 +44,10 @@ const detailPageRoute = computed(() => ({
   },
 }));
 
-const text = computed(() => {
-  const shortReportMatch = getMatch("shortReport", searchResult.textMatches);
-  if (!shortReportMatch) return undefined;
-
-  const plainShortReportMatch = stripAllHtml(shortReportMatch);
-  const fullShortReport = searchResult.item.shortReport;
-  const sanitizedShortReport = sanitizeSearchResult(shortReportMatch);
-
-  if (plainShortReportMatch === fullShortReport) return sanitizedShortReport;
-
-  const prefix = fullShortReport?.startsWith(plainShortReportMatch) ? "" : "… ";
-  const postfix = fullShortReport?.endsWith(plainShortReportMatch) ? "" : " …";
-
-  return `${prefix}${sanitizedShortReport}${postfix}`;
-});
+const previewSections = useSearchResultSections(
+  () => searchResult.textMatches,
+  fields,
+);
 
 function trackResultClick() {
   const url = router.resolve(detailPageRoute.value).href;
@@ -76,8 +69,22 @@ function trackResultClick() {
       </h2>
     </NuxtLink>
 
-    <div v-if="text" class="flex w-full flex-col gap-6">
-      <span data-testid="highlighted-field" v-html="text"> </span>
+    <div class="flex w-full flex-col gap-6">
+      <div v-for="section in previewSections" :key="section.id">
+        <NuxtLink
+          :to="{ ...detailPageRoute, hash: `#${section.id}` }"
+          class="ris-link1-bold link-hover"
+          external
+          @click="trackResultClick()"
+          >{{ section.title }}:</NuxtLink
+        >{{ " " }}
+        <span
+          v-if="section.text"
+          data-testid="highlighted-field"
+          class="ris-label1-regular"
+          v-html="section.text"
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/frontend/src/components/search/CaseLawSearchResult.spec.ts
+++ b/frontend/src/components/search/CaseLawSearchResult.spec.ts
@@ -198,18 +198,18 @@ describe("CaselawSearchResult", () => {
     });
   });
 
-  it("displays the first field in order only when there are no highlights if there are multiple fields", () => {
+  it("sorts fields by field map order", () => {
     const textMatches: TextMatch[] = [
       {
         "@type": "SearchResultMatch",
-        name: "guidingPrinciple",
-        text: "Leitsatz.",
+        name: "caseFacts",
+        text: "<mark>Tatbestand</mark>.",
         location: undefined,
       },
       {
         "@type": "SearchResultMatch",
-        name: "caseFacts",
-        text: "Tatbestand.",
+        name: "guidingPrinciple",
+        text: "<mark>Leitsatz</mark>.",
         location: undefined,
       },
     ];
@@ -217,8 +217,9 @@ describe("CaselawSearchResult", () => {
     renderComponent({ textMatches });
 
     const contentItems = screen.getAllByTestId("highlighted-field");
-    expect(contentItems).toHaveLength(1);
+    expect(contentItems).toHaveLength(2);
     expect(contentItems[0]).toHaveTextContent("Leitsatz.");
+    expect(contentItems[1]).toHaveTextContent("Tatbestand.");
   });
 
   it("displays guiding principle first, if available, then up to 3 other matching items", () => {
@@ -288,38 +289,48 @@ describe("CaselawSearchResult", () => {
     expect(contentItems).toHaveLength(0);
   });
 
-  it("shows only the first text match if none contain marks", () => {
-    const searchResultWithoutHighlights = {
-      item: searchResult.item,
-      textMatches: [
-        {
-          "@type": "SearchResultMatch",
-          name: "guidingPrinciple",
-          text: "Guiding Principle.",
-          location: undefined,
-        },
-        {
-          "@type": "SearchResultMatch",
-          name: "headnote",
-          text: "This should not even be shown.",
-          location: undefined,
-        },
-      ] as TextMatch[],
-    };
-
-    renderComponent(searchResultWithoutHighlights);
-
-    const contentItems = screen.getAllByTestId("highlighted-field");
-    expect(contentItems).toHaveLength(1);
-    expect(contentItems[0]).toHaveTextContent("Guiding Principle.");
-  });
-
-  it("returns the first field from caselaw fields and up to three highlighted fields if highlights are present", () => {
+  it("shows all returned text matches", () => {
     const textMatches: TextMatch[] = [
       {
         "@type": "SearchResultMatch",
         name: "guidingPrinciple",
-        text: "Guiding Principle.",
+        text: "<mark>Guiding Principle</mark>.",
+        location: undefined,
+      },
+      {
+        "@type": "SearchResultMatch",
+        name: "headnote",
+        text: "<mark>Headnote</mark>.",
+        location: undefined,
+      },
+    ] as TextMatch[];
+
+    renderComponent({ textMatches });
+
+    const contentItems = screen.getAllByTestId("highlighted-field");
+    expect(contentItems).toHaveLength(2);
+    expect(contentItems[0]).toHaveTextContent("Guiding Principle.");
+    expect(contentItems[1]).toHaveTextContent("Headnote.");
+  });
+
+  it("shows up to 4 fields sorted by field map order", () => {
+    const textMatches: TextMatch[] = [
+      {
+        "@type": "SearchResultMatch",
+        name: "grounds",
+        text: "<mark>Grounds</mark>.",
+        location: undefined,
+      },
+      {
+        "@type": "SearchResultMatch",
+        name: "headnote",
+        text: "<mark>Headnote</mark>.",
+        location: undefined,
+      },
+      {
+        "@type": "SearchResultMatch",
+        name: "guidingPrinciple",
+        text: "<mark>Guiding Principle</mark>.",
         location: undefined,
       },
       {
@@ -334,12 +345,6 @@ describe("CaselawSearchResult", () => {
         text: "<mark>Tenor</mark>.",
         location: undefined,
       },
-      {
-        "@type": "SearchResultMatch",
-        name: "grounds",
-        text: "<mark>Grounds</mark>.",
-        location: undefined,
-      },
     ];
 
     renderComponent({ textMatches });
@@ -347,9 +352,9 @@ describe("CaselawSearchResult", () => {
     const contentItems = screen.getAllByTestId("highlighted-field");
 
     expect(contentItems).toHaveLength(4);
-    expect(contentItems[0]?.innerHTML).toBe("Guiding Principle.");
-    expect(contentItems[1]?.innerHTML).toBe(textMatches[1]?.text);
-    expect(contentItems[2]?.innerHTML).toBe(textMatches[2]?.text);
-    expect(contentItems[3]?.innerHTML).toBe(textMatches[3]?.text);
+    expect(contentItems[0]).toHaveTextContent("Guiding Principle.");
+    expect(contentItems[1]).toHaveTextContent("Headnote.");
+    expect(contentItems[2]).toHaveTextContent("Other Headnote.");
+    expect(contentItems[3]).toHaveTextContent("Tenor.");
   });
 });

--- a/frontend/src/components/search/CaselawSearchResult.vue
+++ b/frontend/src/components/search/CaselawSearchResult.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { partition } from "lodash-es";
 import GavelIcon from "~icons/ic/outline-gavel";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
 import type { CaseLaw, SearchResult, TextMatch } from "~/types/api";
@@ -107,41 +106,18 @@ const detailPageRoute = computed(() => ({
 }));
 
 const previewSections = computed<ExtendedTextMatch[]>(() => {
-  const textMatches = searchResult.textMatches;
-  const foundFields = new Set<Key>();
-
-  const relevantMatches = textMatches
+  const keys = [...fields.keys()];
+  return searchResult.textMatches
     .filter((match) => fields.has(match.name as Key))
-    .map<ExtendedTextMatch>((match) => {
-      foundFields.add(match.name as Key);
-      return {
-        ...match,
-        text: sanitizeSearchResult(addEllipsis(match.text) ?? ""),
-        ...fields.get(match.name as Key)!, // always defined since we filtered above
-      };
-    });
-
-  // always show the most relevant field, regardless of highlight status
-  const firstFieldName = [...fields.keys()].find((key) => foundFields.has(key));
-  const [firstFields, otherFields] = partition(
-    relevantMatches,
-    (match) => match.name === firstFieldName,
-  );
-
-  // show up to 4 fields
-  const slice: ExtendedTextMatch[] = [...firstFields, ...otherFields]
-    .slice(0, 4)
-    .filter((i) => !!i);
-
-  if (slice.length === 0) return [];
-
-  const highlighted = slice.some((field) => field.text.includes("<mark>"));
-
-  // if no fields have a highlight, show only the first one casting because
-  // TypeScript doesn't realize we already ensured it's not undefined
-  if (!highlighted) return [slice[0] as ExtendedTextMatch];
-
-  return slice;
+    .toSorted(
+      (a, b) => keys.indexOf(a.name as Key) - keys.indexOf(b.name as Key),
+    )
+    .map<ExtendedTextMatch>((match) => ({
+      ...match,
+      text: sanitizeSearchResult(addEllipsis(match.text) ?? ""),
+      ...fields.get(match.name as Key)!, // always defined since we filtered above
+    }))
+    .slice(0, 4);
 });
 
 function trackResultClick() {

--- a/frontend/src/components/search/CaselawSearchResult.vue
+++ b/frontend/src/components/search/CaselawSearchResult.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import GavelIcon from "~icons/ic/outline-gavel";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
-import type { CaseLaw, SearchResult, TextMatch } from "~/types/api";
+import type { CaseLaw, SearchResult } from "~/types/api";
 import {
   getMatch,
   getMatches,
@@ -17,23 +17,7 @@ const { searchResultClicked } = usePostHog();
 
 const router = useRouter();
 
-type Key =
-  | "guidingPrinciple"
-  | "headnote"
-  | "otherHeadnote"
-  | "tenor"
-  | "grounds"
-  | "caseFacts"
-  | "decisionGrounds";
-
-interface FieldDisplayProperties {
-  id: string;
-  title: string;
-}
-
-type ExtendedTextMatch = TextMatch & FieldDisplayProperties;
-
-const fields: Map<Key, FieldDisplayProperties> = new Map([
+const fields = new Map([
   ["guidingPrinciple", { id: "leitsatz", title: "Leitsatz" }],
   ["headnote", { id: "orientierungssatz", title: "Orientierungssatz" }],
   [
@@ -105,20 +89,11 @@ const detailPageRoute = computed(() => ({
   params: { documentNumber: searchResult.item.documentNumber },
 }));
 
-const previewSections = computed<ExtendedTextMatch[]>(() => {
-  const keys = [...fields.keys()];
-  return searchResult.textMatches
-    .filter((match) => fields.has(match.name as Key))
-    .toSorted(
-      (a, b) => keys.indexOf(a.name as Key) - keys.indexOf(b.name as Key),
-    )
-    .map<ExtendedTextMatch>((match) => ({
-      ...match,
-      text: sanitizeSearchResult(addEllipsis(match.text) ?? ""),
-      ...fields.get(match.name as Key)!, // always defined since we filtered above
-    }))
-    .slice(0, 4);
-});
+const previewSections = useSearchResultSections(
+  () => searchResult.textMatches,
+  fields,
+  4,
+);
 
 function trackResultClick() {
   const url = router.resolve(detailPageRoute.value).href;

--- a/frontend/src/components/search/LiteratureSearchResult.spec.ts
+++ b/frontend/src/components/search/LiteratureSearchResult.spec.ts
@@ -67,184 +67,6 @@ function renderComponent({
 }
 
 describe("LiteratureSearchResult", () => {
-  it("renders the expected title", async () => {
-    renderComponent({});
-    expect(
-      screen.getByText(
-        "Eine Untersuchung der juristischen Methoden im 21. Jahrhundert",
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it("has accessible description linking to result type", async () => {
-    renderComponent({});
-    expect(
-      screen.getByRole("link", {
-        name: "Eine Untersuchung der juristischen Methoden im 21. Jahrhundert",
-        description: "Book",
-      }),
-    ).toBeInTheDocument();
-  });
-
-  it("renders placeholder title if title is missing", async () => {
-    const searchResultWithoutTitle = {
-      item: {
-        ...searchResult.item,
-        headline: undefined,
-        alternativeHeadline: undefined,
-      },
-      textMatches: [],
-    };
-    renderComponent(searchResultWithoutTitle);
-    expect(screen.getByText("Titelzeile nicht vorhanden")).toBeInTheDocument();
-  });
-
-  it("displays highlighted headline when mainTitle", async () => {
-    const textMatch: TextMatch = {
-      "@type": "SearchResultMatch",
-      name: "mainTitle",
-      text: `testing <mark>highlighted main title</mark> is here`,
-      location: undefined,
-    };
-
-    renderComponent({ textMatches: [textMatch] });
-
-    const mark = screen.getByText("highlighted main title");
-    expect(mark.tagName).toBe("MARK");
-  });
-
-  it("displays highlighted headline when documentary title has markup", async () => {
-    const textMatch: TextMatch = {
-      "@type": "SearchResultMatch",
-      name: "documentaryTitle",
-      text: `testing <mark>highlighted documentary title</mark> is here`,
-      location: undefined,
-    };
-
-    // Clone the item but set headline to undefined
-    const itemWithoutHeadline = { ...searchResult.item, headline: undefined };
-
-    renderComponent({ item: itemWithoutHeadline, textMatches: [textMatch] });
-
-    const mark = screen.getByText("highlighted documentary title");
-    expect(mark.tagName).toBe("MARK");
-  });
-
-  it("displays alternative title when headline is not present", async () => {
-    const itemWithoutHeadline = { ...searchResult.item, headline: "" };
-    renderComponent({ item: itemWithoutHeadline });
-    expect(
-      screen.getByText("Study of Legal Methodologies in the 21st Century"),
-    ).toBeInTheDocument();
-  });
-
-  it("displays highlighted text with correct class", async () => {
-    const textMatch: TextMatch = {
-      "@type": "SearchResultMatch",
-      name: "shortReport",
-      text: "testing <mark>highlighted Text</mark> is here",
-      location: undefined,
-    };
-
-    renderComponent({ textMatches: [textMatch] });
-
-    const mark = screen.getByText("highlighted Text");
-    expect(mark.tagName).toBe("MARK");
-  });
-
-  it("renders full shortReport when no match is present", async () => {
-    renderComponent({});
-    expect(
-      screen.getByText(/Dieses Werk analysiert die Entwicklung/),
-    ).toBeInTheDocument();
-  });
-
-  it("applies line-clamp-3 class only when no highlight exists", async () => {
-    // No highlight
-    const { rerender } = renderComponent({});
-    const span = screen.getByTestId("highlighted-field");
-    expect(span).toHaveClass("line-clamp-3");
-
-    // With highlight
-    const match: TextMatch = {
-      "@type": "SearchResultMatch",
-      name: "shortReport",
-      text: `<mark>Dieses</mark> Werk analysiert`,
-      location: undefined,
-    };
-    await rerender({
-      searchResult: { item: searchResult.item, textMatches: [match] },
-    });
-    expect(screen.getByTestId("highlighted-field")).not.toHaveClass(
-      "line-clamp-3",
-    );
-  });
-
-  it("highlights a word in the middle of shortReport", async () => {
-    const match: TextMatch = {
-      "@type": "SearchResultMatch",
-      name: "shortReport",
-      text: `… Rolle von <mark>Präzedenzfällen</mark> in modernen Gerichtsbarkeiten …`,
-      location: undefined,
-    };
-
-    renderComponent({ textMatches: [match] });
-
-    const mark = screen.getByText("Präzedenzfällen");
-    expect(mark).toBeInTheDocument();
-    expect(mark.tagName).toBe("MARK");
-  });
-
-  it("highlights a word at the end of shortReport", async () => {
-    const match: TextMatch = {
-      "@type": "SearchResultMatch",
-      name: "shortReport",
-      text: `… automatisierter <mark>Entscheidungsfindung</mark>`,
-      location: undefined,
-    };
-
-    renderComponent({ textMatches: [match] });
-
-    const mark = screen.getByText("Entscheidungsfindung");
-    expect(mark).toBeInTheDocument();
-    expect(mark.tagName).toBe("MARK");
-  });
-
-  it("limits shortReport snippet length and preserves highlight", async () => {
-    const match: TextMatch = {
-      "@type": "SearchResultMatch",
-      name: "shortReport",
-      text: `… Rolle von <mark>Präzedenzfällen</mark> in modernen Gerichtsbarkeiten …`,
-      location: undefined,
-    };
-
-    renderComponent({ textMatches: [match] });
-
-    const snippet = screen.getByTestId("highlighted-field");
-    expect(snippet).toHaveTextContent("Präzedenzfällen");
-    expect(snippet.textContent?.length ?? 0).toBeLessThanOrEqual(280);
-  });
-
-  it("applies line-clamp-3 class only when no highlight exists", async () => {
-    // No match
-    const { rerender } = renderComponent({});
-    let span = screen.getByTestId("highlighted-field");
-    expect(span).toHaveClass("line-clamp-3");
-
-    // With match
-    const match: TextMatch = {
-      "@type": "SearchResultMatch",
-      name: "shortReport",
-      text: `<mark>Dieses</mark> Werk analysiert`,
-      location: undefined,
-    };
-    await rerender({
-      searchResult: { item: searchResult.item, textMatches: [match] },
-    });
-    span = screen.getByTestId("highlighted-field");
-    expect(span).not.toHaveClass("line-clamp-3");
-  });
-
   describe("metadata", () => {
     it("renders first documentType", async () => {
       renderComponent();
@@ -269,6 +91,140 @@ describe("LiteratureSearchResult", () => {
     it("renders first year of publication", async () => {
       renderComponent();
       expect(screen.getByText("2021")).toBeVisible();
+    });
+  });
+
+  describe("headline", () => {
+    it("renders the expected title", async () => {
+      renderComponent({});
+      expect(
+        screen.getByText(
+          "Eine Untersuchung der juristischen Methoden im 21. Jahrhundert",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("has accessible description linking to result type", async () => {
+      renderComponent({});
+      expect(
+        screen.getByRole("link", {
+          name: "Eine Untersuchung der juristischen Methoden im 21. Jahrhundert",
+          description: "Book",
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders placeholder title if title is missing", async () => {
+      const searchResultWithoutTitle = {
+        item: {
+          ...searchResult.item,
+          headline: undefined,
+          alternativeHeadline: undefined,
+        },
+        textMatches: [],
+      };
+      renderComponent(searchResultWithoutTitle);
+      expect(
+        screen.getByText("Titelzeile nicht vorhanden"),
+      ).toBeInTheDocument();
+    });
+
+    it("displays highlighted headline when main title has highlights", async () => {
+      const textMatch: TextMatch = {
+        "@type": "SearchResultMatch",
+        name: "mainTitle",
+        text: `testing <mark>highlighted main title</mark> is here`,
+        location: undefined,
+      };
+
+      renderComponent({ textMatches: [textMatch] });
+
+      const mark = screen.getByText("highlighted main title");
+      expect(mark.tagName).toBe("MARK");
+    });
+
+    it("displays highlighted headline when documentary title has markup", async () => {
+      const textMatch: TextMatch = {
+        "@type": "SearchResultMatch",
+        name: "documentaryTitle",
+        text: `testing <mark>highlighted documentary title</mark> is here`,
+        location: undefined,
+      };
+
+      const itemWithoutHeadline = { ...searchResult.item, headline: undefined };
+
+      renderComponent({ item: itemWithoutHeadline, textMatches: [textMatch] });
+
+      const mark = screen.getByText("highlighted documentary title");
+      expect(mark.tagName).toBe("MARK");
+    });
+
+    it("displays alternative title when headline is not present", async () => {
+      const itemWithoutHeadline = { ...searchResult.item, headline: "" };
+      renderComponent({ item: itemWithoutHeadline });
+      expect(
+        screen.getByText("Study of Legal Methodologies in the 21st Century"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("preview sections", () => {
+    it("renders no highlights when text matches is empty", () => {
+      renderComponent({});
+      expect(screen.queryAllByTestId("highlighted-field")).toHaveLength(0);
+    });
+
+    it("renders matches", () => {
+      const textMatches: TextMatch[] = [
+        {
+          "@type": "SearchResultMatch",
+          name: "outline",
+          text: "<mark>I. Einführung</mark>",
+          location: undefined,
+        },
+        {
+          "@type": "SearchResultMatch",
+          name: "shortReport",
+          text: "testing <mark>highlighted Text</mark> is here",
+          location: undefined,
+        },
+      ];
+
+      renderComponent({ textMatches });
+
+      expect(
+        screen.getByRole("link", { name: "Gliederung:" }),
+      ).toBeInTheDocument();
+      const outlineMark = screen.getByText("I. Einführung");
+      expect(outlineMark.tagName).toBe("MARK");
+
+      expect(
+        screen.getByRole("link", { name: "Kurzreferat:" }),
+      ).toBeInTheDocument();
+      const shortReportMark = screen.getByText("highlighted Text");
+      expect(shortReportMark.tagName).toBe("MARK");
+    });
+
+    it("filters HTML tags except mark, i, b", () => {
+      const text =
+        '<mark>mark</mark> <i>i</i> <b>b</b> <img src="" alt="do not show"> <div>div</div> plain_text.';
+      const expectedSanitized =
+        "<mark>mark</mark> <i>i</i> <b>b</b>  div plain_text.";
+
+      const textMatches: TextMatch[] = [
+        {
+          "@type": "SearchResultMatch",
+          name: "shortReport",
+          text,
+          location: undefined,
+        },
+      ];
+
+      renderComponent({ textMatches });
+
+      const contentItems = screen.getAllByTestId("highlighted-field");
+      expect(contentItems).toHaveLength(1);
+      expect(contentItems[0]?.innerHTML).toBe(expectedSanitized);
     });
   });
 });

--- a/frontend/src/components/search/LiteratureSearchResult.vue
+++ b/frontend/src/components/search/LiteratureSearchResult.vue
@@ -13,6 +13,11 @@ const { searchResultClicked } = usePostHog();
 
 const router = useRouter();
 
+const fields = new Map([
+  ["outline", { id: "gliederung", title: "Gliederung" }],
+  ["shortReport", { id: "kurzreferat", title: "Kurzreferat" }],
+]);
+
 const headline = computed(() =>
   getTitleWithFallback(
     getMatch("mainTitle", searchResult.textMatches),
@@ -40,29 +45,9 @@ const detailPageRoute = computed(() => ({
   params: { documentNumber: searchResult.item.documentNumber },
 }));
 
-const shortReport = computed(() => {
-  const fullText = searchResult.item.shortReport;
-  if (!fullText) return undefined;
-
-  // Find the relevant highlight for "shortReport"
-  const match = searchResult.textMatches.find(
-    (hl) => hl.name === "shortReport" && hl.text?.includes("<mark>"),
-  );
-
-  // No highlight — just return the whole text, will be truncated with
-  // line-clamp because of 3 lines wanted and not only 2
-  if (!match) return fullText;
-
-  // Return the highlighted text (with ellipsis if needed)
-  return addEllipsis(match.text);
-});
-
-const shortReportIncludesHighlight = computed(
-  () => shortReport.value?.includes("<mark>") ?? false,
-);
-
-const sanitizedShortReport = computed(() =>
-  sanitizeSearchResult(shortReport.value ?? ""),
+const previewSections = useSearchResultSections(
+  () => searchResult.textMatches,
+  fields,
 );
 
 function trackResultClick() {
@@ -86,11 +71,21 @@ function trackResultClick() {
     </NuxtLink>
 
     <div class="flex w-full flex-col gap-6">
-      <span
-        data-testid="highlighted-field"
-        :class="{ 'line-clamp-3': !shortReportIncludesHighlight }"
-        v-html="sanitizedShortReport"
-      />
+      <div v-for="section in previewSections" :key="section.id">
+        <NuxtLink
+          :to="{ ...detailPageRoute, hash: `#${section.id}` }"
+          class="ris-link1-bold link-hover"
+          external
+          @click="trackResultClick()"
+          >{{ section.title }}:</NuxtLink
+        >{{ " " }}
+        <span
+          v-if="section.text"
+          data-testid="highlighted-field"
+          class="ris-label1-regular"
+          v-html="section.text"
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/frontend/src/components/search/NormSearchResult.vue
+++ b/frontend/src/components/search/NormSearchResult.vue
@@ -25,11 +25,11 @@ const resultTypeId = useId();
 
 const headerItems = computed<SearchResultHeaderItem[]>(() => {
   let date: string | Dayjs | undefined =
-    searchResult.item?.exampleOfWork.legislationDate;
+    searchResult.item.exampleOfWork.legislationDate;
 
   if (privateFeaturesEnabled) {
     const coverage = temporalCoverageToValidityInterval(
-      searchResult.item?.temporalCoverage,
+      searchResult.item.temporalCoverage,
     );
     date = coverage?.from;
   }

--- a/frontend/src/composables/useSearchResultSections.spec.ts
+++ b/frontend/src/composables/useSearchResultSections.spec.ts
@@ -1,0 +1,104 @@
+import { ref } from "vue";
+import type { TextMatch } from "~/types/api";
+import {
+  type ExtendedTextMatch,
+  useSearchResultSections,
+} from "./useSearchResultSections";
+
+const fields = new Map([
+  ["first", { id: "first-id", title: "First" }],
+  ["second", { id: "second-id", title: "Second" }],
+  ["third", { id: "third-id", title: "Third" }],
+]);
+
+describe("useSearchResultSections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns only matches whose names are in the fields map", async () => {
+    const textMatches: TextMatch[] = [
+      { name: "first", text: "text 1" },
+      { name: "unknown", text: "text u" },
+      { name: "second", text: "text 2" },
+    ];
+    const previewSections = useSearchResultSections(textMatches, fields);
+
+    expect(previewSections.value.map((s) => s.id)).toEqual([
+      "first-id",
+      "second-id",
+    ]);
+  });
+
+  it("orders sections according to the fields map", async () => {
+    const textMatches: TextMatch[] = [
+      { name: "third", text: "text 3" },
+      { name: "first", text: "text 1" },
+      { name: "second", text: "text 2" },
+    ];
+    const previewSections = useSearchResultSections(textMatches, fields);
+
+    expect(previewSections.value.map((s) => s.id)).toEqual([
+      "first-id",
+      "second-id",
+      "third-id",
+    ]);
+  });
+
+  it("adds id and title from the fields map to each section", async () => {
+    const textMatches: TextMatch[] = [{ name: "second", text: "some text" }];
+    const previewSections = useSearchResultSections(textMatches, fields);
+
+    expect(previewSections.value[0]).toMatchObject({
+      id: "second-id",
+      title: "Second",
+    });
+  });
+
+  it("returns an empty array when there are no text matches", async () => {
+    const previewSections = useSearchResultSections([], fields);
+
+    expect(previewSections.value).toEqual([]);
+  });
+
+  it("limits results when a section limit is provided", async () => {
+    const textMatches: TextMatch[] = [
+      { name: "first", text: "text 1" },
+      { name: "second", text: "text 2" },
+      { name: "third", text: "text 3" },
+    ];
+    const previewSections = useSearchResultSections(textMatches, fields, 2);
+
+    expect(previewSections.value).toHaveLength(2);
+    expect(previewSections.value.map((s: ExtendedTextMatch) => s.id)).toEqual([
+      "first-id",
+      "second-id",
+    ]);
+  });
+
+  it("returns all results when no section limit is provided", async () => {
+    const textMatches: TextMatch[] = [
+      { name: "first", text: "text 1" },
+      { name: "second", text: "text 2" },
+      { name: "third", text: "text 3" },
+    ];
+    const previewSections = useSearchResultSections(textMatches, fields);
+
+    expect(previewSections.value).toHaveLength(3);
+  });
+
+  it("accepts a reactive text matches ref and reacts to changes", async () => {
+    const textMatches = ref<TextMatch[]>([{ name: "first", text: "initial" }]);
+    const previewSections = useSearchResultSections(textMatches, fields);
+
+    expect(previewSections.value).toHaveLength(1);
+
+    textMatches.value = [
+      { name: "first", text: "updated" },
+      { name: "second", text: "also here" },
+    ];
+    await nextTick();
+
+    expect(previewSections.value).toHaveLength(2);
+  });
+});

--- a/frontend/src/composables/useSearchResultSections.ts
+++ b/frontend/src/composables/useSearchResultSections.ts
@@ -1,0 +1,43 @@
+import type { TextMatch } from "~/types/api";
+
+export interface FieldDisplayProperties {
+  id: string;
+  title: string;
+}
+
+export type ExtendedTextMatch = TextMatch & FieldDisplayProperties;
+
+/**
+ * Composable that computes the ordered, sanitised preview sections for a search
+ * result card and provides the shared `trackResultClick` analytics handler.
+ *
+ * @param textMatches - The raw text matches returned by the API for this result
+ * @param fields - Ordered map from API field name to display properties (id,
+ *   title)
+ * @param maxSections - Optional cap on the number of sections shown (default:
+ *   unlimited)
+ */
+export function useSearchResultSections(
+  textMatches: MaybeRefOrGetter<TextMatch[]>,
+  fields: Map<string, FieldDisplayProperties>,
+  maxSections?: number,
+) {
+  const previewSections = computed<ExtendedTextMatch[]>(() => {
+    const matchesVal = toValue(textMatches);
+    const keys = [...fields.keys()];
+    const sections = matchesVal
+      .filter((match) => fields.has(match.name))
+      .toSorted((a, b) => keys.indexOf(a.name) - keys.indexOf(b.name))
+      .map<ExtendedTextMatch>((match) => ({
+        ...match,
+        text: sanitizeSearchResult(addEllipsis(match.text) ?? ""),
+        ...fields.get(match.name)!, // always defined since we filtered above
+      }));
+
+    return maxSections !== undefined
+      ? sections.slice(0, maxSections)
+      : sections;
+  });
+
+  return previewSections;
+}

--- a/frontend/src/composables/useSearchResultSections.ts
+++ b/frontend/src/composables/useSearchResultSections.ts
@@ -34,7 +34,7 @@ export function useSearchResultSections(
         ...fields.get(match.name)!, // always defined since we filtered above
       }));
 
-    return maxSections !== undefined
+    return Number.isInteger(maxSections)
       ? sections.slice(0, maxSections)
       : sections;
   });

--- a/frontend/src/public/openapi.json
+++ b/frontend/src/public/openapi.json
@@ -3029,6 +3029,13 @@
               "type" : "string",
               "description" : "Kurzreferat"
             },
+            "outline" : {
+              "type" : "array",
+              "description" : "Gliederung",
+              "items" : {
+                "type" : "string"
+              }
+            },
             "documentType" : {
               "type" : "string",
               "description" : "Dokumenttyp",

--- a/frontend/src/types/api-generated.d.ts
+++ b/frontend/src/types/api-generated.d.ts
@@ -30,8 +30,8 @@ export interface paths {
     /**
      * List and search literature
      *
-     * The endpoint returns a list of literature from our database. The list
-     * is paginated and can be filtered and sorted.
+     * The endpoint returns a list of literature from our database. The list is
+     * paginated and can be filtered and sorted.
      */
     get: operations["searchAndFilter"];
     put?: never;
@@ -74,8 +74,8 @@ export interface paths {
     /**
      * Literature XML
      *
-     * Returns a literature item as XML. This content is used as a source
-     * for the HTML endpoint.
+     * Returns a literature item as XML. This content is used as a source for
+     * the HTML endpoint.
      */
     get: operations["getLiteratureAsXml"];
     put?: never;
@@ -151,23 +151,23 @@ export interface paths {
      * GET /v1/legislation?searchTerm=Gesetz%20über%20das%20Verfahren%20bei%20sonstigen%20Änderungen
      * ```
      *
-     * The API will return only the legislation that contains all these
-     * terms. Please note that in practice very common tokens such as `das`
-     * are ignored (please see <a
+     * The API will return only the legislation that contains all these terms.
+     * Please note that in practice very common tokens such as `das` are ignored
+     * (please see <a
      * href="https://en.wikipedia.org/wiki/Stop_word">https://en.wikipedia.org/wiki/Stop_word</a>
      * for more details).
      *
      * ## Example 2
      *
-     * Get all legislation containing the tokens :` Gesetz` and `über` and
-     * were valid on 2020-01-01
+     * Get all legislation containing the tokens :` Gesetz` and `über` and were
+     * valid on 2020-01-01
      *
      * ```http
      * GET /v1/legislation?temporalCoverageFrom=2020-01-01&temporalCoverageTo=2020-01-01&searchTerm=Gesetz%20über
      * ```
      *
-     * This example can be used to only return currently valid legislation
-     * by replacing 2020-01-01 with today's date.
+     * This example can be used to only return currently valid legislation by
+     * replacing 2020-01-01 with today's date.
      *
      * ## Example 3
      *
@@ -218,8 +218,8 @@ export interface paths {
     /**
      * Manifestation article (§) HTML
      *
-     * Returns a specific article (§) of particular manifestation of a piece
-     * of legislation, converted to HTML.
+     * Returns a specific article (§) of particular manifestation of a piece of
+     * legislation, converted to HTML.
      */
     get: operations["getLegislationArticleAsHtml"];
     put?: never;
@@ -272,8 +272,8 @@ export interface paths {
     /**
      * Manifestation HTML
      *
-     * Returns a particular manifestation of a piece of legislation,
-     * converted to HTML.
+     * Returns a particular manifestation of a piece of legislation, converted
+     * to HTML.
      */
     get: operations["getLegislationSubtypeAsHtml"];
     put?: never;
@@ -294,8 +294,8 @@ export interface paths {
     /**
      * Manifestation resource
      *
-     * Returns a specific resource of a particular manifestation of a piece
-     * of legislation.
+     * Returns a specific resource of a particular manifestation of a piece of
+     * legislation.
      */
     get: operations["getFile"];
     put?: never;
@@ -316,9 +316,9 @@ export interface paths {
     /**
      * Manifestation ZIP (XML and attachments)
      *
-     * Returns a particular manifestation of a piece of legislation,
-     * including attachments, as a ZIP archive. Note the omission of the
-     * subtype path parameter.
+     * Returns a particular manifestation of a piece of legislation, including
+     * attachments, as a ZIP archive. Note the omission of the subtype path
+     * parameter.
      */
     get: operations["getLegislationSubtypeAsZip"];
     put?: never;
@@ -362,16 +362,15 @@ export interface paths {
      * Global search / list
      *
      * This endpoint can be used to search for documents across different
-     * document kinds. Currently we support case law, legislation and
-     * literature document kinds. The endpoint provides a paginated response
-     * with up to 10,000 results with at most 100 results per page. The
-     * searchTerm parameter searches across multiple fields of a document at
-     * the same time. The fields searched depend on the document kind. See
-     * the filters guide for more information. Default sorting is by
-     * relevance from most relevant to least relevant. Multiple factors are
-     * combined to boost the most relevant documents to the top of the
-     * result list. Additionally, sorting by date is possible by setting the
-     * sort query parameter to date.
+     * document kinds. Currently we support case law, legislation and literature
+     * document kinds. The endpoint provides a paginated response with up to
+     * 10,000 results with at most 100 results per page. The searchTerm
+     * parameter searches across multiple fields of a document at the same time.
+     * The fields searched depend on the document kind. See the filters guide
+     * for more information. Default sorting is by relevance from most relevant
+     * to least relevant. Multiple factors are combined to boost the most
+     * relevant documents to the top of the result list. Additionally, sorting
+     * by date is possible by setting the sort query parameter to date.
      */
     get: operations["searchAndFilter_2"];
     put?: never;
@@ -477,8 +476,8 @@ export interface paths {
     /**
      * List and search decisions
      *
-     * The endpoint returns a list of decisions from our database. The list
-     * is paginated and can be filtered and sorted.
+     * The endpoint returns a list of decisions from our database. The list is
+     * paginated and can be filtered and sorted.
      */
     get: operations["searchAndFilter_3"];
     put?: never;
@@ -562,8 +561,8 @@ export interface paths {
     /**
      * Decision XML
      *
-     * Returns a case law decision as XML. This content is used as a source
-     * for the HTML endpoint.
+     * Returns a case law decision as XML. This content is used as a source for
+     * the HTML endpoint.
      */
     get: operations["getCaseLawDocumentationUnitAsXml"];
     put?: never;
@@ -605,10 +604,9 @@ export interface paths {
     /**
      * List courts
      *
-     * Lists courts with long and short name and number of associated
-     * decisions. The prefix parameter may be used to filter this list. Only
-     * includes courts whose decisions have been published in this
-     * database.
+     * Lists courts with long and short name and number of associated decisions.
+     * The prefix parameter may be used to filter this list. Only includes
+     * courts whose decisions have been published in this database.
      */
     get: operations["getCourts"];
     put?: never;
@@ -689,8 +687,8 @@ export interface paths {
     /**
      * Administrative directive metadata
      *
-     * The endpoint returns the metadata of a single administrative
-     * directive from our database.
+     * The endpoint returns the metadata of a single administrative directive
+     * from our database.
      */
     get: operations["getAdministrativeDirectiveMetadata"];
     put?: never;
@@ -711,8 +709,8 @@ export interface paths {
     /**
      * Administrative directive XML
      *
-     * Returns an administrative directive item as XML. This content is used
-     * as a source for the HTML endpoint.
+     * Returns an administrative directive item as XML. This content is used as
+     * a source for the HTML endpoint.
      */
     get: operations["getAdministrativeDirectiveAsXml"];
     put?: never;
@@ -1141,14 +1139,13 @@ export interface components {
       name: string;
       /**
        * @example
-       *   eli/bund/bgbl-1/1975/s1760/1998-01-29/10/deu
+       *   eli / bund / bgbl - 1 / 1975 / s1760 / 1998 - 01 - 29 / 10 / deu;
        */
       legislationIdentifier: string;
       /** The work the expression is based on */
       exampleOfWork: components["schemas"]["LegislationWorkSchema"];
       /**
-       * Textual string indicating a time period in [ISO 8601 time
-       * interval
+       * Textual string indicating a time period in [ISO 8601 time interval
        * format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals)
        *
        * @example
@@ -1225,8 +1222,8 @@ export interface components {
        *
        * Ausfertigungsdatum (The date of adoption or signature of the
        * legislation. This is the date at which the text is officially
-       * acknowledged to be a legislation, even though it might not even
-       * be published or in force.)
+       * acknowledged to be a legislation, even though it might not even be
+       * published or in force.)
        *
        * @example
        *   2003 - 12 - 15;
@@ -1235,9 +1232,9 @@ export interface components {
       /**
        * Format: date
        *
-       * Verkündungsdatum (The date of first publication of the
-       * legislation, when it was published in the official gazette. This
-       * may be later than the `legislationDate`.)
+       * Verkündungsdatum (The date of first publication of the legislation,
+       * when it was published in the official gazette. This may be later than
+       * the `legislationDate`.)
        *
        * @example
        *   2003 - 12 - 16;
@@ -1279,8 +1276,8 @@ export interface components {
        */
       "@id": string;
       /**
-       * Expression-level identifier, uniquely identifying this element in
-       * an FRBR expression
+       * Expression-level identifier, uniquely identifying this element in an
+       * FRBR expression
        *
        * @example
        *   hauptteitel - para - 1;
@@ -1301,8 +1298,7 @@ export interface components {
        */
       headline: string;
       /**
-       * Textual string indicating a time period in [ISO 8601 time
-       * interval
+       * Textual string indicating a time period in [ISO 8601 time interval
        * format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals)
        *
        * @example
@@ -1350,12 +1346,11 @@ export interface components {
       exampleOfWork: components["schemas"]["LegislationWorkSchema"];
       /**
        * @example
-       *   eli/bund/bgbl-1/1975/s1760/1998-01-29/10/deu
+       *   eli / bund / bgbl - 1 / 1975 / s1760 / 1998 - 01 - 29 / 10 / deu;
        */
       legislationIdentifier: string;
       /**
-       * Textual string indicating a time period in [ISO 8601 time
-       * interval
+       * Textual string indicating a time period in [ISO 8601 time interval
        * format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals)
        *
        * @example
@@ -1369,8 +1364,8 @@ export interface components {
        */
       legislationLegalForce: "InForce" | "NotInForce" | "PartiallyInForce";
       /**
-       * List of components (articles, preambles, conclusions,
-       * attachments, …) that form this legislation item.
+       * List of components (articles, preambles, conclusions, attachments, …)
+       * that form this legislation item.
        */
       hasPart: components["schemas"]["LegislationExpressionPartSchema"][];
       encoding: components["schemas"]["LegislationObjectSchema"][];
@@ -1822,10 +1817,7 @@ export interface components {
       /** The url to download the zip file. */
       contentUrl: string;
     };
-    /**
-     * Represents <a
-     * href="https://schema.org/Dataset">schema.org/Dataset</a>.
-     */
+    /** Represents <a href="https://schema.org/Dataset">schema.org/Dataset</a>. */
     ZipDataSetSchema: {
       /**
        * @example
@@ -1955,20 +1947,19 @@ export interface operations {
         author?: string[];
         collaborator?: string[];
         /**
-         * Searches for the given tokens in searchTerm. If searchTerm
-         * contains more than one token, all tokens must be in the
-         * document for the document to match.
+         * Searches for the given tokens in searchTerm. If searchTerm contains
+         * more than one token, all tokens must be in the document for the
+         * document to match.
          */
         searchTerm?: string;
         /**
-         * The from (greater than or equal) parameter returns all
-         * entities where date is later than, or equal to, the given
-         * date.
+         * The from (greater than or equal) parameter returns all entities where
+         * date is later than, or equal to, the given date.
          */
         dateFrom?: string;
         /**
-         * The to (less than or equal) parameter returns all entities
-         * where date is earlier than, or equal to, the given date.
+         * The to (less than or equal) parameter returns all entities where date
+         * is earlier than, or equal to, the given date.
          */
         dateTo?: string;
         /**
@@ -1979,19 +1970,17 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the
-         * value 0
+         * The number of the page to request. The page starts with the value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance
-         * score calculated by OpenSearch. Valid usage of the sort field
-         * are : date and documentNumber and not setting the sort field
-         * (sort by relevance descending).Add a leading - to set the
-         * order to descending (-date)
+         * The field to sort the results by. Default is the relevance score
+         * calculated by OpenSearch. Valid usage of the sort field are : date
+         * and documentNumber and not setting the sort field (sort by relevance
+         * descending).Add a leading - to set the order to descending (-date)
          */
         sort?: string;
       };
@@ -2145,56 +2134,52 @@ export interface operations {
     parameters: {
       query?: {
         /**
-         * Search by European Legislation Identifier (ELI). Right now
-         * only searching by work ELI is supported, but a general eli
-         * prefix match might be supported in the future.
+         * Search by European Legislation Identifier (ELI). Right now only
+         * searching by work ELI is supported, but a general eli prefix match
+         * might be supported in the future.
          */
         eli?: string;
         /**
-         * Filters the result set to only return expressions that are in
-         * force _on or after_ the provided date. The parameter should
-         * be provided in `YYYY-MM-DD` format. Differs from `dateFrom`,
-         * which refers to the date of adoption or signature of the
-         * legislation. If both `temporalCoverageFrom` and
-         * `temporalCoverageTo` are given, this will output all
-         * expressions that were in force during at least one day
-         * between the two dates. To get all expressions for one
-         * specific day, set both parameters to the same day.
+         * Filters the result set to only return expressions that are in force
+         * _on or after_ the provided date. The parameter should be provided in
+         * `YYYY-MM-DD` format. Differs from `dateFrom`, which refers to the
+         * date of adoption or signature of the legislation. If both
+         * `temporalCoverageFrom` and `temporalCoverageTo` are given, this will
+         * output all expressions that were in force during at least one day
+         * between the two dates. To get all expressions for one specific day,
+         * set both parameters to the same day.
          */
         temporalCoverageFrom?: string;
         /**
-         * Filters the result set to only return expressions that are in
-         * force _on or before_ the provided date. The parameter should
-         * be provided in `YYYY-MM-DD` format. Differs from `dateTo`,
-         * which refers to the date of adoption or signature of the
-         * legislation.
+         * Filters the result set to only return expressions that are in force
+         * _on or before_ the provided date. The parameter should be provided in
+         * `YYYY-MM-DD` format. Differs from `dateTo`, which refers to the date
+         * of adoption or signature of the legislation.
          */
         temporalCoverageTo?: string;
         /**
-         * Filters the result set so every work returns exactly one
-         * expression. Most relevant is defined as : The expression in
-         * force on that date if it exists, then the expression that
-         * would next be in force if that exists, then the most recent
-         * expression that was in force. If other filters are used the
-         * work may return 0 expressions due to the most relevant
-         * expression being filtered out.
+         * Filters the result set so every work returns exactly one expression.
+         * Most relevant is defined as : The expression in force on that date if
+         * it exists, then the expression that would next be in force if that
+         * exists, then the most recent expression that was in force. If other
+         * filters are used the work may return 0 expressions due to the most
+         * relevant expression being filtered out.
          */
         mostRelevantOn?: string;
         /**
-         * Searches for the given tokens in searchTerm. If searchTerm
-         * contains more than one token, all tokens must be in the
-         * document for the document to match.
+         * Searches for the given tokens in searchTerm. If searchTerm contains
+         * more than one token, all tokens must be in the document for the
+         * document to match.
          */
         searchTerm?: string;
         /**
-         * The from (greater than or equal) parameter returns all
-         * entities where date is later than, or equal to, the given
-         * date.
+         * The from (greater than or equal) parameter returns all entities where
+         * date is later than, or equal to, the given date.
          */
         dateFrom?: string;
         /**
-         * The to (less than or equal) parameter returns all entities
-         * where date is earlier than, or equal to, the given date.
+         * The to (less than or equal) parameter returns all entities where date
+         * is earlier than, or equal to, the given date.
          */
         dateTo?: string;
         /**
@@ -2205,19 +2190,18 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the
-         * value 0
+         * The number of the page to request. The page starts with the value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance
-         * score calculated by OpenSearch. Valid usage of the sort field
-         * are : date, temporalCoverageFrom, legislationIdentifier and
-         * not setting the sort field (sort by relevance descending).Add
-         * a leading - to set the order to descending (-date)
+         * The field to sort the results by. Default is the relevance score
+         * calculated by OpenSearch. Valid usage of the sort field are : date,
+         * temporalCoverageFrom, legislationIdentifier and not setting the sort
+         * field (sort by relevance descending).Add a leading - to set the order
+         * to descending (-date)
          */
         sort?: string;
       };
@@ -2255,8 +2239,8 @@ export interface operations {
         /** Country or regional code for the jurisdiction */
         jurisdiction: "bund";
         /**
-         * Agent or authority issuing the legislation, e.g., 'bgbl-1'
-         * for Bundesgesetzblatt Teil I (Federal Law Gazette part I)
+         * Agent or authority issuing the legislation, e.g., 'bgbl-1' for
+         * Bundesgesetzblatt Teil I (Federal Law Gazette part I)
          *
          * @example
          *   bgbl - 1;
@@ -2270,8 +2254,8 @@ export interface operations {
          */
         year: string;
         /**
-         * Unique natural identifier for the legislation, specific to
-         * the jurisdiction and agent
+         * Unique natural identifier for the legislation, specific to the
+         * jurisdiction and agent
          *
          * @example
          *   s1325;
@@ -2328,8 +2312,8 @@ export interface operations {
          */
         jurisdiction: "bund";
         /**
-         * Agent or authority issuing the legislation, e.g., 'bgbl-1'
-         * for Bundesgesetzblatt Teil I (Federal Law Gazette part I)
+         * Agent or authority issuing the legislation, e.g., 'bgbl-1' for
+         * Bundesgesetzblatt Teil I (Federal Law Gazette part I)
          *
          * @example
          *   bgbl - 1;
@@ -2343,8 +2327,8 @@ export interface operations {
          */
         year: string;
         /**
-         * Unique natural identifier for the legislation, specific to
-         * the jurisdiction and agent
+         * Unique natural identifier for the legislation, specific to the
+         * jurisdiction and agent
          *
          * @example
          *   s1325;
@@ -2376,8 +2360,7 @@ export interface operations {
          */
         subtype: string;
         /**
-         * The expression identifier, denoting elements inside an
-         * expression
+         * The expression identifier, denoting elements inside an expression
          *
          * @example
          *   art - z1;
@@ -2421,8 +2404,8 @@ export interface operations {
          */
         jurisdiction: "bund";
         /**
-         * Agent or authority issuing the legislation, e.g., 'bgbl-1'
-         * for Bundesgesetzblatt Teil I (Federal Law Gazette part I)
+         * Agent or authority issuing the legislation, e.g., 'bgbl-1' for
+         * Bundesgesetzblatt Teil I (Federal Law Gazette part I)
          *
          * @example
          *   bgbl - 1;
@@ -2436,8 +2419,8 @@ export interface operations {
          */
         year: string;
         /**
-         * Unique natural identifier for the legislation, specific to
-         * the jurisdiction and agent
+         * Unique natural identifier for the legislation, specific to the
+         * jurisdiction and agent
          *
          * @example
          *   s1325;
@@ -2504,8 +2487,8 @@ export interface operations {
          */
         jurisdiction: "bund";
         /**
-         * Agent or authority issuing the legislation, e.g., 'bgbl-1'
-         * for Bundesgesetzblatt Teil I (Federal Law Gazette part I)
+         * Agent or authority issuing the legislation, e.g., 'bgbl-1' for
+         * Bundesgesetzblatt Teil I (Federal Law Gazette part I)
          *
          * @example
          *   bgbl - 1;
@@ -2519,8 +2502,8 @@ export interface operations {
          */
         year: string;
         /**
-         * Unique natural identifier for the legislation, specific to
-         * the jurisdiction and agent
+         * Unique natural identifier for the legislation, specific to the
+         * jurisdiction and agent
          *
          * @example
          *   s1325;
@@ -2589,8 +2572,8 @@ export interface operations {
          */
         jurisdiction: "bund";
         /**
-         * Agent or authority issuing the legislation, e.g., 'bgbl-1'
-         * for Bundesgesetzblatt Teil I (Federal Law Gazette part I)
+         * Agent or authority issuing the legislation, e.g., 'bgbl-1' for
+         * Bundesgesetzblatt Teil I (Federal Law Gazette part I)
          *
          * @example
          *   bgbl - 1;
@@ -2604,8 +2587,8 @@ export interface operations {
          */
         year: string;
         /**
-         * Unique natural identifier for the legislation, specific to
-         * the jurisdiction and agent
+         * Unique natural identifier for the legislation, specific to the
+         * jurisdiction and agent
          *
          * @example
          *   s1325;
@@ -2677,8 +2660,8 @@ export interface operations {
          */
         jurisdiction: "bund";
         /**
-         * Agent or authority issuing the legislation, e.g., 'bgbl-1'
-         * for Bundesgesetzblatt Teil I (Federal Law Gazette part I)
+         * Agent or authority issuing the legislation, e.g., 'bgbl-1' for
+         * Bundesgesetzblatt Teil I (Federal Law Gazette part I)
          *
          * @example
          *   bgbl - 1;
@@ -2692,8 +2675,8 @@ export interface operations {
          */
         year: string;
         /**
-         * Unique natural identifier for the legislation, specific to
-         * the jurisdiction and agent
+         * Unique natural identifier for the legislation, specific to the
+         * jurisdiction and agent
          *
          * @example
          *   s1325;
@@ -2769,29 +2752,27 @@ export interface operations {
     parameters: {
       query?: {
         /**
-         * Searches for the given tokens in searchTerm. If searchTerm
-         * contains more than one token, all tokens must be in the
-         * document for the document to match.
+         * Searches for the given tokens in searchTerm. If searchTerm contains
+         * more than one token, all tokens must be in the document for the
+         * document to match.
          */
         searchTerm?: string;
         /**
-         * The from (greater than or equal) parameter returns all
-         * entities where date is later than, or equal to, the given
-         * date.
+         * The from (greater than or equal) parameter returns all entities where
+         * date is later than, or equal to, the given date.
          */
         dateFrom?: string;
         /**
-         * The to (less than or equal) parameter returns all entities
-         * where date is earlier than, or equal to, the given date.
+         * The to (less than or equal) parameter returns all entities where date
+         * is earlier than, or equal to, the given date.
          */
         dateTo?: string;
         /**
-         * The field to sort the results by. Default is the relevance
-         * score calculated by OpenSearch. Valid usage of the sort field
-         * are : date, temporalCoverageFrom, legislationIdentifier,
-         * courtName, documentNumber and not setting the sort field
-         * (sort by relevance descending).Add a leading - to set the
-         * order to descending (-date)
+         * The field to sort the results by. Default is the relevance score
+         * calculated by OpenSearch. Valid usage of the sort field are : date,
+         * temporalCoverageFrom, legislationIdentifier, courtName,
+         * documentNumber and not setting the sort field (sort by relevance
+         * descending).Add a leading - to set the order to descending (-date)
          */
         sort?: string;
         /**
@@ -2802,21 +2783,19 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the
-         * value 0
+         * The number of the page to request. The page starts with the value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * Filters the result set so every work returns exactly one
-         * expression. Most relevant is defined as : The expression in
-         * force on that date if it exists, then the expression that
-         * would next be in force if that exists, then the most recent
-         * expression that was in force. If other filters are used the
-         * work may return 0 expressions due to the most relevant
-         * expression being filtered out.
+         * Filters the result set so every work returns exactly one expression.
+         * Most relevant is defined as : The expression in force on that date if
+         * it exists, then the expression that would next be in force if that
+         * exists, then the most recent expression that was in force. If other
+         * filters are used the work may return 0 expressions due to the most
+         * relevant expression being filtered out.
          *
          * @example
          *   2026 - 03 - 11;
@@ -2860,20 +2839,18 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the
-         * value 0
+         * The number of the page to request. The page starts with the value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance
-         * score calculated by OpenSearch. Valid usage of the sort field
-         * are : date, temporalCoverageFrom, legislationIdentifier,
-         * courtName, documentNumber and not setting the sort field
-         * (sort by relevance descending).Add a leading - to set the
-         * order to descending (-date)
+         * The field to sort the results by. Default is the relevance score
+         * calculated by OpenSearch. Valid usage of the sort field are : date,
+         * temporalCoverageFrom, legislationIdentifier, courtName,
+         * documentNumber and not setting the sort field (sort by relevance
+         * descending).Add a leading - to set the order to descending (-date)
          */
         sort?: string;
       };
@@ -2914,19 +2891,17 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the
-         * value 0
+         * The number of the page to request. The page starts with the value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance
-         * score calculated by OpenSearch. Valid usage of the sort field
-         * are : date and documentNumber and not setting the sort field
-         * (sort by relevance descending).Add a leading - to set the
-         * order to descending (-date)
+         * The field to sort the results by. Default is the relevance score
+         * calculated by OpenSearch. Valid usage of the sort field are : date
+         * and documentNumber and not setting the sort field (sort by relevance
+         * descending).Add a leading - to set the order to descending (-date)
          */
         sort?: string;
       };
@@ -2967,19 +2942,18 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the
-         * value 0
+         * The number of the page to request. The page starts with the value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance
-         * score calculated by OpenSearch. Valid usage of the sort field
-         * are : date, temporalCoverageFrom, legislationIdentifier and
-         * not setting the sort field (sort by relevance descending).Add
-         * a leading - to set the order to descending (-date)
+         * The field to sort the results by. Default is the relevance score
+         * calculated by OpenSearch. Valid usage of the sort field are : date,
+         * temporalCoverageFrom, legislationIdentifier and not setting the sort
+         * field (sort by relevance descending).Add a leading - to set the order
+         * to descending (-date)
          */
         sort?: string;
       };
@@ -3020,19 +2994,18 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the
-         * value 0
+         * The number of the page to request. The page starts with the value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance
-         * score calculated by OpenSearch. Valid usage of the sort field
-         * are : date, courtName, documentNumber and not setting the
-         * sort field (sort by relevance descending).Add a leading - to
-         * set the order to descending (-date)
+         * The field to sort the results by. Default is the relevance score
+         * calculated by OpenSearch. Valid usage of the sort field are : date,
+         * courtName, documentNumber and not setting the sort field (sort by
+         * relevance descending).Add a leading - to set the order to descending
+         * (-date)
          */
         sort?: string;
       };
@@ -3073,19 +3046,17 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the
-         * value 0
+         * The number of the page to request. The page starts with the value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance
-         * score calculated by OpenSearch. Valid usage of the sort field
-         * are : date and documentNumber and not setting the sort field
-         * (sort by relevance descending).Add a leading - to set the
-         * order to descending (-date)
+         * The field to sort the results by. Default is the relevance score
+         * calculated by OpenSearch. Valid usage of the sort field are : date
+         * and documentNumber and not setting the sort field (sort by relevance
+         * descending).Add a leading - to set the order to descending (-date)
          */
         sort?: string;
       };
@@ -3119,43 +3090,41 @@ export interface operations {
         fileNumber?: string;
         ecli?: string;
         /**
-         * Filter by court name (Finanzgericht Münster, FG Münster, ArbG
-         * Köln) or court type (Finanzgericht, FG, ArbG). Supports both
-         * long and short names.
+         * Filter by court name (Finanzgericht Münster, FG Münster, ArbG Köln)
+         * or court type (Finanzgericht, FG, ArbG). Supports both long and short
+         * names.
          */
         court?: string;
         /**
-         * Corresponds to “Rechtskraft”, meaning that the decision
-         * referred to is legally binding.
+         * Corresponds to “Rechtskraft”, meaning that the decision referred to
+         * is legally binding.
          */
         legalEffect?: "JA" | "NEIN" | "KEINE_ANGABE" | "FALSCHE_ANGABE";
         /**
-         * Filter by document type (Urteil, Versäumnisurteil,
-         * Entscheidung etc.). Multiple values may be specified as a
-         * comma-separated list or by repeating the parameter.
+         * Filter by document type (Urteil, Versäumnisurteil, Entscheidung
+         * etc.). Multiple values may be specified as a comma-separated list or
+         * by repeating the parameter.
          */
         type?: string[];
         /**
-         * Extended filter by type group. Multiple values may be
-         * specified as a comma-separated list or by repeating the
-         * parameter.
+         * Extended filter by type group. Multiple values may be specified as a
+         * comma-separated list or by repeating the parameter.
          */
         typeGroup?: "Urteil" | "Beschluss" | "other";
         /**
-         * Searches for the given tokens in searchTerm. If searchTerm
-         * contains more than one token, all tokens must be in the
-         * document for the document to match.
+         * Searches for the given tokens in searchTerm. If searchTerm contains
+         * more than one token, all tokens must be in the document for the
+         * document to match.
          */
         searchTerm?: string;
         /**
-         * The from (greater than or equal) parameter returns all
-         * entities where date is later than, or equal to, the given
-         * date.
+         * The from (greater than or equal) parameter returns all entities where
+         * date is later than, or equal to, the given date.
          */
         dateFrom?: string;
         /**
-         * The to (less than or equal) parameter returns all entities
-         * where date is earlier than, or equal to, the given date.
+         * The to (less than or equal) parameter returns all entities where date
+         * is earlier than, or equal to, the given date.
          */
         dateTo?: string;
         /**
@@ -3166,19 +3135,18 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the
-         * value 0
+         * The number of the page to request. The page starts with the value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance
-         * score calculated by OpenSearch. Valid usage of the sort field
-         * are : date, courtName, documentNumber and not setting the
-         * sort field (sort by relevance descending).Add a leading - to
-         * set the order to descending (-date)
+         * The field to sort the results by. Default is the relevance score
+         * calculated by OpenSearch. Valid usage of the sort field are : date,
+         * courtName, documentNumber and not setting the sort field (sort by
+         * relevance descending).Add a leading - to set the order to descending
+         * (-date)
          */
         sort?: string;
       };
@@ -3451,20 +3419,19 @@ export interface operations {
       query?: {
         documentNumber?: string;
         /**
-         * Searches for the given tokens in searchTerm. If searchTerm
-         * contains more than one token, all tokens must be in the
-         * document for the document to match.
+         * Searches for the given tokens in searchTerm. If searchTerm contains
+         * more than one token, all tokens must be in the document for the
+         * document to match.
          */
         searchTerm?: string;
         /**
-         * The from (greater than or equal) parameter returns all
-         * entities where date is later than, or equal to, the given
-         * date.
+         * The from (greater than or equal) parameter returns all entities where
+         * date is later than, or equal to, the given date.
          */
         dateFrom?: string;
         /**
-         * The to (less than or equal) parameter returns all entities
-         * where date is earlier than, or equal to, the given date.
+         * The to (less than or equal) parameter returns all entities where date
+         * is earlier than, or equal to, the given date.
          */
         dateTo?: string;
         /**
@@ -3475,19 +3442,17 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the
-         * value 0
+         * The number of the page to request. The page starts with the value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance
-         * score calculated by OpenSearch. Valid usage of the sort field
-         * are : date and documentNumber and not setting the sort field
-         * (sort by relevance descending).Add a leading - to set the
-         * order to descending (-date)
+         * The field to sort the results by. Default is the relevance score
+         * calculated by OpenSearch. Valid usage of the sort field are : date
+         * and documentNumber and not setting the sort field (sort by relevance
+         * descending).Add a leading - to set the order to descending (-date)
          */
         sort?: string;
       };

--- a/frontend/src/types/api-generated.d.ts
+++ b/frontend/src/types/api-generated.d.ts
@@ -30,8 +30,8 @@ export interface paths {
     /**
      * List and search literature
      *
-     * The endpoint returns a list of literature from our database. The list is
-     * paginated and can be filtered and sorted.
+     * The endpoint returns a list of literature from our database. The list
+     * is paginated and can be filtered and sorted.
      */
     get: operations["searchAndFilter"];
     put?: never;
@@ -74,8 +74,8 @@ export interface paths {
     /**
      * Literature XML
      *
-     * Returns a literature item as XML. This content is used as a source for
-     * the HTML endpoint.
+     * Returns a literature item as XML. This content is used as a source
+     * for the HTML endpoint.
      */
     get: operations["getLiteratureAsXml"];
     put?: never;
@@ -151,23 +151,23 @@ export interface paths {
      * GET /v1/legislation?searchTerm=Gesetz%20über%20das%20Verfahren%20bei%20sonstigen%20Änderungen
      * ```
      *
-     * The API will return only the legislation that contains all these terms.
-     * Please note that in practice very common tokens such as `das` are ignored
-     * (please see <a
+     * The API will return only the legislation that contains all these
+     * terms. Please note that in practice very common tokens such as `das`
+     * are ignored (please see <a
      * href="https://en.wikipedia.org/wiki/Stop_word">https://en.wikipedia.org/wiki/Stop_word</a>
      * for more details).
      *
      * ## Example 2
      *
-     * Get all legislation containing the tokens :` Gesetz` and `über` and were
-     * valid on 2020-01-01
+     * Get all legislation containing the tokens :` Gesetz` and `über` and
+     * were valid on 2020-01-01
      *
      * ```http
      * GET /v1/legislation?temporalCoverageFrom=2020-01-01&temporalCoverageTo=2020-01-01&searchTerm=Gesetz%20über
      * ```
      *
-     * This example can be used to only return currently valid legislation by
-     * replacing 2020-01-01 with today's date.
+     * This example can be used to only return currently valid legislation
+     * by replacing 2020-01-01 with today's date.
      *
      * ## Example 3
      *
@@ -218,8 +218,8 @@ export interface paths {
     /**
      * Manifestation article (§) HTML
      *
-     * Returns a specific article (§) of particular manifestation of a piece of
-     * legislation, converted to HTML.
+     * Returns a specific article (§) of particular manifestation of a piece
+     * of legislation, converted to HTML.
      */
     get: operations["getLegislationArticleAsHtml"];
     put?: never;
@@ -272,8 +272,8 @@ export interface paths {
     /**
      * Manifestation HTML
      *
-     * Returns a particular manifestation of a piece of legislation, converted
-     * to HTML.
+     * Returns a particular manifestation of a piece of legislation,
+     * converted to HTML.
      */
     get: operations["getLegislationSubtypeAsHtml"];
     put?: never;
@@ -294,8 +294,8 @@ export interface paths {
     /**
      * Manifestation resource
      *
-     * Returns a specific resource of a particular manifestation of a piece of
-     * legislation.
+     * Returns a specific resource of a particular manifestation of a piece
+     * of legislation.
      */
     get: operations["getFile"];
     put?: never;
@@ -316,9 +316,9 @@ export interface paths {
     /**
      * Manifestation ZIP (XML and attachments)
      *
-     * Returns a particular manifestation of a piece of legislation, including
-     * attachments, as a ZIP archive. Note the omission of the subtype path
-     * parameter.
+     * Returns a particular manifestation of a piece of legislation,
+     * including attachments, as a ZIP archive. Note the omission of the
+     * subtype path parameter.
      */
     get: operations["getLegislationSubtypeAsZip"];
     put?: never;
@@ -362,15 +362,16 @@ export interface paths {
      * Global search / list
      *
      * This endpoint can be used to search for documents across different
-     * document kinds. Currently we support case law, legislation and literature
-     * document kinds. The endpoint provides a paginated response with up to
-     * 10,000 results with at most 100 results per page. The searchTerm
-     * parameter searches across multiple fields of a document at the same time.
-     * The fields searched depend on the document kind. See the filters guide
-     * for more information. Default sorting is by relevance from most relevant
-     * to least relevant. Multiple factors are combined to boost the most
-     * relevant documents to the top of the result list. Additionally, sorting
-     * by date is possible by setting the sort query parameter to date.
+     * document kinds. Currently we support case law, legislation and
+     * literature document kinds. The endpoint provides a paginated response
+     * with up to 10,000 results with at most 100 results per page. The
+     * searchTerm parameter searches across multiple fields of a document at
+     * the same time. The fields searched depend on the document kind. See
+     * the filters guide for more information. Default sorting is by
+     * relevance from most relevant to least relevant. Multiple factors are
+     * combined to boost the most relevant documents to the top of the
+     * result list. Additionally, sorting by date is possible by setting the
+     * sort query parameter to date.
      */
     get: operations["searchAndFilter_2"];
     put?: never;
@@ -476,8 +477,8 @@ export interface paths {
     /**
      * List and search decisions
      *
-     * The endpoint returns a list of decisions from our database. The list is
-     * paginated and can be filtered and sorted.
+     * The endpoint returns a list of decisions from our database. The list
+     * is paginated and can be filtered and sorted.
      */
     get: operations["searchAndFilter_3"];
     put?: never;
@@ -561,8 +562,8 @@ export interface paths {
     /**
      * Decision XML
      *
-     * Returns a case law decision as XML. This content is used as a source for
-     * the HTML endpoint.
+     * Returns a case law decision as XML. This content is used as a source
+     * for the HTML endpoint.
      */
     get: operations["getCaseLawDocumentationUnitAsXml"];
     put?: never;
@@ -604,9 +605,10 @@ export interface paths {
     /**
      * List courts
      *
-     * Lists courts with long and short name and number of associated decisions.
-     * The prefix parameter may be used to filter this list. Only includes
-     * courts whose decisions have been published in this database.
+     * Lists courts with long and short name and number of associated
+     * decisions. The prefix parameter may be used to filter this list. Only
+     * includes courts whose decisions have been published in this
+     * database.
      */
     get: operations["getCourts"];
     put?: never;
@@ -631,6 +633,22 @@ export interface paths {
      * points in time.
      */
     get: operations["getChangelogs_2"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/bulk-zip-links": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["getBulkZipLinks"];
     put?: never;
     post?: never;
     delete?: never;
@@ -671,8 +689,8 @@ export interface paths {
     /**
      * Administrative directive metadata
      *
-     * The endpoint returns the metadata of a single administrative directive
-     * from our database.
+     * The endpoint returns the metadata of a single administrative
+     * directive from our database.
      */
     get: operations["getAdministrativeDirectiveMetadata"];
     put?: never;
@@ -693,8 +711,8 @@ export interface paths {
     /**
      * Administrative directive XML
      *
-     * Returns an administrative directive item as XML. This content is used as
-     * a source for the HTML endpoint.
+     * Returns an administrative directive item as XML. This content is used
+     * as a source for the HTML endpoint.
      */
     get: operations["getAdministrativeDirectiveAsXml"];
     put?: never;
@@ -1123,13 +1141,14 @@ export interface components {
       name: string;
       /**
        * @example
-       *   eli / bund / bgbl - 1 / 1975 / s1760 / 1998 - 01 - 29 / 10 / deu;
+       *   eli/bund/bgbl-1/1975/s1760/1998-01-29/10/deu
        */
       legislationIdentifier: string;
       /** The work the expression is based on */
       exampleOfWork: components["schemas"]["LegislationWorkSchema"];
       /**
-       * Textual string indicating a time period in [ISO 8601 time interval
+       * Textual string indicating a time period in [ISO 8601 time
+       * interval
        * format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals)
        *
        * @example
@@ -1206,8 +1225,8 @@ export interface components {
        *
        * Ausfertigungsdatum (The date of adoption or signature of the
        * legislation. This is the date at which the text is officially
-       * acknowledged to be a legislation, even though it might not even be
-       * published or in force.)
+       * acknowledged to be a legislation, even though it might not even
+       * be published or in force.)
        *
        * @example
        *   2003 - 12 - 15;
@@ -1216,9 +1235,9 @@ export interface components {
       /**
        * Format: date
        *
-       * Verkündungsdatum (The date of first publication of the legislation,
-       * when it was published in the official gazette. This may be later than
-       * the `legislationDate`.)
+       * Verkündungsdatum (The date of first publication of the
+       * legislation, when it was published in the official gazette. This
+       * may be later than the `legislationDate`.)
        *
        * @example
        *   2003 - 12 - 16;
@@ -1260,8 +1279,8 @@ export interface components {
        */
       "@id": string;
       /**
-       * Expression-level identifier, uniquely identifying this element in an
-       * FRBR expression
+       * Expression-level identifier, uniquely identifying this element in
+       * an FRBR expression
        *
        * @example
        *   hauptteitel - para - 1;
@@ -1282,7 +1301,8 @@ export interface components {
        */
       headline: string;
       /**
-       * Textual string indicating a time period in [ISO 8601 time interval
+       * Textual string indicating a time period in [ISO 8601 time
+       * interval
        * format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals)
        *
        * @example
@@ -1330,11 +1350,12 @@ export interface components {
       exampleOfWork: components["schemas"]["LegislationWorkSchema"];
       /**
        * @example
-       *   eli / bund / bgbl - 1 / 1975 / s1760 / 1998 - 01 - 29 / 10 / deu;
+       *   eli/bund/bgbl-1/1975/s1760/1998-01-29/10/deu
        */
       legislationIdentifier: string;
       /**
-       * Textual string indicating a time period in [ISO 8601 time interval
+       * Textual string indicating a time period in [ISO 8601 time
+       * interval
        * format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals)
        *
        * @example
@@ -1348,8 +1369,8 @@ export interface components {
        */
       legislationLegalForce: "InForce" | "NotInForce" | "PartiallyInForce";
       /**
-       * List of components (articles, preambles, conclusions, attachments, …)
-       * that form this legislation item.
+       * List of components (articles, preambles, conclusions,
+       * attachments, …) that form this legislation item.
        */
       hasPart: components["schemas"]["LegislationExpressionPartSchema"][];
       encoding: components["schemas"]["LegislationObjectSchema"][];
@@ -1401,6 +1422,8 @@ export interface components {
       headline?: string;
       /** Kurzreferat */
       shortReport?: string;
+      /** Gliederung */
+      outline?: string[];
       /**
        * Dokumenttyp
        *
@@ -1764,6 +1787,58 @@ export interface components {
        */
       label?: string;
     };
+    /**
+     * Represents a <a
+     * href="https://schema.org/DataCatalog">schema.org/DataCatalog</a>.
+     */
+    ZipDataCatalogSchema: {
+      /**
+       * @example
+       *   https://schema.org/
+       */
+      "@context"?: string;
+      /**
+       * @example
+       *   DataCatalog;
+       */
+      "@type"?: string;
+      /** The name of this data catalog. */
+      name: string;
+      /** The list of zip datasets contained in this catalog. */
+      dataSet: components["schemas"]["ZipDataSetSchema"][];
+    };
+    /**
+     * Represents <a
+     * href="https://schema.org/DataDownload">schema.org/DataDownload</a>.
+     */
+    ZipDataDownloadSchema: {
+      /**
+       * @example
+       *   DataDownload;
+       */
+      "@type"?: string;
+      /** Will always be application/zip. */
+      encodingFormat: string;
+      /** The url to download the zip file. */
+      contentUrl: string;
+    };
+    /**
+     * Represents <a
+     * href="https://schema.org/Dataset">schema.org/Dataset</a>.
+     */
+    ZipDataSetSchema: {
+      /**
+       * @example
+       *   Dataset;
+       */
+      "@type"?: string;
+      /** The name of the dataset. */
+      name: string;
+      /** A short summary describing the contents of the dataset. */
+      description: string;
+      /** The downloadable form of this dataset. */
+      distribution?: components["schemas"]["ZipDataDownloadSchema"];
+    };
     AdministrativeDirectiveSchema: {
       /**
        * @example
@@ -1880,19 +1955,20 @@ export interface operations {
         author?: string[];
         collaborator?: string[];
         /**
-         * Searches for the given tokens in searchTerm. If searchTerm contains
-         * more than one token, all tokens must be in the document for the
-         * document to match.
+         * Searches for the given tokens in searchTerm. If searchTerm
+         * contains more than one token, all tokens must be in the
+         * document for the document to match.
          */
         searchTerm?: string;
         /**
-         * The from (greater than or equal) parameter returns all entities where
-         * date is later than, or equal to, the given date.
+         * The from (greater than or equal) parameter returns all
+         * entities where date is later than, or equal to, the given
+         * date.
          */
         dateFrom?: string;
         /**
-         * The to (less than or equal) parameter returns all entities where date
-         * is earlier than, or equal to, the given date.
+         * The to (less than or equal) parameter returns all entities
+         * where date is earlier than, or equal to, the given date.
          */
         dateTo?: string;
         /**
@@ -1903,17 +1979,19 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the value 0
+         * The number of the page to request. The page starts with the
+         * value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance score
-         * calculated by OpenSearch. Valid usage of the sort field are : date
-         * and documentNumber and not setting the sort field (sort by relevance
-         * descending).Add a leading - to set the order to descending (-date)
+         * The field to sort the results by. Default is the relevance
+         * score calculated by OpenSearch. Valid usage of the sort field
+         * are : date and documentNumber and not setting the sort field
+         * (sort by relevance descending).Add a leading - to set the
+         * order to descending (-date)
          */
         sort?: string;
       };
@@ -2067,52 +2145,56 @@ export interface operations {
     parameters: {
       query?: {
         /**
-         * Search by European Legislation Identifier (ELI). Right now only
-         * searching by work ELI is supported, but a general eli prefix match
-         * might be supported in the future.
+         * Search by European Legislation Identifier (ELI). Right now
+         * only searching by work ELI is supported, but a general eli
+         * prefix match might be supported in the future.
          */
         eli?: string;
         /**
-         * Filters the result set to only return expressions that are in force
-         * _on or after_ the provided date. The parameter should be provided in
-         * `YYYY-MM-DD` format. Differs from `dateFrom`, which refers to the
-         * date of adoption or signature of the legislation. If both
-         * `temporalCoverageFrom` and `temporalCoverageTo` are given, this will
-         * output all expressions that were in force during at least one day
-         * between the two dates. To get all expressions for one specific day,
-         * set both parameters to the same day.
+         * Filters the result set to only return expressions that are in
+         * force _on or after_ the provided date. The parameter should
+         * be provided in `YYYY-MM-DD` format. Differs from `dateFrom`,
+         * which refers to the date of adoption or signature of the
+         * legislation. If both `temporalCoverageFrom` and
+         * `temporalCoverageTo` are given, this will output all
+         * expressions that were in force during at least one day
+         * between the two dates. To get all expressions for one
+         * specific day, set both parameters to the same day.
          */
         temporalCoverageFrom?: string;
         /**
-         * Filters the result set to only return expressions that are in force
-         * _on or before_ the provided date. The parameter should be provided in
-         * `YYYY-MM-DD` format. Differs from `dateTo`, which refers to the date
-         * of adoption or signature of the legislation.
+         * Filters the result set to only return expressions that are in
+         * force _on or before_ the provided date. The parameter should
+         * be provided in `YYYY-MM-DD` format. Differs from `dateTo`,
+         * which refers to the date of adoption or signature of the
+         * legislation.
          */
         temporalCoverageTo?: string;
         /**
-         * Filters the result set so every work returns exactly one expression.
-         * Most relevant is defined as : The expression in force on that date if
-         * it exists, then the expression that would next be in force if that
-         * exists, then the most recent expression that was in force. If other
-         * filters are used the work may return 0 expressions due to the most
-         * relevant expression being filtered out.
+         * Filters the result set so every work returns exactly one
+         * expression. Most relevant is defined as : The expression in
+         * force on that date if it exists, then the expression that
+         * would next be in force if that exists, then the most recent
+         * expression that was in force. If other filters are used the
+         * work may return 0 expressions due to the most relevant
+         * expression being filtered out.
          */
         mostRelevantOn?: string;
         /**
-         * Searches for the given tokens in searchTerm. If searchTerm contains
-         * more than one token, all tokens must be in the document for the
-         * document to match.
+         * Searches for the given tokens in searchTerm. If searchTerm
+         * contains more than one token, all tokens must be in the
+         * document for the document to match.
          */
         searchTerm?: string;
         /**
-         * The from (greater than or equal) parameter returns all entities where
-         * date is later than, or equal to, the given date.
+         * The from (greater than or equal) parameter returns all
+         * entities where date is later than, or equal to, the given
+         * date.
          */
         dateFrom?: string;
         /**
-         * The to (less than or equal) parameter returns all entities where date
-         * is earlier than, or equal to, the given date.
+         * The to (less than or equal) parameter returns all entities
+         * where date is earlier than, or equal to, the given date.
          */
         dateTo?: string;
         /**
@@ -2123,18 +2205,19 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the value 0
+         * The number of the page to request. The page starts with the
+         * value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance score
-         * calculated by OpenSearch. Valid usage of the sort field are : date,
-         * temporalCoverageFrom, legislationIdentifier and not setting the sort
-         * field (sort by relevance descending).Add a leading - to set the order
-         * to descending (-date)
+         * The field to sort the results by. Default is the relevance
+         * score calculated by OpenSearch. Valid usage of the sort field
+         * are : date, temporalCoverageFrom, legislationIdentifier and
+         * not setting the sort field (sort by relevance descending).Add
+         * a leading - to set the order to descending (-date)
          */
         sort?: string;
       };
@@ -2172,8 +2255,8 @@ export interface operations {
         /** Country or regional code for the jurisdiction */
         jurisdiction: "bund";
         /**
-         * Agent or authority issuing the legislation, e.g., 'bgbl-1' for
-         * Bundesgesetzblatt Teil I (Federal Law Gazette part I)
+         * Agent or authority issuing the legislation, e.g., 'bgbl-1'
+         * for Bundesgesetzblatt Teil I (Federal Law Gazette part I)
          *
          * @example
          *   bgbl - 1;
@@ -2187,8 +2270,8 @@ export interface operations {
          */
         year: string;
         /**
-         * Unique natural identifier for the legislation, specific to the
-         * jurisdiction and agent
+         * Unique natural identifier for the legislation, specific to
+         * the jurisdiction and agent
          *
          * @example
          *   s1325;
@@ -2245,8 +2328,8 @@ export interface operations {
          */
         jurisdiction: "bund";
         /**
-         * Agent or authority issuing the legislation, e.g., 'bgbl-1' for
-         * Bundesgesetzblatt Teil I (Federal Law Gazette part I)
+         * Agent or authority issuing the legislation, e.g., 'bgbl-1'
+         * for Bundesgesetzblatt Teil I (Federal Law Gazette part I)
          *
          * @example
          *   bgbl - 1;
@@ -2260,8 +2343,8 @@ export interface operations {
          */
         year: string;
         /**
-         * Unique natural identifier for the legislation, specific to the
-         * jurisdiction and agent
+         * Unique natural identifier for the legislation, specific to
+         * the jurisdiction and agent
          *
          * @example
          *   s1325;
@@ -2293,7 +2376,8 @@ export interface operations {
          */
         subtype: string;
         /**
-         * The expression identifier, denoting elements inside an expression
+         * The expression identifier, denoting elements inside an
+         * expression
          *
          * @example
          *   art - z1;
@@ -2337,8 +2421,8 @@ export interface operations {
          */
         jurisdiction: "bund";
         /**
-         * Agent or authority issuing the legislation, e.g., 'bgbl-1' for
-         * Bundesgesetzblatt Teil I (Federal Law Gazette part I)
+         * Agent or authority issuing the legislation, e.g., 'bgbl-1'
+         * for Bundesgesetzblatt Teil I (Federal Law Gazette part I)
          *
          * @example
          *   bgbl - 1;
@@ -2352,8 +2436,8 @@ export interface operations {
          */
         year: string;
         /**
-         * Unique natural identifier for the legislation, specific to the
-         * jurisdiction and agent
+         * Unique natural identifier for the legislation, specific to
+         * the jurisdiction and agent
          *
          * @example
          *   s1325;
@@ -2420,8 +2504,8 @@ export interface operations {
          */
         jurisdiction: "bund";
         /**
-         * Agent or authority issuing the legislation, e.g., 'bgbl-1' for
-         * Bundesgesetzblatt Teil I (Federal Law Gazette part I)
+         * Agent or authority issuing the legislation, e.g., 'bgbl-1'
+         * for Bundesgesetzblatt Teil I (Federal Law Gazette part I)
          *
          * @example
          *   bgbl - 1;
@@ -2435,8 +2519,8 @@ export interface operations {
          */
         year: string;
         /**
-         * Unique natural identifier for the legislation, specific to the
-         * jurisdiction and agent
+         * Unique natural identifier for the legislation, specific to
+         * the jurisdiction and agent
          *
          * @example
          *   s1325;
@@ -2505,8 +2589,8 @@ export interface operations {
          */
         jurisdiction: "bund";
         /**
-         * Agent or authority issuing the legislation, e.g., 'bgbl-1' for
-         * Bundesgesetzblatt Teil I (Federal Law Gazette part I)
+         * Agent or authority issuing the legislation, e.g., 'bgbl-1'
+         * for Bundesgesetzblatt Teil I (Federal Law Gazette part I)
          *
          * @example
          *   bgbl - 1;
@@ -2520,8 +2604,8 @@ export interface operations {
          */
         year: string;
         /**
-         * Unique natural identifier for the legislation, specific to the
-         * jurisdiction and agent
+         * Unique natural identifier for the legislation, specific to
+         * the jurisdiction and agent
          *
          * @example
          *   s1325;
@@ -2593,8 +2677,8 @@ export interface operations {
          */
         jurisdiction: "bund";
         /**
-         * Agent or authority issuing the legislation, e.g., 'bgbl-1' for
-         * Bundesgesetzblatt Teil I (Federal Law Gazette part I)
+         * Agent or authority issuing the legislation, e.g., 'bgbl-1'
+         * for Bundesgesetzblatt Teil I (Federal Law Gazette part I)
          *
          * @example
          *   bgbl - 1;
@@ -2608,8 +2692,8 @@ export interface operations {
          */
         year: string;
         /**
-         * Unique natural identifier for the legislation, specific to the
-         * jurisdiction and agent
+         * Unique natural identifier for the legislation, specific to
+         * the jurisdiction and agent
          *
          * @example
          *   s1325;
@@ -2685,27 +2769,29 @@ export interface operations {
     parameters: {
       query?: {
         /**
-         * Searches for the given tokens in searchTerm. If searchTerm contains
-         * more than one token, all tokens must be in the document for the
-         * document to match.
+         * Searches for the given tokens in searchTerm. If searchTerm
+         * contains more than one token, all tokens must be in the
+         * document for the document to match.
          */
         searchTerm?: string;
         /**
-         * The from (greater than or equal) parameter returns all entities where
-         * date is later than, or equal to, the given date.
+         * The from (greater than or equal) parameter returns all
+         * entities where date is later than, or equal to, the given
+         * date.
          */
         dateFrom?: string;
         /**
-         * The to (less than or equal) parameter returns all entities where date
-         * is earlier than, or equal to, the given date.
+         * The to (less than or equal) parameter returns all entities
+         * where date is earlier than, or equal to, the given date.
          */
         dateTo?: string;
         /**
-         * The field to sort the results by. Default is the relevance score
-         * calculated by OpenSearch. Valid usage of the sort field are : date,
-         * temporalCoverageFrom, legislationIdentifier, courtName,
-         * documentNumber and not setting the sort field (sort by relevance
-         * descending).Add a leading - to set the order to descending (-date)
+         * The field to sort the results by. Default is the relevance
+         * score calculated by OpenSearch. Valid usage of the sort field
+         * are : date, temporalCoverageFrom, legislationIdentifier,
+         * courtName, documentNumber and not setting the sort field
+         * (sort by relevance descending).Add a leading - to set the
+         * order to descending (-date)
          */
         sort?: string;
         /**
@@ -2716,19 +2802,21 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the value 0
+         * The number of the page to request. The page starts with the
+         * value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * Filters the result set so every work returns exactly one expression.
-         * Most relevant is defined as : The expression in force on that date if
-         * it exists, then the expression that would next be in force if that
-         * exists, then the most recent expression that was in force. If other
-         * filters are used the work may return 0 expressions due to the most
-         * relevant expression being filtered out.
+         * Filters the result set so every work returns exactly one
+         * expression. Most relevant is defined as : The expression in
+         * force on that date if it exists, then the expression that
+         * would next be in force if that exists, then the most recent
+         * expression that was in force. If other filters are used the
+         * work may return 0 expressions due to the most relevant
+         * expression being filtered out.
          *
          * @example
          *   2026 - 03 - 11;
@@ -2772,18 +2860,20 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the value 0
+         * The number of the page to request. The page starts with the
+         * value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance score
-         * calculated by OpenSearch. Valid usage of the sort field are : date,
-         * temporalCoverageFrom, legislationIdentifier, courtName,
-         * documentNumber and not setting the sort field (sort by relevance
-         * descending).Add a leading - to set the order to descending (-date)
+         * The field to sort the results by. Default is the relevance
+         * score calculated by OpenSearch. Valid usage of the sort field
+         * are : date, temporalCoverageFrom, legislationIdentifier,
+         * courtName, documentNumber and not setting the sort field
+         * (sort by relevance descending).Add a leading - to set the
+         * order to descending (-date)
          */
         sort?: string;
       };
@@ -2824,17 +2914,19 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the value 0
+         * The number of the page to request. The page starts with the
+         * value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance score
-         * calculated by OpenSearch. Valid usage of the sort field are : date
-         * and documentNumber and not setting the sort field (sort by relevance
-         * descending).Add a leading - to set the order to descending (-date)
+         * The field to sort the results by. Default is the relevance
+         * score calculated by OpenSearch. Valid usage of the sort field
+         * are : date and documentNumber and not setting the sort field
+         * (sort by relevance descending).Add a leading - to set the
+         * order to descending (-date)
          */
         sort?: string;
       };
@@ -2875,18 +2967,19 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the value 0
+         * The number of the page to request. The page starts with the
+         * value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance score
-         * calculated by OpenSearch. Valid usage of the sort field are : date,
-         * temporalCoverageFrom, legislationIdentifier and not setting the sort
-         * field (sort by relevance descending).Add a leading - to set the order
-         * to descending (-date)
+         * The field to sort the results by. Default is the relevance
+         * score calculated by OpenSearch. Valid usage of the sort field
+         * are : date, temporalCoverageFrom, legislationIdentifier and
+         * not setting the sort field (sort by relevance descending).Add
+         * a leading - to set the order to descending (-date)
          */
         sort?: string;
       };
@@ -2927,18 +3020,19 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the value 0
+         * The number of the page to request. The page starts with the
+         * value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance score
-         * calculated by OpenSearch. Valid usage of the sort field are : date,
-         * courtName, documentNumber and not setting the sort field (sort by
-         * relevance descending).Add a leading - to set the order to descending
-         * (-date)
+         * The field to sort the results by. Default is the relevance
+         * score calculated by OpenSearch. Valid usage of the sort field
+         * are : date, courtName, documentNumber and not setting the
+         * sort field (sort by relevance descending).Add a leading - to
+         * set the order to descending (-date)
          */
         sort?: string;
       };
@@ -2979,17 +3073,19 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the value 0
+         * The number of the page to request. The page starts with the
+         * value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance score
-         * calculated by OpenSearch. Valid usage of the sort field are : date
-         * and documentNumber and not setting the sort field (sort by relevance
-         * descending).Add a leading - to set the order to descending (-date)
+         * The field to sort the results by. Default is the relevance
+         * score calculated by OpenSearch. Valid usage of the sort field
+         * are : date and documentNumber and not setting the sort field
+         * (sort by relevance descending).Add a leading - to set the
+         * order to descending (-date)
          */
         sort?: string;
       };
@@ -3023,41 +3119,43 @@ export interface operations {
         fileNumber?: string;
         ecli?: string;
         /**
-         * Filter by court name (Finanzgericht Münster, FG Münster, ArbG Köln)
-         * or court type (Finanzgericht, FG, ArbG). Supports both long and short
-         * names.
+         * Filter by court name (Finanzgericht Münster, FG Münster, ArbG
+         * Köln) or court type (Finanzgericht, FG, ArbG). Supports both
+         * long and short names.
          */
         court?: string;
         /**
-         * Corresponds to “Rechtskraft”, meaning that the decision referred to
-         * is legally binding.
+         * Corresponds to “Rechtskraft”, meaning that the decision
+         * referred to is legally binding.
          */
         legalEffect?: "JA" | "NEIN" | "KEINE_ANGABE" | "FALSCHE_ANGABE";
         /**
-         * Filter by document type (Urteil, Versäumnisurteil, Entscheidung
-         * etc.). Multiple values may be specified as a comma-separated list or
-         * by repeating the parameter.
+         * Filter by document type (Urteil, Versäumnisurteil,
+         * Entscheidung etc.). Multiple values may be specified as a
+         * comma-separated list or by repeating the parameter.
          */
         type?: string[];
         /**
-         * Extended filter by type group. Multiple values may be specified as a
-         * comma-separated list or by repeating the parameter.
+         * Extended filter by type group. Multiple values may be
+         * specified as a comma-separated list or by repeating the
+         * parameter.
          */
         typeGroup?: "Urteil" | "Beschluss" | "other";
         /**
-         * Searches for the given tokens in searchTerm. If searchTerm contains
-         * more than one token, all tokens must be in the document for the
-         * document to match.
+         * Searches for the given tokens in searchTerm. If searchTerm
+         * contains more than one token, all tokens must be in the
+         * document for the document to match.
          */
         searchTerm?: string;
         /**
-         * The from (greater than or equal) parameter returns all entities where
-         * date is later than, or equal to, the given date.
+         * The from (greater than or equal) parameter returns all
+         * entities where date is later than, or equal to, the given
+         * date.
          */
         dateFrom?: string;
         /**
-         * The to (less than or equal) parameter returns all entities where date
-         * is earlier than, or equal to, the given date.
+         * The to (less than or equal) parameter returns all entities
+         * where date is earlier than, or equal to, the given date.
          */
         dateTo?: string;
         /**
@@ -3068,18 +3166,19 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the value 0
+         * The number of the page to request. The page starts with the
+         * value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance score
-         * calculated by OpenSearch. Valid usage of the sort field are : date,
-         * courtName, documentNumber and not setting the sort field (sort by
-         * relevance descending).Add a leading - to set the order to descending
-         * (-date)
+         * The field to sort the results by. Default is the relevance
+         * score calculated by OpenSearch. Valid usage of the sort field
+         * are : date, courtName, documentNumber and not setting the
+         * sort field (sort by relevance descending).Add a leading - to
+         * set the order to descending (-date)
          */
         sort?: string;
       };
@@ -3327,24 +3426,45 @@ export interface operations {
       };
     };
   };
+  getBulkZipLinks: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ZipDataCatalogSchema"];
+        };
+      };
+    };
+  };
   searchAndFilter_4: {
     parameters: {
       query?: {
         documentNumber?: string;
         /**
-         * Searches for the given tokens in searchTerm. If searchTerm contains
-         * more than one token, all tokens must be in the document for the
-         * document to match.
+         * Searches for the given tokens in searchTerm. If searchTerm
+         * contains more than one token, all tokens must be in the
+         * document for the document to match.
          */
         searchTerm?: string;
         /**
-         * The from (greater than or equal) parameter returns all entities where
-         * date is later than, or equal to, the given date.
+         * The from (greater than or equal) parameter returns all
+         * entities where date is later than, or equal to, the given
+         * date.
          */
         dateFrom?: string;
         /**
-         * The to (less than or equal) parameter returns all entities where date
-         * is earlier than, or equal to, the given date.
+         * The to (less than or equal) parameter returns all entities
+         * where date is earlier than, or equal to, the given date.
          */
         dateTo?: string;
         /**
@@ -3355,17 +3475,19 @@ export interface operations {
          */
         size?: number;
         /**
-         * The number of the page to request. The page starts with the value 0
+         * The number of the page to request. The page starts with the
+         * value 0
          *
          * @example
          *   0;
          */
         pageIndex?: number;
         /**
-         * The field to sort the results by. Default is the relevance score
-         * calculated by OpenSearch. Valid usage of the sort field are : date
-         * and documentNumber and not setting the sort field (sort by relevance
-         * descending).Add a leading - to set the order to descending (-date)
+         * The field to sort the results by. Default is the relevance
+         * score calculated by OpenSearch. Valid usage of the sort field
+         * are : date and documentNumber and not setting the sort field
+         * (sort by relevance descending).Add a leading - to set the
+         * order to descending (-date)
          */
         sort?: string;
       };

--- a/frontend/src/utils/search/searchResults.spec.ts
+++ b/frontend/src/utils/search/searchResults.spec.ts
@@ -45,13 +45,6 @@ describe("searchResults", () => {
       ]);
     });
 
-    it("returns only the sanitized texts for the requested name", () => {
-      expect(getMatches("headline", matches)).toEqual([
-        "The <mark>Main</mark> Title",
-        "Second headline",
-      ]);
-    });
-
     it("sanitizes disallowed tags from each match", () => {
       const m: TextMatch[] = [
         { name: "field", text: "<img src='x'/><mark>hit</mark>" },


### PR DESCRIPTION
- updates the backend to return highlights in table of contents for administrative directives
- shows highlights in different document sections in literature and administrative directive search results
- extracts highlight section creation into a shared composable for all document types