### PR TITLE
RISDEV-10827 Extract tabs layout into dedicated component

### DIFF
--- a/frontend/src/components/TabsLayout.spec.ts
+++ b/frontend/src/components/TabsLayout.spec.ts
@@ -1,0 +1,148 @@
+import { mockNuxtImport, renderSuspended } from "@nuxt/test-utils/runtime";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
+import { nextTick, reactive } from "vue";
+import TabsLayout, { type TabView } from "./TabsLayout.vue";
+
+const { useRouteMock } = vi.hoisted(() => ({
+  useRouteMock: vi.fn(() => ({ query: {} })),
+}));
+
+mockNuxtImport("useRoute", () => useRouteMock);
+
+const IconA = { template: `<svg aria-label="icon-a" />` };
+const IconB = { template: `<svg aria-label="icon-b" />` };
+
+const views: OneOrMore<TabView> = [
+  { label: "Tab A", path: "view-a", icon: IconA },
+  { label: "Tab B", path: "view-b", icon: IconB, analyticsId: "tab-b" },
+];
+
+describe("TabsLayout", () => {
+  it("renders all tab labels", async () => {
+    useRouteMock.mockReturnValue({ query: {} });
+
+    await renderSuspended(TabsLayout, { props: { views } });
+
+    expect(screen.getByRole("tab", { name: /Tab A/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Tab B/i })).toBeInTheDocument();
+  });
+
+  it("renders tab icons", async () => {
+    useRouteMock.mockReturnValue({ query: {} });
+
+    await renderSuspended(TabsLayout, { props: { views } });
+
+    expect(screen.getByLabelText("icon-a")).toBeInTheDocument();
+    expect(screen.getByLabelText("icon-b")).toBeInTheDocument();
+  });
+
+  it("marks only the first tab as active when no query param is set", async () => {
+    useRouteMock.mockReturnValue({ query: {} });
+
+    await renderSuspended(TabsLayout, { props: { views } });
+
+    expect(screen.getByRole("tab", { name: /Tab A/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: /Tab B/i })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+  });
+
+  it("marks only the tab matching route.query.view as active", async () => {
+    useRouteMock.mockReturnValue({ query: { view: "view-b" } });
+
+    await renderSuspended(TabsLayout, { props: { views } });
+
+    expect(screen.getByRole("tab", { name: /Tab A/i })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+
+    expect(screen.getByRole("tab", { name: /Tab B/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("renders the named slot for the active view", async () => {
+    useRouteMock.mockReturnValue({ query: { view: "view-a" } });
+
+    await renderSuspended(TabsLayout, {
+      props: { views },
+      slots: { "view-a": "Content A" },
+    });
+
+    expect(screen.getByText("Content A")).toBeInTheDocument();
+  });
+
+  it("does not render the slot for an inactive view", async () => {
+    useRouteMock.mockReturnValue({ query: { view: "view-a" } });
+
+    await renderSuspended(TabsLayout, {
+      props: { views },
+      slots: { "view-a": "Content A", "view-b": "Content B" },
+    });
+
+    expect(screen.queryByText("Content B")).not.toBeInTheDocument();
+  });
+
+  it("renders tab links with the correct view query param", async () => {
+    useRouteMock.mockReturnValue({ query: {} });
+
+    await renderSuspended(TabsLayout, { props: { views } });
+
+    const tabA = screen.getByRole("tab", { name: /Tab A/i });
+    const tabB = screen.getByRole("tab", { name: /Tab B/i });
+
+    expect(tabA).toHaveAttribute(
+      "href",
+      expect.stringContaining("view=view-a"),
+    );
+    expect(tabB).toHaveAttribute(
+      "href",
+      expect.stringContaining("view=view-b"),
+    );
+  });
+
+  it("forwards analyticsId as data-attr on the tab", async () => {
+    useRouteMock.mockReturnValue({ query: {} });
+
+    await renderSuspended(TabsLayout, { props: { views } });
+
+    expect(screen.getByRole("tab", { name: /Tab B/i })).toHaveAttribute(
+      "data-attr",
+      "tab-b",
+    );
+  });
+
+  it("updates active tab and displayed slot when route query changes", async () => {
+    const route = reactive({ query: { view: "view-a" } });
+    useRouteMock.mockReturnValue(route);
+
+    await renderSuspended(TabsLayout, {
+      props: { views },
+      slots: { "view-a": "Content A", "view-b": "Content B" },
+    });
+
+    expect(screen.getByRole("tab", { name: /Tab A/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("Content A")).toBeInTheDocument();
+    expect(screen.queryByText("Content B")).not.toBeInTheDocument();
+
+    route.query = { view: "view-b" };
+    await nextTick();
+
+    expect(screen.getByRole("tab", { name: /Tab B/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("Content B")).toBeInTheDocument();
+    expect(screen.queryByText("Content A")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/TabsLayout.vue
+++ b/frontend/src/components/TabsLayout.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { Tab, TabList, Tabs } from "primevue";
+import { NuxtLink } from "#components";
+
+export type TabView = {
+  label: string;
+  path: string;
+  icon: Component;
+  analyticsId?: string;
+};
+
+const { views } = defineProps<{
+  views: OneOrMore<TabView>;
+}>();
+
+const route = useRoute();
+
+const currentView = computed(
+  () => route.query.view?.toString() ?? views[0].path,
+);
+</script>
+
+<template>
+  <div>
+    <div class="border-b border-gray-400">
+      <nav class="wrapper -mb-1 overflow-x-auto pt-1" aria-label="Tab">
+        <Tabs :value="currentView" :show-navigators="false">
+          <TabList>
+            <!-- Note that we need to override aria-controls manually,
+                otherwise PrimeVue will insert the ID of a tab panel that
+                doesn't exist -->
+            <Tab
+              v-for="view in views"
+              :key="view.path"
+              :value="view.path"
+              :as="NuxtLink"
+              :to="{ query: { view: view.path } }"
+              :aria-controls="undefined"
+              :data-attr="view.analyticsId"
+              class="flex items-center gap-8"
+            >
+              <component :is="view.icon" />
+              {{ view.label }}
+            </Tab>
+          </TabList>
+        </Tabs>
+      </nav>
+    </div>
+
+    <div id="content" class="min-h-96 bg-white print:py-0">
+      <div class="wrapper">
+        <slot :name="currentView" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/layouts/document.spec.ts
+++ b/frontend/src/layouts/document.spec.ts
@@ -3,7 +3,8 @@ import { screen } from "@testing-library/vue";
 import { describe, expect, it, vi } from "vitest";
 import IcBaselineSubject from "~icons/ic/baseline-subject";
 import IcOutlineInfo from "~icons/ic/outline-info";
-import DocumentLayout, { type DocumentView } from "./document.vue";
+import type { TabView } from "~/components/TabsLayout.vue";
+import DocumentLayout from "./document.vue";
 
 const { useRouteMock } = vi.hoisted(() => ({
   useRouteMock: vi.fn(() => ({ query: {} })),
@@ -11,7 +12,7 @@ const { useRouteMock } = vi.hoisted(() => ({
 
 mockNuxtImport("useRoute", () => useRouteMock);
 
-const defaultViews: OneOrMore<DocumentView> = [
+const defaultViews: OneOrMore<TabView> = [
   { label: "Text", path: "text", icon: IcBaselineSubject },
   { label: "Details", path: "details", icon: IcOutlineInfo },
 ];

--- a/frontend/src/layouts/document.vue
+++ b/frontend/src/layouts/document.vue
@@ -1,16 +1,8 @@
 <script setup lang="ts">
-import { Tab, TabList, Tabs } from "primevue";
-import { NuxtLink } from "#components";
 import type { BreadcrumbItem } from "~/components/Breadcrumbs.vue";
 import type { MetadataItem } from "~/components/Metadata.vue";
+import type { TabView } from "~/components/TabsLayout.vue";
 import BreadcrumbPageLayout from "./breadcrumbPage.vue";
-
-export type DocumentView = {
-  label: string;
-  path: string;
-  icon: Component;
-  analyticsId?: string;
-};
 
 const { titlePlaceholder = "Titelzeile nicht vorhanden", views } = defineProps<{
   title?: string;
@@ -18,14 +10,8 @@ const { titlePlaceholder = "Titelzeile nicht vorhanden", views } = defineProps<{
   isEmptyDocument?: boolean;
   breadcrumbs?: BreadcrumbItem[];
   metadata?: MetadataItem[];
-  views: OneOrMore<DocumentView>;
+  views: OneOrMore<TabView>;
 }>();
-
-const route = useRoute();
-
-const currentView = computed(
-  () => route.query.view?.toString() ?? views[0].path,
-);
 </script>
 
 <template>
@@ -64,36 +50,11 @@ const currentView = computed(
 
         <div v-else>
           <!-- Tabs -->
-          <div class="border-b border-gray-400">
-            <nav class="wrapper -mb-1" aria-label="Tab">
-              <Tabs :value="currentView" :show-navigators="false">
-                <TabList>
-                  <!-- Note that we need to override aria-controls manually,
-                otherwise PrimeVue will insert the ID of a tab panel that
-                doesn't exist -->
-                  <Tab
-                    v-for="view in views"
-                    :key="view.path"
-                    :value="view.path"
-                    :as="NuxtLink"
-                    :to="{ query: { view: view.path } }"
-                    :aria-controls="undefined"
-                    :data-attr="view.analyticsId"
-                    class="flex items-center gap-8"
-                  >
-                    <component :is="view.icon" />
-                    {{ view.label }}
-                  </Tab>
-                </TabList>
-              </Tabs>
-            </nav>
-          </div>
-
-          <div id="content" class="min-h-96 bg-white">
-            <div class="wrapper">
-              <slot :name="currentView" />
-            </div>
-          </div>
+          <TabsLayout :views>
+            <template v-for="(_, name) in $slots" #[name]>
+              <slot :name="name" />
+            </template>
+          </TabsLayout>
         </div>
       </div>
     </template>

--- a/frontend/src/pages/administrative-directives/[documentNumber].vue
+++ b/frontend/src/pages/administrative-directives/[documentNumber].vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import IcBaselineSubject from "~icons/ic/baseline-subject";
 import IcOutlineInfo from "~icons/ic/outline-info";
+import type { TabView } from "~/components/TabsLayout.vue";
 import type { TreeItem } from "~/components/TreeView.vue";
 import { useAdministrativeDirectiveSeo } from "~/composables/useAdministrativeDirectiveSeo";
-import type { DocumentView } from "~/layouts/document.vue";
 import { type AdministrativeDirective, DocumentKind } from "~/types/api";
 
 definePageMeta({
@@ -40,7 +40,7 @@ if (contentError?.value) showError(contentError.value);
 
 // Page contents ------------------------------------------
 
-const views: DocumentView[] = [
+const views: TabView[] = [
   { path: "text", label: "Text", icon: IcBaselineSubject },
   { path: "details", label: "Details", icon: IcOutlineInfo },
 ];

--- a/frontend/src/pages/case-law/[documentNumber].vue
+++ b/frontend/src/pages/case-law/[documentNumber].vue
@@ -3,9 +3,9 @@ import IcBaselineSubject from "~icons/ic/baseline-subject";
 import IcOutlineFileDownload from "~icons/ic/outline-file-download";
 import IcOutlineInfo from "~icons/ic/outline-info";
 import type { MetadataItem } from "~/components/Metadata.vue";
+import type { TabView } from "~/components/TabsLayout.vue";
 import type { TreeItem } from "~/components/TreeView.vue";
 import { useCaselawSeo } from "~/composables/useCaselawSeo";
-import type { DocumentView } from "~/layouts/document.vue";
 import { type CaseLaw, DocumentKind } from "~/types/api";
 
 definePageMeta({
@@ -42,7 +42,7 @@ useCaselawSeo({ caseLaw: caseLaw.value, document: document.value });
 
 // Page contents ------------------------------------------
 
-const views: DocumentView[] = [
+const views: TabView[] = [
   { path: "text", label: "Text", icon: IcBaselineSubject },
   {
     path: "details",

--- a/frontend/src/pages/literature/[documentNumber].vue
+++ b/frontend/src/pages/literature/[documentNumber].vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import IcBaselineSubject from "~icons/ic/baseline-subject";
 import IcOutlineInfo from "~icons/ic/outline-info";
+import type { TabView } from "~/components/TabsLayout.vue";
 import type { TreeItem } from "~/components/TreeView.vue";
 import { useLiteratureSeo } from "~/composables/useLiteratureSeo";
-import type { DocumentView } from "~/layouts/document.vue";
 import { DocumentKind, type Literature } from "~/types/api";
 
 definePageMeta({
@@ -41,7 +41,7 @@ if (contentError?.value) showError(contentError.value);
 
 // Page contents ------------------------------------------
 
-const views: DocumentView[] = [
+const views: TabView[] = [
   { path: "text", label: "Text", icon: IcBaselineSubject },
   {
     path: "details",

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Button, Tab, TabList, Tabs } from "primevue";
+import { Button } from "primevue";
 import IcBaselineSubject from "~icons/ic/baseline-subject";
 import IconFileDownload from "~icons/ic/outline-file-download";
 import IcOutlineInfo from "~icons/ic/outline-info";
@@ -7,6 +7,7 @@ import IcOutlineRestore from "~icons/ic/outline-settings-backup-restore";
 import { NuxtLink } from "#components";
 import type { BreadcrumbItem } from "~/components/Breadcrumbs.vue";
 import DateInput from "~/components/DateInput.vue";
+import type { TabView } from "~/components/TabsLayout.vue";
 import { useNormSeo } from "~/composables/useNormSeo";
 import { DocumentKind, type LegislationExpression } from "~/types/api";
 
@@ -118,7 +119,7 @@ const metadataItems = computed(() => {
   ];
 });
 
-const views = [
+const views: OneOrMore<TabView> = [
   {
     path: "text",
     label: "Text",
@@ -138,10 +139,6 @@ const views = [
     analyticsId: "norm-versions-tab",
   },
 ] as const;
-
-const currentView = computed(
-  () => route.query.view?.toString() ?? views[0].path,
-);
 
 const { dateFilterValue: fassungenDateFilterValue, filteredNormVersions } =
   useNormVersionFilter(normVersions);
@@ -182,180 +179,155 @@ const fassungenDateFilterInputId = useId();
         <Metadata :items="metadataItems" />
       </div>
 
-      <div class="border-b border-gray-400">
-        <nav class="wrapper -mb-1 overflow-x-auto pt-1" aria-label="Tab">
-          <Tabs :value="currentView" :show-navigators="false">
-            <TabList>
-              <Tab
-                v-for="view in views"
-                :key="view.path"
-                :value="view.path"
-                :as="NuxtLink"
-                :to="{ query: { view: view.path } }"
-                :aria-controls="undefined"
-                :data-attr="view.analyticsId"
-                class="flex items-center gap-8"
-              >
-                <component :is="view.icon" />
-                {{ view.label }}
-              </Tab>
-            </TabList>
-          </Tabs>
-        </nav>
-      </div>
-
-      <div id="content" class="min-h-96 bg-white print:py-0">
-        <section
-          v-if="currentView === 'text'"
-          role="tabpanel"
-          :aria-labelledby="textTabPanelTitleId"
-        >
-          <SidebarLayout class="wrapper">
-            <template #content>
-              <h2 :id="textTabPanelTitleId" class="sr-only">Text</h2>
-              <DocumentsIncompleteDataMessage />
-              <DocumentsNormsLegislationContent
-                :official-toc="htmlParts.officialToc"
-              >
-                <div v-html="htmlParts.body" />
-              </DocumentsNormsLegislationContent>
-            </template>
-
-            <template #sidebar v-if="tableOfContents?.length">
-              <client-only>
-                <DocumentsTableOfContents
-                  :subheading="normBreadcrumbTitle"
-                  :table-of-contents="tableOfContents"
-                />
-              </client-only>
-            </template>
-          </SidebarLayout>
-        </section>
-
-        <section
-          v-else-if="currentView === 'details'"
-          role="tabpanel"
-          :aria-labelledby="detailsTabPanelTitleId"
-        >
-          <div class="wrapper pt-32 pb-32 md:pb-56">
-            <h2 :id="detailsTabPanelTitleId" class="typo-headline3-bold">
-              Details
-            </h2>
-            <DocumentsIncompleteDataMessage class="my-24" />
-            <DetailsList>
-              <DetailsListEntry
-                label="Ausfertigungsdatum:"
-                :value="
-                  dateFormattedDDMMYYYY(metadata.exampleOfWork.legislationDate)
-                "
-              />
-              <DetailsListEntry
-                label="Vollzitat:"
-                :value="htmlParts.vollzitat"
-              />
-              <DetailsListEntry
-                label="Stand:"
-                :value-list="htmlParts.standangaben"
-              />
-              <DetailsListEntry
-                label="Hinweis zum Stand:"
-                :value-list="htmlParts.standangabenHinweis"
-              />
-              <DetailsListEntry
-                v-if="htmlParts.prefaceContainer"
-                label="Besonderer Hinweis:"
-              >
-                <div v-html="htmlParts.prefaceContainer" />
-              </DetailsListEntry>
-              <DetailsListEntry label="Fußnoten:">
-                <template v-if="htmlParts.headingNotes">
-                  <div class="footnotes" v-html="htmlParts.headingNotes" />
-                </template>
-              </DetailsListEntry>
-              <DetailsListEntry label="Download:">
-                <NuxtLink
-                  data-attr="xml-zip-view"
-                  class="typo-link-regular"
-                  external
-                  :to="zipUrl"
+      <TabsLayout :views>
+        <template #text>
+          <section role="tabpanel" :aria-labelledby="textTabPanelTitleId">
+            <SidebarLayout class="wrapper">
+              <template #content>
+                <h2 :id="textTabPanelTitleId" class="sr-only">Text</h2>
+                <DocumentsIncompleteDataMessage />
+                <DocumentsNormsLegislationContent
+                  :official-toc="htmlParts.officialToc"
                 >
-                  <IconFileDownload class="mr-2 inline" />
-                  {{ metadata.abbreviation ?? "Inhalte" }} als ZIP herunterladen
-                </NuxtLink>
-              </DetailsListEntry>
-            </DetailsList>
-          </div>
-        </section>
+                  <div v-html="htmlParts.body" />
+                </DocumentsNormsLegislationContent>
+              </template>
 
-        <section
-          v-else-if="currentView === 'versions'"
-          role="tabpanel"
-          :aria-labelledby="fassungenTabPanelTitleId"
-        >
-          <div class="wrapper pt-32 pb-32 md:pb-56">
-            <template v-if="privateFeaturesEnabled">
-              <h2 :id="fassungenTabPanelTitleId" class="typo-headline3-bold">
-                Fassungen
+              <template #sidebar v-if="tableOfContents?.length">
+                <client-only>
+                  <DocumentsTableOfContents
+                    :subheading="normBreadcrumbTitle"
+                    :table-of-contents="tableOfContents"
+                  />
+                </client-only>
+              </template>
+            </SidebarLayout>
+          </section>
+        </template>
+
+        <template #details>
+          <section role="tabpanel" :aria-labelledby="detailsTabPanelTitleId">
+            <div class="wrapper pt-32 pb-32 md:pb-56">
+              <h2 :id="detailsTabPanelTitleId" class="typo-headline3-bold">
+                Details
               </h2>
-
               <DocumentsIncompleteDataMessage class="my-24" />
-              <div class="my-16 md:my-24">
-                <label
-                  :for="fassungenDateFilterInputId"
-                  class="typo-label2-regular"
-                  >Gültig am</label
-                >
-                <DateInput
-                  v-model="fassungenDateFilterValue"
-                  class="mb-16 max-w-240 md:mb-24"
-                  :id="fassungenDateFilterInputId"
-                  :showClear="true"
+              <DetailsList>
+                <DetailsListEntry
+                  label="Ausfertigungsdatum:"
+                  :value="
+                    dateFormattedDDMMYYYY(
+                      metadata.exampleOfWork.legislationDate,
+                    )
+                  "
                 />
-              </div>
-              <DocumentsNormsNormVersionList
-                :status="normVersionsStatus"
-                :current-legislation-identifier="
-                  metadata.legislationIdentifier ?? ''
-                "
-                :versions="filteredNormVersions"
-              />
-            </template>
-
-            <div class="max-w-prose" v-else>
-              <h2
-                :id="fassungenTabPanelTitleId"
-                class="typo-headline3-bold mb-24"
-              >
-                Fassungen sind noch nicht verfügbar
-              </h2>
-              <p>
-                Mit dem Livegang des neuen Rechtsinformationsportals werden auch
-                außer Kraft getretene und zukünftig in Kraft tretende Fassungen
-                der Gesetze und Verordnungen zur Verfügung gestellt.
-              </p>
-
-              <h3 class="typo-headline3-bold mt-48 mb-24">
-                Unterstützen Sie uns bei der Entwicklung dieser Funktion
-              </h3>
-
-              <p>
-                Unser Ziel ist es, Rechtsinformationen für Bürgerinnen und
-                Bürger leichter zugänglich zu machen. Deshalb suchen wir
-                Menschen, die ihre Erfahrungen mit uns teilen und unseren
-                Service testen.
-              </p>
-
-              <Button
-                :as="NuxtLink"
-                class="mt-16"
-                :to="{ name: 'usage-tests' }"
-              >
-                Mehr über Nutzungstest erfahren
-              </Button>
+                <DetailsListEntry
+                  label="Vollzitat:"
+                  :value="htmlParts.vollzitat"
+                />
+                <DetailsListEntry
+                  label="Stand:"
+                  :value-list="htmlParts.standangaben"
+                />
+                <DetailsListEntry
+                  label="Hinweis zum Stand:"
+                  :value-list="htmlParts.standangabenHinweis"
+                />
+                <DetailsListEntry
+                  v-if="htmlParts.prefaceContainer"
+                  label="Besonderer Hinweis:"
+                >
+                  <div v-html="htmlParts.prefaceContainer" />
+                </DetailsListEntry>
+                <DetailsListEntry label="Fußnoten:">
+                  <template v-if="htmlParts.headingNotes">
+                    <div class="footnotes" v-html="htmlParts.headingNotes" />
+                  </template>
+                </DetailsListEntry>
+                <DetailsListEntry label="Download:">
+                  <NuxtLink
+                    data-attr="xml-zip-view"
+                    class="typo-link-regular"
+                    external
+                    :to="zipUrl"
+                  >
+                    <IconFileDownload class="mr-2 inline" />
+                    {{ metadata.abbreviation ?? "Inhalte" }} als ZIP
+                    herunterladen
+                  </NuxtLink>
+                </DetailsListEntry>
+              </DetailsList>
             </div>
-          </div>
-        </section>
-      </div>
+          </section>
+        </template>
+
+        <template #versions>
+          <section role="tabpanel" :aria-labelledby="fassungenTabPanelTitleId">
+            <div class="wrapper pt-32 pb-32 md:pb-56">
+              <template v-if="privateFeaturesEnabled">
+                <h2 :id="fassungenTabPanelTitleId" class="typo-headline3-bold">
+                  Fassungen
+                </h2>
+
+                <DocumentsIncompleteDataMessage class="my-24" />
+                <div class="my-16 md:my-24">
+                  <label
+                    :for="fassungenDateFilterInputId"
+                    class="typo-label2-regular"
+                    >Gültig am</label
+                  >
+                  <DateInput
+                    v-model="fassungenDateFilterValue"
+                    class="mb-16 max-w-240 md:mb-24"
+                    :id="fassungenDateFilterInputId"
+                    :showClear="true"
+                  />
+                </div>
+                <DocumentsNormsNormVersionList
+                  :status="normVersionsStatus"
+                  :current-legislation-identifier="
+                    metadata.legislationIdentifier ?? ''
+                  "
+                  :versions="filteredNormVersions"
+                />
+              </template>
+
+              <div class="max-w-prose" v-else>
+                <h2
+                  :id="fassungenTabPanelTitleId"
+                  class="typo-headline3-bold mb-24"
+                >
+                  Fassungen sind noch nicht verfügbar
+                </h2>
+                <p>
+                  Mit dem Livegang des neuen Rechtsinformationsportals werden
+                  auch außer Kraft getretene und zukünftig in Kraft tretende
+                  Fassungen der Gesetze und Verordnungen zur Verfügung gestellt.
+                </p>
+
+                <h3 class="typo-headline3-bold mt-48 mb-24">
+                  Unterstützen Sie uns bei der Entwicklung dieser Funktion
+                </h3>
+
+                <p>
+                  Unser Ziel ist es, Rechtsinformationen für Bürgerinnen und
+                  Bürger leichter zugänglich zu machen. Deshalb suchen wir
+                  Menschen, die ihre Erfahrungen mit uns teilen und unseren
+                  Service testen.
+                </p>
+
+                <Button
+                  :as="NuxtLink"
+                  class="mt-16"
+                  :to="{ name: 'usage-tests' }"
+                >
+                  Mehr über Nutzungstest erfahren
+                </Button>
+              </div>
+            </div>
+          </section>
+        </template>
+      </TabsLayout>
     </template>
   </NuxtLayout>
 </template>

--- a/frontend/src/pages/translations/[id].vue
+++ b/frontend/src/pages/translations/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Message, Tab, TabList, Tabs } from "primevue";
+import { Message } from "primevue";
 import { computed } from "vue";
 import IcBaselineSubject from "~icons/ic/baseline-subject";
 import IcOutlineInfo from "~icons/ic/outline-info";
@@ -8,6 +8,7 @@ import { NuxtLink } from "#components";
 import DetailsList from "~/components/DetailsList.vue";
 import DetailsListEntry from "~/components/DetailsListEntry.vue";
 import NormTranslationActionMenu from "~/components/documents/actionMenu/NormTranslationActionMenu.vue";
+import type { TabView } from "~/components/TabsLayout.vue";
 import {
   fetchTranslationAndHTML,
   getGermanOriginal,
@@ -70,7 +71,7 @@ const breadcrumbItems = computed(() => {
   ];
 });
 
-const views = [
+const views: OneOrMore<TabView> = [
   {
     path: "text",
     label: "Text",
@@ -85,10 +86,7 @@ const views = [
   },
 ] as const;
 
-const currentView = computed(
-  () => route.query.view?.toString() ?? views[0].path,
-);
-
+const textSectionId = useId();
 const detailsTabPanelTitleId = useId();
 </script>
 
@@ -139,37 +137,20 @@ const detailsTabPanelTitleId = useId();
         </Message>
       </div>
 
-      <div class="border-b border-gray-400">
-        <nav class="wrapper -mb-1">
-          <Tabs :value="currentView" :show-navigators="false">
-            <TabList>
-              <Tab
-                v-for="view in views"
-                :key="view.path"
-                :value="view.path"
-                :as="NuxtLink"
-                :to="{ query: { view: view.path } }"
-                :aria-controls="undefined"
-                :data-attr="view.analyticsId"
-                class="flex items-center gap-8"
-              >
-                <component :is="view.icon" />
-                {{ view.label }}
-              </Tab>
-            </TabList>
-          </Tabs>
-        </nav>
-      </div>
-
-      <div class="min-h-96 bg-white">
-        <div class="wrapper">
-          <section v-if="currentView === 'text'" class="pt-32 pb-32 md:pb-56">
-            <h2 class="sr-only">Text</h2>
+      <TabsLayout :views>
+        <template #text>
+          <section
+            class="pt-32 pb-32 md:pb-56"
+            role="tabpanel"
+            :aria-labelledby="textSectionId"
+          >
+            <h2 :id="textSectionId" class="sr-only">Text</h2>
             <section class="max-w-prose" v-html="html" />
           </section>
+        </template>
 
+        <template #details>
           <section
-            v-else-if="currentView === 'details'"
             class="pt-32 pb-32 md:pb-56"
             :aria-labelledby="detailsTabPanelTitleId"
           >
@@ -187,8 +168,8 @@ const detailsTabPanelTitleId = useId();
               />
             </DetailsList>
           </section>
-        </div>
-      </div>
+        </template>
+      </TabsLayout>
     </template>
   </NuxtLayout>
 </template>


### PR DESCRIPTION
- refactor tab layout usage by extracting it into a dedicated component
- reuse the `TabsLayout` component in all places where tabs are needed
- had to add vertical spacing around the translations page tab content -> this will probably be updated with the unify spacing PR

RISDEV-10827