### PR TITLE
refactor:risdev-11833 refactor norms reindex

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
@@ -17,7 +17,6 @@ import java.time.LocalDate;
 import java.time.Month;
 import java.time.Period;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -27,7 +26,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.collections4.ListUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,7 +73,8 @@ public class IndexNormsService implements IndexService {
    */
   public void reindexAll(String startingTimestamp) {
     DateUtils.avoidOpenSearchSubMillisecondDateBug();
-    Set<WorkEli> workElis = getWorks(normsBucket.getAllKeysByPrefix("eli/").stream());
+    List<String> allFiles = normsBucket.getAllKeysByPrefix("eli/");
+    Map<WorkEli, List<String>> workElis = getWorks(allFiles.stream());
     processWorkEliUpdates(workElis, startingTimestamp);
     clearOldNorms(startingTimestamp);
   }
@@ -83,7 +82,7 @@ public class IndexNormsService implements IndexService {
   @Override
   public void indexChangelog(Changelog changelog) {
     try {
-      Set<WorkEli> workElis =
+      Map<WorkEli, List<String>> workElis =
           getWorks(Stream.concat(changelog.getChanged().stream(), changelog.getDeleted().stream()));
       processWorkEliUpdates(workElis, Instant.now().toString());
     } catch (IllegalArgumentException e) {
@@ -91,31 +90,29 @@ public class IndexNormsService implements IndexService {
     }
   }
 
-  private Set<WorkEli> getWorks(Stream<String> files) {
+  private Map<WorkEli, List<String>> getWorks(Stream<String> files) {
     return files
         .map(EliFile::fromString)
-        // this filters out the files that are not an EliFile
-        .flatMap(Optional::stream)
-        .map(EliFile::getWorkEli)
-        // collecting to a set makes sure each work eli occurs at most once
-        .collect(Collectors.toSet());
+        .flatMap(Optional::stream) // Filters out empty optionals, leaving Stream<EliFile>
+        .collect(
+            Collectors.groupingBy(
+                EliFile::getWorkEli, // Key: Group by the WorkEli
+                Collectors.mapping( // Value: Extract the filename and collect to a list
+                    EliFile::toString, Collectors.toList())));
   }
 
-  private void processWorkEliUpdates(Collection<WorkEli> workElis, String startingTimestamp) {
-    List<List<WorkEli>> batches = ListUtils.partition(workElis.stream().toList(), 100);
-    for (int i = 0; i < batches.size(); i++) {
-      List<WorkEli> oneBatch = batches.get(i);
-      logger.info("Indexing batch {} of {}", i + 1, batches.size());
-      for (WorkEli eli : oneBatch) {
-        processOneNormWork(eli, startingTimestamp);
-      }
+  private void processWorkEliUpdates(
+      Map<WorkEli, List<String>> workElis, String startingTimestamp) {
+    for (WorkEli eli : workElis.keySet()) {
+      processOneNormWork(eli, workElis.get(eli), startingTimestamp);
     }
   }
 
-  private void processOneNormWork(WorkEli workEli, String startingTimestamp) {
-    // Get all expressions for the current work from the bucket
+  private void processOneNormWork(
+      WorkEli workEli, List<String> filenames, String startingTimestamp) {
+
     Set<ExpressionEli> expressionElis =
-        normsBucket.getAllKeysByPrefix(workEli.toString() + "/").stream()
+        filenames.stream()
             .map(EliFile::fromString)
             .flatMap(Optional::stream)
             .map(EliFile::getExpressionEli)
@@ -125,7 +122,7 @@ public class IndexNormsService implements IndexService {
     List<Norm> normExpressions = new ArrayList<>();
     for (ExpressionEli expressionEli : expressionElis) {
       try {
-        getNormFromS3(expressionEli).ifPresent(normExpressions::add);
+        getNormFromS3(expressionEli, filenames).ifPresent(normExpressions::add);
       } catch (ObjectStoreServiceException e) {
         // If we can't get the content of an expression we log an error and move on
         // That means on failure of a work "changed" it will end up deleted
@@ -135,10 +132,8 @@ public class IndexNormsService implements IndexService {
 
     addTimeRelevanceWindows(workEli.toString(), normExpressions);
 
+    normsRepository.saveAll(normExpressions);
     for (Norm norm : normExpressions) {
-      // saving norms in a batch caused an error due to opensearch request being too large
-      //noinspection UseBulkOperation
-      normsRepository.save(norm);
       articlesRepository.saveAll(norm.getArticles());
     }
 
@@ -212,12 +207,12 @@ public class IndexNormsService implements IndexService {
     return !norm2.getEntryIntoForceDate().isAfter(norm1.getExpiryDate());
   }
 
-  private Optional<Norm> getNormFromS3(ExpressionEli expressionEli)
+  private Optional<Norm> getNormFromS3(ExpressionEli expressionEli, List<String> filenames)
       throws ObjectStoreServiceException {
 
     // Get all files for the current expression.
     final List<String> keysMatchingExpressionEli =
-        normsBucket.getAllKeysByPrefix(expressionEli.toString());
+        filenames.stream().filter(n -> n.startsWith(expressionEli.toString())).toList();
 
     Optional<String> newestFileName =
         keysMatchingExpressionEli.stream()

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
@@ -74,7 +74,7 @@ public class IndexNormsService implements IndexService {
   public void reindexAll(String startingTimestamp) {
     DateUtils.avoidOpenSearchSubMillisecondDateBug();
     List<String> allFiles = normsBucket.getAllKeysByPrefix("eli/");
-    Map<WorkEli, List<String>> workElis = getWorks(allFiles.stream());
+    Map<WorkEli, List<String>> workElis = groupFilesByWorkEli(allFiles.stream());
     processWorkEliUpdates(workElis, startingTimestamp);
     clearOldNorms(startingTimestamp);
   }
@@ -82,15 +82,33 @@ public class IndexNormsService implements IndexService {
   @Override
   public void indexChangelog(Changelog changelog) {
     try {
-      Map<WorkEli, List<String>> workElis =
+      Set<WorkEli> workElis =
           getWorks(Stream.concat(changelog.getChanged().stream(), changelog.getDeleted().stream()));
-      processWorkEliUpdates(workElis, Instant.now().toString());
+
+      Map<WorkEli, List<String>> allFilesByWorkEli = new HashMap<>();
+      workElis.forEach(
+          (workEli -> {
+            List<String> filesOfWork = normsBucket.getAllKeysByPrefix(workEli.toString() + "/");
+            allFilesByWorkEli.put(workEli, filesOfWork);
+          }));
+
+      processWorkEliUpdates(allFilesByWorkEli, Instant.now().toString());
     } catch (IllegalArgumentException e) {
       logger.error("Error while reading changelog file: {}", e.getMessage());
     }
   }
 
-  private Map<WorkEli, List<String>> getWorks(Stream<String> files) {
+  private Set<WorkEli> getWorks(Stream<String> files) {
+    return files
+        .map(EliFile::fromString)
+        // this filters out the files that are not an EliFile
+        .flatMap(Optional::stream)
+        .map(EliFile::getWorkEli)
+        // collecting to a set makes sure each work eli occurs at most once
+        .collect(Collectors.toSet());
+  }
+
+  private Map<WorkEli, List<String>> groupFilesByWorkEli(Stream<String> files) {
     return files
         .map(EliFile::fromString)
         .flatMap(Optional::stream) // Filters out empty optionals, leaving Stream<EliFile>

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
@@ -86,13 +86,10 @@ public class IndexNormsService implements IndexService {
           getWorks(Stream.concat(changelog.getChanged().stream(), changelog.getDeleted().stream()));
 
       // retrieve all file paths for the given workElis
-      Map<WorkEli, List<String>> allFilesByWorkEli =
-          workElis.stream()
-              .collect(
-                  Collectors.toMap(
-                      workEli -> workEli,
-                      workEli -> normsBucket.getAllKeysByPrefix(workEli.toString() + "/")));
-
+      Map<WorkEli, List<String>> allFilesByWorkEli = new HashMap<>();
+      for (WorkEli workEli : workElis) {
+        allFilesByWorkEli.put(workEli, normsBucket.getAllKeysByPrefix(workEli.toString() + "/"));
+      }
       processWorkEliUpdates(allFilesByWorkEli, Instant.now().toString());
     } catch (IllegalArgumentException e) {
       logger.error("Error while reading changelog file: {}", e.getMessage());
@@ -132,8 +129,16 @@ public class IndexNormsService implements IndexService {
 
   private void processWorkEliUpdates(
       Map<WorkEli, List<String>> workElis, String startingTimestamp) {
+    int processedWorkEli = 0;
+    int totalWorkElis = workElis.size();
+
     for (Map.Entry<WorkEli, List<String>> entry : workElis.entrySet()) {
       processOneNormWork(entry.getKey(), entry.getValue(), startingTimestamp);
+
+      processedWorkEli++;
+      if (processedWorkEli % 100 == 0 || processedWorkEli == totalWorkElis) {
+        logger.info("index progress: {}/{} works processed", processedWorkEli, totalWorkElis);
+      }
     }
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
@@ -85,12 +85,13 @@ public class IndexNormsService implements IndexService {
       Set<WorkEli> workElis =
           getWorks(Stream.concat(changelog.getChanged().stream(), changelog.getDeleted().stream()));
 
-      Map<WorkEli, List<String>> allFilesByWorkEli = new HashMap<>();
-      workElis.forEach(
-          (workEli -> {
-            List<String> filesOfWork = normsBucket.getAllKeysByPrefix(workEli.toString() + "/");
-            allFilesByWorkEli.put(workEli, filesOfWork);
-          }));
+      // retrieve all file paths for the given workElis
+      Map<WorkEli, List<String>> allFilesByWorkEli =
+          workElis.stream()
+              .collect(
+                  Collectors.toMap(
+                      workEli -> workEli,
+                      workEli -> normsBucket.getAllKeysByPrefix(workEli.toString() + "/")));
 
       processWorkEliUpdates(allFilesByWorkEli, Instant.now().toString());
     } catch (IllegalArgumentException e) {
@@ -98,6 +99,12 @@ public class IndexNormsService implements IndexService {
     }
   }
 
+  /**
+   * retrieves a Set of workElis from a stream of files
+   *
+   * @param files list of file paths
+   * @return Set of WorkElis
+   */
   private Set<WorkEli> getWorks(Stream<String> files) {
     return files
         .map(EliFile::fromString)
@@ -108,21 +115,25 @@ public class IndexNormsService implements IndexService {
         .collect(Collectors.toSet());
   }
 
+  /**
+   * takes a list of File paths and groups them by workEli
+   *
+   * @param files list of file paths
+   * @return Map of the paths grouped by workEli
+   */
   private Map<WorkEli, List<String>> groupFilesByWorkEli(Stream<String> files) {
     return files
         .map(EliFile::fromString)
-        .flatMap(Optional::stream) // Filters out empty optionals, leaving Stream<EliFile>
+        .flatMap(Optional::stream)
         .collect(
             Collectors.groupingBy(
-                EliFile::getWorkEli, // Key: Group by the WorkEli
-                Collectors.mapping( // Value: Extract the filename and collect to a list
-                    EliFile::toString, Collectors.toList())));
+                EliFile::getWorkEli, Collectors.mapping(EliFile::toString, Collectors.toList())));
   }
 
   private void processWorkEliUpdates(
       Map<WorkEli, List<String>> workElis, String startingTimestamp) {
-    for (WorkEli eli : workElis.keySet()) {
-      processOneNormWork(eli, workElis.get(eli), startingTimestamp);
+    for (Map.Entry<WorkEli, List<String>> entry : workElis.entrySet()) {
+      processOneNormWork(entry.getKey(), entry.getValue(), startingTimestamp);
     }
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexNormsServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexNormsServiceTest.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.search.unit.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -139,6 +140,7 @@ class IndexNormsServiceTest {
     String startingTimestamp = "2024-01-01T12:00:00Z";
     this.service.reindexAll(startingTimestamp);
 
+    verify(repo, times(1)).saveAll(any());
     verify(repo, times(1))
         .saveAll(
             argThat(

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexNormsServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexNormsServiceTest.java
@@ -1,7 +1,6 @@
 package de.bund.digitalservice.ris.search.unit.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -133,13 +132,6 @@ class IndexNormsServiceTest {
             List.of(
                 "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-1.xml",
                 "eli/not_an_eli"));
-    when(this.bucket.getAllKeysByPrefix("eli/bund/bgbl-1/1992/s101/"))
-        .thenReturn(
-            List.of("eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-1.xml"));
-
-    when(this.bucket.getAllKeysByPrefix("eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu"))
-        .thenReturn(
-            List.of("eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-1.xml"));
     when(this.bucket.getFileAsString(
             "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-1.xml"))
         .thenReturn(Optional.of(testContent));
@@ -147,9 +139,14 @@ class IndexNormsServiceTest {
     String startingTimestamp = "2024-01-01T12:00:00Z";
     this.service.reindexAll(startingTimestamp);
 
-    verify(repo, times(1)).save(any());
     verify(repo, times(1))
-        .save(argThat(arg -> "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu".equals(arg.getId())));
+        .saveAll(
+            argThat(
+                arg ->
+                    arg.iterator()
+                        .next()
+                        .getId()
+                        .equals("eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu")));
     verify(repo, times(1)).deleteByIndexedAtBefore(startingTimestamp);
   }
 


### PR DESCRIPTION
The goal of this PR is to reduce the number of list calls to s3 during a full reindex. In its current implementation, we make 2 additional s3 calls per document work after listing all files. When keeping the files in memory we can reduce this overhead completely. 

The works are still processed sequentially right now but instead of storing every expression of a work one after the other, we store the expressions in bulk.