### PR TITLE
RISDEV-11882 align pages to grid layout

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -36,6 +36,10 @@
   @apply mx-auto max-w-(--breakpoint-2xl) px-16 lg:px-24;
 }
 
+@utility base-grid {
+  @apply grid auto-rows-auto grid-cols-12 gap-x-8 md:gap-x-16 lg:gap-x-24;
+}
+
 mark {
   @apply bg-yellow-200;
 }

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -32,10 +32,8 @@
   }
 }
 
-@layer utilities {
-  .wrapper {
-    @apply mx-auto px-16 lg:px-24 2xl:max-w-(--breakpoint-2xl);
-  }
+@utility wrapper {
+  @apply mx-auto max-w-(--breakpoint-2xl) px-16 lg:px-24;
 }
 
 mark {

--- a/frontend/src/components/DetailsList.vue
+++ b/frontend/src/components/DetailsList.vue
@@ -1,5 +1,5 @@
 <template>
-  <dl data-testid="details-list" class="space-y-24">
+  <dl data-testid="details-list" class="base-grid gap-y-24">
     <slot />
   </dl>
 </template>

--- a/frontend/src/components/DetailsListEntry.vue
+++ b/frontend/src/components/DetailsListEntry.vue
@@ -19,33 +19,36 @@ const emptyValuePlaceholder = "nicht vorhanden";
 </script>
 
 <template>
-  <div
-    class="flex flex-col gap-8 md:grid md:grid-cols-4 md:gap-8 md:px-0 lg:grid-cols-5 xl:grid-cols-6"
-  >
-    <dt class="typo-label1-bold hyphens-auto">
+  <div class="col-span-12 grid grid-cols-subgrid">
+    <dt
+      class="typo-label1-bold col-span-12 hyphens-auto md:col-span-3 xl:col-span-2"
+    >
       {{ label }}
     </dt>
+
     <dd
       v-if="$slots.default"
-      class="typo-label1-regular max-w-prose md:col-span-3"
+      class="typo-label1-regular col-span-12 md:col-span-9 lg:col-span-6"
       :class="valueClass"
     >
       <div>
         <slot />
       </div>
     </dd>
+
     <dd
       v-for="listItem in valueList"
       v-else-if="valueList?.length"
       :key="listItem"
-      class="typo-label1-regular max-w-prose md:col-span-3 md:col-start-2"
+      class="typo-label1-regular col-span-12 md:col-span-9 md:col-start-4 lg:col-span-6 xl:col-start-3"
       :class="valueClass"
     >
       {{ listItem }}
     </dd>
+
     <dd
       v-else
-      class="typo-label1-regular max-w-prose data-empty:text-gray-900 md:col-span-3"
+      class="typo-label1-regular col-span-12 data-empty:text-gray-900 md:col-span-9 lg:col-span-6"
       :data-empty="emptyProp"
       :class="valueClass"
     >

--- a/frontend/src/components/SidebarLayout.spec.ts
+++ b/frontend/src/components/SidebarLayout.spec.ts
@@ -7,7 +7,7 @@ describe("SidebarLayout", () => {
   it("renders content and sidebar", async () => {
     await renderSuspended(SidebarLayout, {
       slots: {
-        content: "Main content",
+        default: "Main content",
         sidebar: "Sidebar content",
       },
     });
@@ -19,7 +19,7 @@ describe("SidebarLayout", () => {
   it("does not render the sidebar container when the sidebar slot is empty", async () => {
     const { container } = await renderSuspended(SidebarLayout, {
       slots: {
-        content: "Main content",
+        default: "Main content",
       },
     });
 

--- a/frontend/src/components/SidebarLayout.vue
+++ b/frontend/src/components/SidebarLayout.vue
@@ -1,19 +1,12 @@
-<script setup lang="ts">
-defineSlots<{
-  content(): unknown;
-  sidebar(): unknown;
-}>();
-</script>
-
 <template>
-  <div
-    class="grid grid-cols-1 grid-rows-1 items-start gap-16 md:grid-cols-3 print:block"
-  >
-    <div class="col-span-2 pt-32 pb-32 md:pb-56"><slot name="content" /></div>
+  <div class="base-grid print:block">
+    <div class="col-span-12 pt-32 pb-32 md:col-span-7 md:pb-56">
+      <slot />
+    </div>
 
     <div
       v-if="$slots.sidebar"
-      class="col-span-1 row-start-1 md:row-start-auto md:h-full md:border-l md:border-gray-400 print:hidden"
+      class="col-span-12 row-start-1 md:col-span-4 md:col-start-9 md:row-start-auto md:h-full md:border-l md:border-gray-400 print:hidden"
     >
       <div
         class="overflow-auto md:sticky md:top-0 md:max-h-[calc(min(100%,100dvh))]"

--- a/frontend/src/components/TabsLayout.vue
+++ b/frontend/src/components/TabsLayout.vue
@@ -47,7 +47,7 @@ const currentView = computed(
       </nav>
     </div>
 
-    <div class="min-h-96 bg-white print:py-0">
+    <div id="content" class="min-h-96 bg-white print:py-0">
       <div class="wrapper">
         <slot :name="currentView" />
       </div>

--- a/frontend/src/components/TabsLayout.vue
+++ b/frontend/src/components/TabsLayout.vue
@@ -47,7 +47,7 @@ const currentView = computed(
       </nav>
     </div>
 
-    <div id="content" class="min-h-96 bg-white print:py-0">
+    <div class="min-h-96 bg-white print:py-0">
       <div class="wrapper">
         <slot :name="currentView" />
       </div>

--- a/frontend/src/components/documents/IncompleteDataMessage.vue
+++ b/frontend/src/components/documents/IncompleteDataMessage.vue
@@ -5,7 +5,7 @@ import { Message } from "primevue";
 <template>
   <Message
     severity="warn"
-    class="ris-body2-regular max-w-prose"
+    class="ris-body2-regular"
     role="status"
     aria-live="off"
   >

--- a/frontend/src/components/documents/norms/LegislationContent.vue
+++ b/frontend/src/components/documents/norms/LegislationContent.vue
@@ -27,10 +27,6 @@ defineProps<{
 <style scoped>
 @reference "~/assets/main.css";
 
-.legislation {
-  @apply max-w-prose print:max-w-none;
-}
-
 /* AKN */
 :deep(.akn-act) {
   @apply flex flex-col gap-32 pt-24;
@@ -215,7 +211,7 @@ Attributes from the Juris CALS format without a corresponding HTML attribute mig
   h2,
   p,
   table {
-    @apply max-w-prose;
+    @apply max-w-full;
   }
 
   table.pgwide {

--- a/frontend/src/layouts/document.vue
+++ b/frontend/src/layouts/document.vue
@@ -22,41 +22,40 @@ const { titlePlaceholder = "Titelzeile nicht vorhanden", views } = defineProps<{
         <slot name="actionMenu" />
       </div>
     </template>
-    <template #default>
-      <div>
-        <!-- Header -->
-        <div class="wrapper text-left">
-          <DocumentsDocumentTitle
-            :title="title"
-            :placeholder="titlePlaceholder"
-          />
 
-          <Metadata
-            v-if="metadata?.length"
-            :items="metadata"
-            class="my-24 sm:my-32 md:my-40"
-          />
-        </div>
+    <div>
+      <!-- Header -->
+      <div class="wrapper text-left">
+        <DocumentsDocumentTitle
+          :title="title"
+          :placeholder="titlePlaceholder"
+        />
 
-        <!-- Empty documents -->
-        <div
-          v-if="isEmptyDocument"
-          class="min-h-96 border-t border-t-gray-400 bg-white print:py-0"
-        >
-          <div class="wrapper">
-            <slot name="details" />
-          </div>
-        </div>
+        <Metadata
+          v-if="metadata?.length"
+          :items="metadata"
+          class="my-24 sm:my-32 md:my-40"
+        />
+      </div>
 
-        <div v-else>
-          <!-- Tabs -->
-          <TabsLayout :views>
-            <template v-for="(_, name) in $slots" #[name]>
-              <slot :name="name" />
-            </template>
-          </TabsLayout>
+      <!-- Empty documents -->
+      <div
+        v-if="isEmptyDocument"
+        class="min-h-96 border-t border-t-gray-400 bg-white print:py-0"
+      >
+        <div class="wrapper">
+          <slot name="details" />
         </div>
       </div>
-    </template>
+
+      <div v-else>
+        <!-- Tabs -->
+        <TabsLayout :views>
+          <template v-for="(_, name) in $slots" #[name]>
+            <slot :name="name" />
+          </template>
+        </TabsLayout>
+      </div>
+    </div>
   </BreadcrumbPageLayout>
 </template>

--- a/frontend/src/layouts/markdownPage.vue
+++ b/frontend/src/layouts/markdownPage.vue
@@ -12,13 +12,11 @@ defineProps<{
       <slot name="breadcrumb" />
     </template>
 
-    <template #default>
-      <div class="wrapper pb-32 md:pb-56">
-        <div class="prose">
-          <MDC :value="staticContent"></MDC>
-        </div>
+    <div class="wrapper pb-32 md:pb-56">
+      <div class="prose">
+        <MDC :value="staticContent"></MDC>
       </div>
-    </template>
+    </div>
   </BreadcrumbPageLayout>
 </template>
 

--- a/frontend/src/layouts/markdownPage.vue
+++ b/frontend/src/layouts/markdownPage.vue
@@ -12,8 +12,10 @@ defineProps<{
       <slot name="breadcrumb" />
     </template>
 
-    <div class="wrapper pb-32 md:pb-56">
-      <div class="prose">
+    <div class="wrapper base-grid pb-32 md:pb-56">
+      <div
+        class="markdown-content col-span-12 md:col-span-9 lg:col-span-8 xl:col-span-7 2xl:col-span-6"
+      >
         <MDC :value="staticContent"></MDC>
       </div>
     </div>
@@ -31,9 +33,9 @@ defineProps<{
   styles defined here.
 
 see: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@scope */
-@scope (.prose) to (.no-prose) {
+@scope (.markdown-content) to (.no-markdown-content) {
   :scope {
-    @apply ris-body2-regular sm:ris-body1-regular max-w-prose 2xl:text-[1.25rem];
+    @apply ris-body2-regular sm:ris-body1-regular 2xl:text-[1.25rem];
   }
 
   h1 {

--- a/frontend/src/pages/about/content.md
+++ b/frontend/src/pages/about/content.md
@@ -10,7 +10,7 @@ Der Service wird gemeinsam vom Bundesministerium der Justiz und für Verbraucher
 
 Der Service enthält bereits eine erste Auswahl an Gesetzen, Verordnungen und Gerichtsentscheidungen. Während der Testphase kann es noch zu fehlenden Inhalten oder Darstellungsfehlern kommen. Ihr Feedback hilft uns, den Service weiter zu verbessern.
 
-::static-content-status-card-grid{class="no-prose my-24"}
+::static-content-status-card-grid{class="no-markdown-content my-24"}
 ::static-content-status-card{status="implemented"}
 #header
 Gesetze und Verordnungen
@@ -51,7 +51,7 @@ mit der unsere Daten direkt abgerufen werden können
 
 Wir entwickeln den Service stetig weiter und arbeiten an folgenden Inhalten und Funktionen:
 
-::static-content-status-card-grid{class="no-prose my-24"}
+::static-content-status-card-grid{class="no-markdown-content my-24"}
 ::static-content-status-card{status="in_progress"}
 #header
 Verwaltungsvorschriften

--- a/frontend/src/pages/administrative-directives/[documentNumber].vue
+++ b/frontend/src/pages/administrative-directives/[documentNumber].vue
@@ -117,17 +117,15 @@ const detailItems = computed(() =>
 
     <template #text>
       <SidebarLayout>
-        <template #content>
-          <section role="tabpanel" :aria-labelledby="textSectionId">
-            <h2 :id="textSectionId" class="sr-only">Text</h2>
-            <DocumentsIncompleteDataMessage />
-            <div
-              v-if="document"
-              class="administrative-directive"
-              v-html="document.body.innerHTML"
-            ></div>
-          </section>
-        </template>
+        <section role="tabpanel" :aria-labelledby="textSectionId">
+          <h2 :id="textSectionId" class="sr-only">Text</h2>
+          <DocumentsIncompleteDataMessage />
+          <div
+            v-if="document"
+            class="administrative-directive"
+            v-html="document.body.innerHTML"
+          ></div>
+        </section>
 
         <template #sidebar>
           <client-only>

--- a/frontend/src/pages/advanced-search/index.vue
+++ b/frontend/src/pages/advanced-search/index.vue
@@ -296,7 +296,7 @@ watch(searchStatus, async (newStatus, oldStatus) => {
           />
         </div>
 
-        <div id="search" class="col-span-12 lg:col-span-7">
+        <div class="col-span-12 lg:col-span-7">
           <Pagination
             v-if="searchStatus !== 'idle'"
             :is-loading="searchStatus === 'pending'"

--- a/frontend/src/pages/advanced-search/index.vue
+++ b/frontend/src/pages/advanced-search/index.vue
@@ -219,10 +219,8 @@ watch(searchStatus, async (newStatus, oldStatus) => {
       <Breadcrumbs :items="[{ label: 'Erweiterte Suche' }]" />
     </template>
 
-    <div
-      class="wrapper grid grid-cols-1 gap-40 pb-32 md:pb-56 lg:grid-cols-[20rem_1fr] lg:gap-64"
-    >
-      <div class="lg:col-span-2">
+    <div class="wrapper base-grid gap-y-40 pb-32 md:pb-56 lg:gap-y-64">
+      <div class="col-span-12">
         <h1 class="typo-headline1-bold mb-16">Erweiterte Suche</h1>
         <p class="text-balance">
           Nutzen Sie die erweiterte Suche, um genau das zu finden, was Sie
@@ -233,7 +231,7 @@ watch(searchStatus, async (newStatus, oldStatus) => {
       </div>
 
       <aside
-        class="row-start-3 lg:row-span-2 lg:row-start-auto"
+        class="col-span-12 lg:col-span-4 lg:row-span-2 xl:col-span-3"
         aria-label="Filter"
       >
         <fieldset class="mb-40">
@@ -251,7 +249,7 @@ watch(searchStatus, async (newStatus, oldStatus) => {
         />
       </aside>
 
-      <div id="search" class="row-start-2 lg:row-start-auto">
+      <div id="search" class="col-span-12 lg:col-span-8 lg:col-start-5">
         <SearchDataFieldPicker
           v-model="localQuery"
           :data-fields="queryableDataFields"
@@ -263,60 +261,67 @@ watch(searchStatus, async (newStatus, oldStatus) => {
         />
       </div>
 
-      <div ref="resultsContainerRef" id="search-results" class="scroll-mt-16">
-        <Pagination
-          v-if="searchStatus !== 'idle'"
-          :is-loading="searchStatus === 'pending'"
-          :page="searchResults"
-          navigation-position="bottom"
-          @update-page="handlePageUpdate"
+      <div
+        ref="resultsContainerRef"
+        id="search-results"
+        class="col-span-12 grid scroll-mt-16 grid-cols-subgrid gap-y-32 lg:col-span-8 lg:col-start-5"
+      >
+        <div
+          class="col-span-12 flex flex-col gap-16 md:flex-row md:items-center md:gap-48 lg:col-span-8"
         >
-          <div
-            class="mb-32 flex flex-col gap-16 md:flex-row md:items-center md:gap-48"
+          <output
+            aria-atomic="true"
+            aria-live="polite"
+            class="typo-label2-regular mr-auto text-nowrap"
           >
-            <output
-              aria-atomic="true"
-              aria-live="polite"
-              class="typo-label2-regular mr-auto text-nowrap"
-            >
-              {{ formattedResultCount }}
-            </output>
+            {{ formattedResultCount }}
+          </output>
 
-            <div class="flex items-center gap-8">
-              <label :id="itemsPerPageLabelId" class="typo-label2-regular">
-                Einträge pro Seite
-              </label>
-              <Select
-                :model-value="itemsPerPage"
-                :aria-labelledby="itemsPerPageLabelId"
-                :options="itemsPerPageOptions"
-                @update:model-value="updateItemsPerPage"
-              />
-            </div>
-
-            <SearchSortSelect
-              :model-value="sort"
-              :document-kind
-              @update:model-value="updateSort"
+          <div class="flex items-center gap-8">
+            <label :id="itemsPerPageLabelId" class="typo-label2-regular">
+              Einträge pro Seite
+            </label>
+            <Select
+              :model-value="itemsPerPage"
+              :aria-labelledby="itemsPerPageLabelId"
+              :options="itemsPerPageOptions"
+              @update:model-value="updateItemsPerPage"
             />
           </div>
 
-          <div class="max-w-prose">
+          <SearchSortSelect
+            :model-value="sort"
+            :document-kind
+            @update:model-value="updateSort"
+          />
+        </div>
+
+        <div id="search" class="col-span-12 lg:col-span-7">
+          <Pagination
+            v-if="searchStatus !== 'idle'"
+            :is-loading="searchStatus === 'pending'"
+            :page="searchResults"
+            navigation-position="bottom"
+            @update-page="handlePageUpdate"
+          >
             <Message v-if="!!searchError" severity="error">
               {{ searchError.message }}
             </Message>
 
-            <ul v-if="searchResults" aria-label="Suchergebnisse">
+            <ul
+              v-if="searchResults"
+              aria-label="Suchergebnisse"
+              class="space-y-40"
+            >
               <li
                 v-for="(searchResult, order) in searchResults.member"
                 :key="getIdentifier(searchResult.item)"
-                class="my-40"
               >
                 <SearchResult :search-result :order />
               </li>
             </ul>
-          </div>
-        </Pagination>
+          </Pagination>
+        </div>
       </div>
     </div>
   </NuxtLayout>

--- a/frontend/src/pages/advanced-search/index.vue
+++ b/frontend/src/pages/advanced-search/index.vue
@@ -218,107 +218,106 @@ watch(searchStatus, async (newStatus, oldStatus) => {
     <template #breadcrumb>
       <Breadcrumbs :items="[{ label: 'Erweiterte Suche' }]" />
     </template>
-    <template #default>
-      <div
-        class="wrapper grid grid-cols-1 gap-40 pb-32 md:pb-56 lg:grid-cols-[20rem_1fr] lg:gap-64"
+
+    <div
+      class="wrapper grid grid-cols-1 gap-40 pb-32 md:pb-56 lg:grid-cols-[20rem_1fr] lg:gap-64"
+    >
+      <div class="lg:col-span-2">
+        <h1 class="typo-headline1-bold mb-16">Erweiterte Suche</h1>
+        <p class="text-balance">
+          Nutzen Sie die erweiterte Suche, um genau das zu finden, was Sie
+          brauchen – ob im Leitsatz, Titel oder direkt im Volltext. Mit
+          Suchoperatoren wie AND, OR und NOT bekommen Sie noch präzisere
+          Ergebnisse.
+        </p>
+      </div>
+
+      <aside
+        class="row-start-3 lg:row-span-2 lg:row-start-auto"
+        aria-label="Filter"
       >
-        <div class="lg:col-span-2">
-          <h1 class="typo-headline1-bold mb-16">Erweiterte Suche</h1>
-          <p class="text-balance">
-            Nutzen Sie die erweiterte Suche, um genau das zu finden, was Sie
-            brauchen – ob im Leitsatz, Titel oder direkt im Volltext. Mit
-            Suchoperatoren wie AND, OR und NOT bekommen Sie noch präzisere
-            Ergebnisse.
-          </p>
-        </div>
+        <fieldset class="mb-40">
+          <legend class="typo-label1-bold mb-8">Dokumentart</legend>
+          <PanelMenu
+            :model="documentKindMenuItems"
+            :expanded-keys="{ [documentKind]: true }"
+          />
+        </fieldset>
 
-        <aside
-          class="row-start-3 lg:row-span-2 lg:row-start-auto"
-          aria-label="Filter"
+        <SearchDateFilter
+          v-model="localDateFilter"
+          :document-kind
+          @update:model-value="updateDateFilter"
+        />
+      </aside>
+
+      <div id="search" class="row-start-2 lg:row-start-auto">
+        <SearchDataFieldPicker
+          v-model="localQuery"
+          :data-fields="queryableDataFields"
+          :document-kind
+          :loading="searchStatus === 'pending'"
+          :form-id="searchFormId"
+          :count
+          @submit="submit"
+        />
+      </div>
+
+      <div ref="resultsContainerRef" id="search-results" class="scroll-mt-16">
+        <Pagination
+          v-if="searchStatus !== 'idle'"
+          :is-loading="searchStatus === 'pending'"
+          :page="searchResults"
+          navigation-position="bottom"
+          @update-page="handlePageUpdate"
         >
-          <fieldset class="mb-40">
-            <legend class="typo-label1-bold mb-8">Dokumentart</legend>
-            <PanelMenu
-              :model="documentKindMenuItems"
-              :expanded-keys="{ [documentKind]: true }"
-            />
-          </fieldset>
-
-          <SearchDateFilter
-            v-model="localDateFilter"
-            :document-kind
-            @update:model-value="updateDateFilter"
-          />
-        </aside>
-
-        <div id="search" class="row-start-2 lg:row-start-auto">
-          <SearchDataFieldPicker
-            v-model="localQuery"
-            :data-fields="queryableDataFields"
-            :document-kind
-            :loading="searchStatus === 'pending'"
-            :form-id="searchFormId"
-            :count
-            @submit="submit"
-          />
-        </div>
-
-        <div ref="resultsContainerRef" id="search-results" class="scroll-mt-16">
-          <Pagination
-            v-if="searchStatus !== 'idle'"
-            :is-loading="searchStatus === 'pending'"
-            :page="searchResults"
-            navigation-position="bottom"
-            @update-page="handlePageUpdate"
+          <div
+            class="mb-32 flex flex-col gap-16 md:flex-row md:items-center md:gap-48"
           >
-            <div
-              class="mb-32 flex flex-col gap-16 md:flex-row md:items-center md:gap-48"
+            <output
+              aria-atomic="true"
+              aria-live="polite"
+              class="typo-label2-regular mr-auto text-nowrap"
             >
-              <output
-                aria-atomic="true"
-                aria-live="polite"
-                class="typo-label2-regular mr-auto text-nowrap"
-              >
-                {{ formattedResultCount }}
-              </output>
+              {{ formattedResultCount }}
+            </output>
 
-              <div class="flex items-center gap-8">
-                <label :id="itemsPerPageLabelId" class="typo-label2-regular">
-                  Einträge pro Seite
-                </label>
-                <Select
-                  :model-value="itemsPerPage"
-                  :aria-labelledby="itemsPerPageLabelId"
-                  :options="itemsPerPageOptions"
-                  @update:model-value="updateItemsPerPage"
-                />
-              </div>
-
-              <SearchSortSelect
-                :model-value="sort"
-                :document-kind
-                @update:model-value="updateSort"
+            <div class="flex items-center gap-8">
+              <label :id="itemsPerPageLabelId" class="typo-label2-regular">
+                Einträge pro Seite
+              </label>
+              <Select
+                :model-value="itemsPerPage"
+                :aria-labelledby="itemsPerPageLabelId"
+                :options="itemsPerPageOptions"
+                @update:model-value="updateItemsPerPage"
               />
             </div>
 
-            <div class="max-w-prose">
-              <Message v-if="!!searchError" severity="error">
-                {{ searchError.message }}
-              </Message>
+            <SearchSortSelect
+              :model-value="sort"
+              :document-kind
+              @update:model-value="updateSort"
+            />
+          </div>
 
-              <ul v-if="searchResults" aria-label="Suchergebnisse">
-                <li
-                  v-for="(searchResult, order) in searchResults.member"
-                  :key="getIdentifier(searchResult.item)"
-                  class="my-40"
-                >
-                  <SearchResult :search-result :order />
-                </li>
-              </ul>
-            </div>
-          </Pagination>
-        </div>
+          <div class="max-w-prose">
+            <Message v-if="!!searchError" severity="error">
+              {{ searchError.message }}
+            </Message>
+
+            <ul v-if="searchResults" aria-label="Suchergebnisse">
+              <li
+                v-for="(searchResult, order) in searchResults.member"
+                :key="getIdentifier(searchResult.item)"
+                class="my-40"
+              >
+                <SearchResult :search-result :order />
+              </li>
+            </ul>
+          </div>
+        </Pagination>
       </div>
-    </template>
+    </div>
   </NuxtLayout>
 </template>

--- a/frontend/src/pages/case-law/[documentNumber].vue
+++ b/frontend/src/pages/case-law/[documentNumber].vue
@@ -160,17 +160,15 @@ const detailsSectionId = useId();
 
     <template #text>
       <SidebarLayout>
-        <template #content>
-          <section role="tabpanel" :aria-labelledby="textSectionId">
-            <h2 :id="textSectionId" class="sr-only">Text</h2>
-            <DocumentsIncompleteDataMessage />
-            <div
-              v-if="document"
-              class="case-law"
-              v-html="document.body.innerHTML"
-            ></div>
-          </section>
-        </template>
+        <section role="tabpanel" :aria-labelledby="textSectionId">
+          <h2 :id="textSectionId" class="sr-only">Text</h2>
+          <DocumentsIncompleteDataMessage />
+          <div
+            v-if="document"
+            class="case-law"
+            v-html="document.body.innerHTML"
+          ></div>
+        </section>
 
         <template #sidebar v-if="tocEntries?.length">
           <client-only>

--- a/frontend/src/pages/cookie-settings/content.md
+++ b/frontend/src/pages/cookie-settings/content.md
@@ -2,7 +2,7 @@
 
 ## Sind Sie mit der Nutzung von Analyse-Cookies einverstanden?
 
-:static-content-consent-status{class="no-prose my-24"}
+:static-content-consent-status{class="no-markdown-content my-24"}
 
 Nachfolgend informieren wir Sie darüber, welche Cookies auf der Webseite **testphase.rechtsinformationen.bund.de** eingesetzt werden. Cookies sind kleine Textdateien, die auf dem Datenträger des Nutzenden gespeichert werden und über den Browser bestimmte Einstellungen und Daten mit dem System des BMJ austauschen.
 

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -46,9 +46,11 @@ const privateFeaturesEnabled = usePrivateFeaturesFlag();
   </div>
 
   <div
-    class="wrapper flex flex-col gap-16 pt-16 pb-32 sm:gap-24 sm:pt-24 md:pb-56"
+    class="wrapper base-grid gap-y-16 pt-16 pb-32 sm:gap-y-24 sm:pt-24 md:pb-56"
   >
-    <FeatureCard>
+    <FeatureCard
+      class="col-span-12 lg:col-span-10 lg:col-start-2 xl:col-span-8 xl:col-start-3"
+    >
       <div>
         <h2 class="typo-headline2-bold wrap-break-word hyphens-auto">
           Testen Sie die Suche
@@ -82,7 +84,9 @@ const privateFeaturesEnabled = usePrivateFeaturesFlag();
       </Message>
     </FeatureCard>
 
-    <FeatureCard>
+    <FeatureCard
+      class="col-span-12 lg:col-span-10 lg:col-start-2 xl:col-span-8 xl:col-start-3"
+    >
       <div>
         <h2 class="typo-headline2-bold wrap-break-word hyphens-auto">
           Testen Sie die Darstellung aktueller Gesetze, Verordnungen und
@@ -103,7 +107,10 @@ const privateFeaturesEnabled = usePrivateFeaturesFlag();
       </div>
     </FeatureCard>
 
-    <FeatureCard v-if="privateFeaturesEnabled">
+    <FeatureCard
+      class="col-span-12 lg:col-span-10 lg:col-start-2 xl:col-span-8 xl:col-start-3"
+      v-if="privateFeaturesEnabled"
+    >
       <div>
         <h2 class="typo-headline2-bold wrap-break-word hyphens-auto">
           English translation of German laws and regulations
@@ -121,7 +128,9 @@ const privateFeaturesEnabled = usePrivateFeaturesFlag();
       </div>
     </FeatureCard>
 
-    <FeatureCard>
+    <FeatureCard
+      class="col-span-12 lg:col-span-10 lg:col-start-2 xl:col-span-8 xl:col-start-3"
+    >
       <div>
         <h2 class="typo-headline2-bold wrap-break-word hyphens-auto">
           Testen Sie die Programmierschnittstelle
@@ -144,7 +153,10 @@ const privateFeaturesEnabled = usePrivateFeaturesFlag();
       </div>
     </FeatureCard>
 
-    <FeatureCard inner-class="gap-x-64 gap-y-32 md:flex-row">
+    <FeatureCard
+      class="col-span-12 lg:col-span-10 lg:col-start-2 xl:col-span-8 xl:col-start-3"
+      inner-class="gap-x-64 gap-y-32 md:flex-row"
+    >
       <img
         class="mt-20 ml-20 self-start md:mt-4 md:ml-0"
         :src="bmjvLogo"

--- a/frontend/src/pages/literature/[documentNumber].vue
+++ b/frontend/src/pages/literature/[documentNumber].vue
@@ -119,17 +119,15 @@ const detailItems = computed(() => getLiteratureDetailItems(literature.value));
 
     <template #text>
       <SidebarLayout>
-        <template #content>
-          <section role="tabpanel" :aria-labelledby="textSectionId">
-            <h2 :id="textSectionId" class="sr-only">Text</h2>
-            <DocumentsIncompleteDataMessage />
-            <div
-              v-if="document"
-              class="literature"
-              v-html="document.body.innerHTML"
-            ></div>
-          </section>
-        </template>
+        <section role="tabpanel" :aria-labelledby="textSectionId">
+          <h2 :id="textSectionId" class="sr-only">Text</h2>
+          <DocumentsIncompleteDataMessage />
+          <div
+            v-if="document"
+            class="literature"
+            v-html="document.body.innerHTML"
+          ></div>
+        </section>
 
         <template #sidebar>
           <client-only>

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -230,7 +230,7 @@ const metadataItems = computed(() => {
 
       <div class="border-t border-t-gray-400 bg-white">
         <SidebarLayout class="wrapper">
-          <template v-if="!!articleHtml" #content>
+          <template v-if="!!articleHtml">
             <DocumentsIncompleteDataMessage />
             <DocumentsNormsLegislationContent single-article>
               <div class="akn-act" v-html="articleHtml" />

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -207,75 +207,74 @@ const metadataItems = computed(() => {
         </div>
       </div>
     </template>
-    <template #default>
-      <div
-        class="wrapper mb-24 space-y-24 sm:mb-32 sm:space-y-32 md:mb-40 md:space-y-40"
-      >
-        <p class="typo-headline3-regular mb-8">
-          {{ normTitle }}
-        </p>
-        <h1
-          class="typo-headline1-bold wrap-break-word hyphens-auto"
-          v-html="htmlTitle"
-        />
 
-        <DocumentsNormsArticleVersionWarning
-          v-if="inForceNormLink && article"
-          :in-force-version-link="inForceNormLink"
-          :current-article="article"
-        />
+    <div
+      class="wrapper mb-24 space-y-24 sm:mb-32 sm:space-y-32 md:mb-40 md:space-y-40"
+    >
+      <p class="typo-headline3-regular mb-8">
+        {{ normTitle }}
+      </p>
+      <h1
+        class="typo-headline1-bold wrap-break-word hyphens-auto"
+        v-html="htmlTitle"
+      />
 
-        <Metadata v-if="privateFeaturesEnabled" :items="metadataItems" />
-      </div>
+      <DocumentsNormsArticleVersionWarning
+        v-if="inForceNormLink && article"
+        :in-force-version-link="inForceNormLink"
+        :current-article="article"
+      />
 
-      <div class="border-t border-t-gray-400 bg-white">
-        <SidebarLayout class="wrapper">
-          <template v-if="!!articleHtml">
-            <DocumentsIncompleteDataMessage />
-            <DocumentsNormsLegislationContent single-article>
-              <div class="akn-act" v-html="articleHtml" />
-            </DocumentsNormsLegislationContent>
+      <Metadata v-if="privateFeaturesEnabled" :items="metadataItems" />
+    </div>
 
-            <nav class="flex flex-row justify-between" aria-label="Paragrafen">
-              <div class="flex flex-col">
-                <NuxtLink
-                  v-if="previousArticleUrl"
-                  :to="previousArticleUrl"
-                  class="typo-link-regular link-hover"
-                >
-                  <div class="flex items-center space-x-8">
-                    <IcBaselineArrowBack class="mt-1 shrink-0" />
-                    <span>Vorheriger Paragraf</span>
-                  </div>
-                </NuxtLink>
-              </div>
+    <div class="border-t border-t-gray-400 bg-white">
+      <SidebarLayout class="wrapper">
+        <template v-if="!!articleHtml">
+          <DocumentsIncompleteDataMessage />
+          <DocumentsNormsLegislationContent single-article>
+            <div class="akn-act" v-html="articleHtml" />
+          </DocumentsNormsLegislationContent>
 
-              <div class="flex flex-col">
-                <NuxtLink
-                  v-if="nextArticleUrl"
-                  :to="nextArticleUrl"
-                  class="typo-link-regular link-hover"
-                >
-                  <div class="flex items-center space-x-8">
-                    <span>Nächster Paragraf</span>
-                    <IcBaselineArrowForward class="mt-1 shrink-0" />
-                  </div>
-                </NuxtLink>
-              </div>
-            </nav>
-          </template>
+          <nav class="flex flex-row justify-between" aria-label="Paragrafen">
+            <div class="flex flex-col">
+              <NuxtLink
+                v-if="previousArticleUrl"
+                :to="previousArticleUrl"
+                class="typo-link-regular link-hover"
+              >
+                <div class="flex items-center space-x-8">
+                  <IcBaselineArrowBack class="mt-1 shrink-0" />
+                  <span>Vorheriger Paragraf</span>
+                </div>
+              </NuxtLink>
+            </div>
 
-          <template #sidebar>
-            <DocumentsTableOfContents
-              v-if="tableOfContents.length"
-              :subheading="normTitle"
-              :subheading-to="normPath"
-              :table-of-contents="tableOfContents"
-              :selected-key="eId"
-            />
-          </template>
-        </SidebarLayout>
-      </div>
-    </template>
+            <div class="flex flex-col">
+              <NuxtLink
+                v-if="nextArticleUrl"
+                :to="nextArticleUrl"
+                class="typo-link-regular link-hover"
+              >
+                <div class="flex items-center space-x-8">
+                  <span>Nächster Paragraf</span>
+                  <IcBaselineArrowForward class="mt-1 shrink-0" />
+                </div>
+              </NuxtLink>
+            </div>
+          </nav>
+        </template>
+
+        <template #sidebar>
+          <DocumentsTableOfContents
+            v-if="tableOfContents.length"
+            :subheading="normTitle"
+            :subheading-to="normPath"
+            :table-of-contents="tableOfContents"
+            :selected-key="eId"
+          />
+        </template>
+      </SidebarLayout>
+    </div>
   </NuxtLayout>
 </template>

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -228,7 +228,7 @@ const metadataItems = computed(() => {
       <Metadata v-if="privateFeaturesEnabled" :items="metadataItems" />
     </div>
 
-    <div class="border-t border-t-gray-400 bg-white">
+    <div id="content" class="border-t border-t-gray-400 bg-white">
       <SidebarLayout class="wrapper">
         <template v-if="!!articleHtml">
           <DocumentsIncompleteDataMessage />

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -228,7 +228,7 @@ const metadataItems = computed(() => {
         <Metadata v-if="privateFeaturesEnabled" :items="metadataItems" />
       </div>
 
-      <div id="content" class="border-t border-t-gray-400 bg-white">
+      <div class="border-t border-t-gray-400 bg-white">
         <SidebarLayout class="wrapper">
           <template v-if="!!articleHtml" #content>
             <DocumentsIncompleteDataMessage />

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -209,7 +209,13 @@ const fassungenDateFilterInputId = useId();
               <h2 :id="detailsTabPanelTitleId" class="typo-headline3-bold">
                 Details
               </h2>
-              <DocumentsIncompleteDataMessage class="my-24" />
+
+              <div class="base-grid my-24">
+                <DocumentsIncompleteDataMessage
+                  class="col-span-12 lg:col-span-7"
+                />
+              </div>
+
               <DetailsList>
                 <DetailsListEntry
                   label="Ausfertigungsdatum:"
@@ -267,7 +273,12 @@ const fassungenDateFilterInputId = useId();
                   Fassungen
                 </h2>
 
-                <DocumentsIncompleteDataMessage class="my-24" />
+                <div class="base-grid my-24">
+                  <DocumentsIncompleteDataMessage
+                    class="col-span-12 lg:col-span-7"
+                  />
+                </div>
+
                 <div class="my-16 md:my-24">
                   <label
                     :for="fassungenDateFilterInputId"
@@ -362,6 +373,6 @@ const fassungenDateFilterInputId = useId();
 }
 
 .footnotes :deep(.nichtamtliche-fussnoten .fussnote:first-child pre) {
-  @apply -mt-8;
+  @apply md:-mt-8;
 }
 </style>

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -161,53 +161,113 @@ const fassungenDateFilterInputId = useId();
         />
       </div>
     </template>
-    <template #default>
-      <div
-        class="wrapper mb-24 space-y-24 sm:mb-32 sm:space-y-32 md:mb-40 md:space-y-40"
-      >
-        <DocumentsNormsNormHeadingGroup
-          :metadata="metadata"
-          :html-parts="htmlParts"
-        />
 
-        <DocumentsNormsNormVersionWarning
-          v-if="normVersionsStatus === 'success'"
-          :versions="normVersions"
-          :current-version="metadata"
-        />
+    <div
+      class="wrapper mb-24 space-y-24 sm:mb-32 sm:space-y-32 md:mb-40 md:space-y-40"
+    >
+      <DocumentsNormsNormHeadingGroup
+        :metadata="metadata"
+        :html-parts="htmlParts"
+      />
 
-        <Metadata :items="metadataItems" />
-      </div>
+      <DocumentsNormsNormVersionWarning
+        v-if="normVersionsStatus === 'success'"
+        :versions="normVersions"
+        :current-version="metadata"
+      />
 
-      <TabsLayout :views>
-        <template #text>
-          <section role="tabpanel" :aria-labelledby="textTabPanelTitleId">
-            <SidebarLayout>
-              <h2 :id="textTabPanelTitleId" class="sr-only">Text</h2>
-              <DocumentsIncompleteDataMessage />
-              <DocumentsNormsLegislationContent
-                :official-toc="htmlParts.officialToc"
+      <Metadata :items="metadataItems" />
+    </div>
+
+    <TabsLayout :views>
+      <template #text>
+        <section role="tabpanel" :aria-labelledby="textTabPanelTitleId">
+          <SidebarLayout>
+            <h2 :id="textTabPanelTitleId" class="sr-only">Text</h2>
+            <DocumentsIncompleteDataMessage />
+            <DocumentsNormsLegislationContent
+              :official-toc="htmlParts.officialToc"
+            >
+              <div v-html="htmlParts.body" />
+            </DocumentsNormsLegislationContent>
+
+            <template #sidebar v-if="tableOfContents?.length">
+              <client-only>
+                <DocumentsTableOfContents
+                  :subheading="normBreadcrumbTitle"
+                  :table-of-contents="tableOfContents"
+                />
+              </client-only>
+            </template>
+          </SidebarLayout>
+        </section>
+      </template>
+
+      <template #details>
+        <section role="tabpanel" :aria-labelledby="detailsTabPanelTitleId">
+          <div class="pt-32 pb-32 md:pb-56">
+            <h2 :id="detailsTabPanelTitleId" class="typo-headline3-bold">
+              Details
+            </h2>
+
+            <div class="base-grid my-24">
+              <DocumentsIncompleteDataMessage
+                class="col-span-12 lg:col-span-7"
+              />
+            </div>
+
+            <DetailsList>
+              <DetailsListEntry
+                label="Ausfertigungsdatum:"
+                :value="
+                  dateFormattedDDMMYYYY(metadata.exampleOfWork.legislationDate)
+                "
+              />
+              <DetailsListEntry
+                label="Vollzitat:"
+                :value="htmlParts.vollzitat"
+              />
+              <DetailsListEntry
+                label="Stand:"
+                :value-list="htmlParts.standangaben"
+              />
+              <DetailsListEntry
+                label="Hinweis zum Stand:"
+                :value-list="htmlParts.standangabenHinweis"
+              />
+              <DetailsListEntry
+                v-if="htmlParts.prefaceContainer"
+                label="Besonderer Hinweis:"
               >
-                <div v-html="htmlParts.body" />
-              </DocumentsNormsLegislationContent>
+                <div v-html="htmlParts.prefaceContainer" />
+              </DetailsListEntry>
+              <DetailsListEntry label="Fußnoten:">
+                <template v-if="htmlParts.headingNotes">
+                  <div class="footnotes" v-html="htmlParts.headingNotes" />
+                </template>
+              </DetailsListEntry>
+              <DetailsListEntry label="Download:">
+                <NuxtLink
+                  data-attr="xml-zip-view"
+                  class="typo-link-regular"
+                  external
+                  :to="zipUrl"
+                >
+                  <IconFileDownload class="mr-2 inline" />
+                  {{ metadata.abbreviation ?? "Inhalte" }} als ZIP herunterladen
+                </NuxtLink>
+              </DetailsListEntry>
+            </DetailsList>
+          </div>
+        </section>
+      </template>
 
-              <template #sidebar v-if="tableOfContents?.length">
-                <client-only>
-                  <DocumentsTableOfContents
-                    :subheading="normBreadcrumbTitle"
-                    :table-of-contents="tableOfContents"
-                  />
-                </client-only>
-              </template>
-            </SidebarLayout>
-          </section>
-        </template>
-
-        <template #details>
-          <section role="tabpanel" :aria-labelledby="detailsTabPanelTitleId">
-            <div class="pt-32 pb-32 md:pb-56">
-              <h2 :id="detailsTabPanelTitleId" class="typo-headline3-bold">
-                Details
+      <template #versions>
+        <section role="tabpanel" :aria-labelledby="fassungenTabPanelTitleId">
+          <div class="pt-32 pb-32 md:pb-56">
+            <template v-if="privateFeaturesEnabled">
+              <h2 :id="fassungenTabPanelTitleId" class="typo-headline3-bold">
+                Fassungen
               </h2>
 
               <div class="base-grid my-24">
@@ -216,128 +276,64 @@ const fassungenDateFilterInputId = useId();
                 />
               </div>
 
-              <DetailsList>
-                <DetailsListEntry
-                  label="Ausfertigungsdatum:"
-                  :value="
-                    dateFormattedDDMMYYYY(
-                      metadata.exampleOfWork.legislationDate,
-                    )
-                  "
-                />
-                <DetailsListEntry
-                  label="Vollzitat:"
-                  :value="htmlParts.vollzitat"
-                />
-                <DetailsListEntry
-                  label="Stand:"
-                  :value-list="htmlParts.standangaben"
-                />
-                <DetailsListEntry
-                  label="Hinweis zum Stand:"
-                  :value-list="htmlParts.standangabenHinweis"
-                />
-                <DetailsListEntry
-                  v-if="htmlParts.prefaceContainer"
-                  label="Besonderer Hinweis:"
+              <div class="my-16 md:my-24">
+                <label
+                  :for="fassungenDateFilterInputId"
+                  class="typo-label2-regular"
+                  >Gültig am</label
                 >
-                  <div v-html="htmlParts.prefaceContainer" />
-                </DetailsListEntry>
-                <DetailsListEntry label="Fußnoten:">
-                  <template v-if="htmlParts.headingNotes">
-                    <div class="footnotes" v-html="htmlParts.headingNotes" />
-                  </template>
-                </DetailsListEntry>
-                <DetailsListEntry label="Download:">
-                  <NuxtLink
-                    data-attr="xml-zip-view"
-                    class="typo-link-regular"
-                    external
-                    :to="zipUrl"
-                  >
-                    <IconFileDownload class="mr-2 inline" />
-                    {{ metadata.abbreviation ?? "Inhalte" }} als ZIP
-                    herunterladen
-                  </NuxtLink>
-                </DetailsListEntry>
-              </DetailsList>
-            </div>
-          </section>
-        </template>
-
-        <template #versions>
-          <section role="tabpanel" :aria-labelledby="fassungenTabPanelTitleId">
-            <div class="pt-32 pb-32 md:pb-56">
-              <template v-if="privateFeaturesEnabled">
-                <h2 :id="fassungenTabPanelTitleId" class="typo-headline3-bold">
-                  Fassungen
-                </h2>
-
-                <div class="base-grid my-24">
-                  <DocumentsIncompleteDataMessage
-                    class="col-span-12 lg:col-span-7"
-                  />
-                </div>
-
-                <div class="my-16 md:my-24">
-                  <label
-                    :for="fassungenDateFilterInputId"
-                    class="typo-label2-regular"
-                    >Gültig am</label
-                  >
-                  <DateInput
-                    v-model="fassungenDateFilterValue"
-                    class="mb-16 max-w-240 md:mb-24"
-                    :id="fassungenDateFilterInputId"
-                    :showClear="true"
-                  />
-                </div>
-                <DocumentsNormsNormVersionList
-                  :status="normVersionsStatus"
-                  :current-legislation-identifier="
-                    metadata.legislationIdentifier ?? ''
-                  "
-                  :versions="filteredNormVersions"
+                <DateInput
+                  v-model="fassungenDateFilterValue"
+                  class="mb-16 max-w-240 md:mb-24"
+                  :id="fassungenDateFilterInputId"
+                  :showClear="true"
                 />
-              </template>
-
-              <div class="max-w-prose" v-else>
-                <h2
-                  :id="fassungenTabPanelTitleId"
-                  class="typo-headline3-bold mb-24"
-                >
-                  Fassungen sind noch nicht verfügbar
-                </h2>
-                <p>
-                  Mit dem Livegang des neuen Rechtsinformationsportals werden
-                  auch außer Kraft getretene und zukünftig in Kraft tretende
-                  Fassungen der Gesetze und Verordnungen zur Verfügung gestellt.
-                </p>
-
-                <h3 class="typo-headline3-bold mt-48 mb-24">
-                  Unterstützen Sie uns bei der Entwicklung dieser Funktion
-                </h3>
-
-                <p>
-                  Unser Ziel ist es, Rechtsinformationen für Bürgerinnen und
-                  Bürger leichter zugänglich zu machen. Deshalb suchen wir
-                  Menschen, die ihre Erfahrungen mit uns teilen und unseren
-                  Service testen.
-                </p>
-
-                <Button
-                  :as="NuxtLink"
-                  class="mt-16"
-                  :to="{ name: 'usage-tests' }"
-                >
-                  Mehr über Nutzungstest erfahren
-                </Button>
               </div>
+              <DocumentsNormsNormVersionList
+                :status="normVersionsStatus"
+                :current-legislation-identifier="
+                  metadata.legislationIdentifier ?? ''
+                "
+                :versions="filteredNormVersions"
+              />
+            </template>
+
+            <div class="max-w-prose" v-else>
+              <h2
+                :id="fassungenTabPanelTitleId"
+                class="typo-headline3-bold mb-24"
+              >
+                Fassungen sind noch nicht verfügbar
+              </h2>
+              <p>
+                Mit dem Livegang des neuen Rechtsinformationsportals werden auch
+                außer Kraft getretene und zukünftig in Kraft tretende Fassungen
+                der Gesetze und Verordnungen zur Verfügung gestellt.
+              </p>
+
+              <h3 class="typo-headline3-bold mt-48 mb-24">
+                Unterstützen Sie uns bei der Entwicklung dieser Funktion
+              </h3>
+
+              <p>
+                Unser Ziel ist es, Rechtsinformationen für Bürgerinnen und
+                Bürger leichter zugänglich zu machen. Deshalb suchen wir
+                Menschen, die ihre Erfahrungen mit uns teilen und unseren
+                Service testen.
+              </p>
+
+              <Button
+                :as="NuxtLink"
+                class="mt-16"
+                :to="{ name: 'usage-tests' }"
+              >
+                Mehr über Nutzungstest erfahren
+              </Button>
             </div>
-          </section>
-        </template>
-      </TabsLayout>
-    </template>
+          </div>
+        </section>
+      </template>
+    </TabsLayout>
   </NuxtLayout>
 </template>
 

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -183,15 +183,13 @@ const fassungenDateFilterInputId = useId();
         <template #text>
           <section role="tabpanel" :aria-labelledby="textTabPanelTitleId">
             <SidebarLayout>
-              <template #content>
-                <h2 :id="textTabPanelTitleId" class="sr-only">Text</h2>
-                <DocumentsIncompleteDataMessage />
-                <DocumentsNormsLegislationContent
-                  :official-toc="htmlParts.officialToc"
-                >
-                  <div v-html="htmlParts.body" />
-                </DocumentsNormsLegislationContent>
-              </template>
+              <h2 :id="textTabPanelTitleId" class="sr-only">Text</h2>
+              <DocumentsIncompleteDataMessage />
+              <DocumentsNormsLegislationContent
+                :official-toc="htmlParts.officialToc"
+              >
+                <div v-html="htmlParts.body" />
+              </DocumentsNormsLegislationContent>
 
               <template #sidebar v-if="tableOfContents?.length">
                 <client-only>

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -182,7 +182,7 @@ const fassungenDateFilterInputId = useId();
       <TabsLayout :views>
         <template #text>
           <section role="tabpanel" :aria-labelledby="textTabPanelTitleId">
-            <SidebarLayout class="wrapper">
+            <SidebarLayout>
               <template #content>
                 <h2 :id="textTabPanelTitleId" class="sr-only">Text</h2>
                 <DocumentsIncompleteDataMessage />
@@ -207,7 +207,7 @@ const fassungenDateFilterInputId = useId();
 
         <template #details>
           <section role="tabpanel" :aria-labelledby="detailsTabPanelTitleId">
-            <div class="wrapper pt-32 pb-32 md:pb-56">
+            <div class="pt-32 pb-32 md:pb-56">
               <h2 :id="detailsTabPanelTitleId" class="typo-headline3-bold">
                 Details
               </h2>
@@ -263,7 +263,7 @@ const fassungenDateFilterInputId = useId();
 
         <template #versions>
           <section role="tabpanel" :aria-labelledby="fassungenTabPanelTitleId">
-            <div class="wrapper pt-32 pb-32 md:pb-56">
+            <div class="pt-32 pb-32 md:pb-56">
               <template v-if="privateFeaturesEnabled">
                 <h2 :id="fassungenTabPanelTitleId" class="typo-headline3-bold">
                   Fassungen

--- a/frontend/src/pages/search/index.vue
+++ b/frontend/src/pages/search/index.vue
@@ -202,159 +202,155 @@ watch(searchStatus, async (newStatus, oldStatus) => {
     <template #breadcrumb>
       <Breadcrumbs :items="[{ label: 'Suche' }]" />
     </template>
-    <template #default>
-      <div class="wrapper pb-32 md:pb-56">
-        <h1 class="typo-headline1-bold inline-block pb-8">Suche</h1>
 
-        <div id="search">
-          <SearchSimpleSearchInput
-            :model-value="query"
-            @update:model-value="updateQuery"
-            @empty-search="handleEmptySearch"
-          />
-        </div>
+    <div class="wrapper pb-32 md:pb-56">
+      <h1 class="typo-headline1-bold inline-block pb-8">Suche</h1>
 
-        <SkipLink to="#search-results" class="mt-8">
-          Zu den Ergebnissen
-        </SkipLink>
+      <div id="search">
+        <SearchSimpleSearchInput
+          :model-value="query"
+          @update:model-value="updateQuery"
+          @empty-search="handleEmptySearch"
+        />
+      </div>
 
-        <p v-if="privateFeaturesEnabled" class="typo-label2-regular mt-8">
-          Mehr Suchoptionen finden Sie unter
-          <NuxtLink
-            :to="{ name: 'advanced-search' }"
-            class="ris-link2-bold 2xl:ris-link1-bold"
+      <SkipLink to="#search-results" class="mt-8">
+        Zu den Ergebnissen
+      </SkipLink>
+
+      <p v-if="privateFeaturesEnabled" class="typo-label2-regular mt-8">
+        Mehr Suchoptionen finden Sie unter
+        <NuxtLink
+          :to="{ name: 'advanced-search' }"
+          class="ris-link2-bold 2xl:ris-link1-bold"
+        >
+          Erweiterte Suche
+        </NuxtLink>
+      </p>
+
+      <div class="mt-32 flex flex-col gap-48 md:mt-48 lg:flex-row">
+        <aside class="pb-10 lg:w-3/12" :aria-labelledby="filterHeadingId">
+          <h2
+            :id="filterHeadingId"
+            class="typo-label1-regular flex h-48 items-center"
           >
-            Erweiterte Suche
-          </NuxtLink>
-        </p>
+            Filter
+          </h2>
 
-        <div class="mt-32 flex flex-col gap-48 md:mt-48 lg:flex-row">
-          <aside class="pb-10 lg:w-3/12" :aria-labelledby="filterHeadingId">
-            <h2
-              :id="filterHeadingId"
-              class="typo-label1-regular flex h-48 items-center"
-            >
-              Filter
-            </h2>
+          <div class="flex flex-col gap-24">
+            <SearchCategoryFilter
+              :model-value="categoryFilterValue"
+              @update:model-value="updateCategoryFilter"
+            />
 
-            <div class="flex flex-col gap-24">
-              <SearchCategoryFilter
-                :model-value="categoryFilterValue"
-                @update:model-value="updateCategoryFilter"
-              />
+            <SearchCourtFilter
+              v-if="documentKind === DocumentKind.CaseLaw"
+              :model-value="court"
+              @update:model-value="updateCourt"
+            />
 
-              <SearchCourtFilter
-                v-if="documentKind === DocumentKind.CaseLaw"
-                :model-value="court"
-                @update:model-value="updateCourt"
-              />
+            <SearchDateRangeFilter
+              v-if="
+                documentKind === DocumentKind.CaseLaw ||
+                documentKind === DocumentKind.AdministrativeDirective
+              "
+              v-model="localDateFilter"
+              @update:model-value="updateDateFilter"
+            />
 
-              <SearchDateRangeFilter
-                v-if="
-                  documentKind === DocumentKind.CaseLaw ||
-                  documentKind === DocumentKind.AdministrativeDirective
-                "
-                v-model="localDateFilter"
-                @update:model-value="updateDateFilter"
-              />
+            <SearchYearRangeFilter
+              v-else-if="documentKind === DocumentKind.Literature"
+              v-model="localDateFilter"
+              @update:model-value="updateDateFilter"
+            />
+          </div>
+        </aside>
 
-              <SearchYearRangeFilter
-                v-else-if="documentKind === DocumentKind.Literature"
-                v-model="localDateFilter"
-                @update:model-value="updateDateFilter"
-              />
-            </div>
-          </aside>
-
-          <div
-            id="search-results"
-            ref="resultsContainerRef"
-            class="w-full scroll-mt-16 flex-col justify-end gap-8 lg:w-9/12"
+        <div
+          id="search-results"
+          ref="resultsContainerRef"
+          class="w-full scroll-mt-16 flex-col justify-end gap-8 lg:w-9/12"
+        >
+          <Pagination
+            :is-loading="isLoading"
+            :page="searchResults"
+            navigation-position="bottom"
+            @update-page="updatePage"
           >
-            <Pagination
-              :is-loading="isLoading"
-              :page="searchResults"
-              navigation-position="bottom"
-              @update-page="updatePage"
+            <div
+              class="mb-12 flex w-full flex-wrap items-center justify-between gap-x-32 gap-y-16"
             >
-              <div
-                class="mb-12 flex w-full flex-wrap items-center justify-between gap-x-32 gap-y-16"
+              <output
+                aria-atomic="true"
+                aria-live="polite"
+                class="typo-label1-regular"
               >
-                <output
-                  aria-atomic="true"
-                  aria-live="polite"
-                  class="typo-label1-regular"
-                >
-                  {{ isLoading ? "Lade ..." : formattedResultCount }}
-                </output>
+                {{ isLoading ? "Lade ..." : formattedResultCount }}
+              </output>
 
-                <div class="flex flex-wrap gap-x-32 gap-y-16">
-                  <div class="flex items-center gap-8">
-                    <label
-                      :id="itemsPerPageLabelId"
-                      class="typo-label2-regular"
-                    >
-                      Einträge pro Seite
-                    </label>
-                    <Select
-                      :model-value="itemsPerPage"
-                      :aria-labelledby="itemsPerPageLabelId"
-                      :options="itemsPerPageOptions"
-                      @update:model-value="updateItemsPerPage"
-                    />
-                  </div>
-
-                  <SearchSortSelect
-                    :model-value="sort"
-                    :document-kind
-                    @update:model-value="updateSort"
+              <div class="flex flex-wrap gap-x-32 gap-y-16">
+                <div class="flex items-center gap-8">
+                  <label :id="itemsPerPageLabelId" class="typo-label2-regular">
+                    Einträge pro Seite
+                  </label>
+                  <Select
+                    :model-value="itemsPerPage"
+                    :aria-labelledby="itemsPerPageLabelId"
+                    :options="itemsPerPageOptions"
+                    @update:model-value="updateItemsPerPage"
                   />
                 </div>
+
+                <SearchSortSelect
+                  :model-value="sort"
+                  :document-kind
+                  @update:model-value="updateSort"
+                />
               </div>
+            </div>
 
-              <div class="max-w-prose">
-                <Message v-if="!!searchError" severity="error">
-                  {{ searchError.message }}
-                </Message>
+            <div class="max-w-prose">
+              <Message v-if="!!searchError" severity="error">
+                {{ searchError.message }}
+              </Message>
 
-                <Message
-                  severity="warn"
-                  class="ris-body2-regular mt-16 max-w-prose"
-                  role="status"
-                  aria-live="off"
+              <Message
+                severity="warn"
+                class="ris-body2-regular mt-16 max-w-prose"
+                role="status"
+                aria-live="off"
+              >
+                <p class="ris-body2-bold mt-2">
+                  Dieser Service befindet sich in der Testphase.
+                </p>
+                <p>
+                  Der Datenbestand ist noch nicht vollständig und die
+                  Suchpriorisierung noch nicht final. Der Service ist in
+                  Entwicklung. Wir arbeiten an der Ergänzung und Darstellung
+                  aller Inhalte.
+                </p>
+              </Message>
+
+              <ul v-if="searchResults" aria-label="Suchergebnisse">
+                <li
+                  v-for="(searchResult, index) in searchResults.member"
+                  :key="getIdentifier(searchResult.item)"
+                  class="my-40"
                 >
-                  <p class="ris-body2-bold mt-2">
-                    Dieser Service befindet sich in der Testphase.
-                  </p>
-                  <p>
-                    Der Datenbestand ist noch nicht vollständig und die
-                    Suchpriorisierung noch nicht final. Der Service ist in
-                    Entwicklung. Wir arbeiten an der Ergänzung und Darstellung
-                    aller Inhalte.
-                  </p>
-                </Message>
+                  <SearchResult :search-result :order="index" />
+                </li>
+              </ul>
 
-                <ul v-if="searchResults" aria-label="Suchergebnisse">
-                  <li
-                    v-for="(searchResult, index) in searchResults.member"
-                    :key="getIdentifier(searchResult.item)"
-                    class="my-40"
-                  >
-                    <SearchResult :search-result :order="index" />
-                  </li>
-                </ul>
-
-                <div
-                  v-if="isLoading"
-                  class="flex h-full min-h-48 w-full items-center justify-center"
-                >
-                  <DelayedLoadingMessage />
-                </div>
+              <div
+                v-if="isLoading"
+                class="flex h-full min-h-48 w-full items-center justify-center"
+              >
+                <DelayedLoadingMessage />
               </div>
-            </Pagination>
-          </div>
+            </div>
+          </Pagination>
         </div>
       </div>
-    </template>
+    </div>
   </NuxtLayout>
 </template>

--- a/frontend/src/pages/search/index.vue
+++ b/frontend/src/pages/search/index.vue
@@ -228,11 +228,46 @@ watch(searchStatus, async (newStatus, oldStatus) => {
         </NuxtLink>
       </p>
 
-      <div class="mt-32 flex flex-col gap-48 md:mt-48 lg:flex-row">
-        <aside class="pb-10 lg:w-3/12" :aria-labelledby="filterHeadingId">
+      <div class="base-grid mt-32 gap-y-32">
+        <div
+          class="col-span-12 row-start-2 flex flex-wrap items-center justify-between gap-x-32 gap-y-16 md:row-auto"
+        >
+          <output
+            aria-atomic="true"
+            aria-live="polite"
+            class="typo-label1-bold"
+          >
+            {{ isLoading ? "Lade ..." : formattedResultCount }}
+          </output>
+
+          <div class="flex flex-wrap gap-x-32 gap-y-16">
+            <div class="flex items-center gap-8">
+              <label :id="itemsPerPageLabelId" class="typo-label2-regular">
+                Einträge pro Seite
+              </label>
+              <Select
+                :model-value="itemsPerPage"
+                :aria-labelledby="itemsPerPageLabelId"
+                :options="itemsPerPageOptions"
+                @update:model-value="updateItemsPerPage"
+              />
+            </div>
+
+            <SearchSortSelect
+              :model-value="sort"
+              :document-kind
+              @update:model-value="updateSort"
+            />
+          </div>
+        </div>
+
+        <aside
+          class="col-span-12 pb-10 md:col-span-4 lg:col-span-3"
+          :aria-labelledby="filterHeadingId"
+        >
           <h2
             :id="filterHeadingId"
-            class="typo-label1-regular flex h-48 items-center"
+            class="typo-label1-regular mb-16 flex items-center"
           >
             Filter
           </h2>
@@ -269,7 +304,7 @@ watch(searchStatus, async (newStatus, oldStatus) => {
         <div
           id="search-results"
           ref="resultsContainerRef"
-          class="w-full scroll-mt-16 flex-col justify-end gap-8 lg:w-9/12"
+          class="col-span-12 scroll-mt-16 flex-col justify-end gap-8 md:col-span-8 lg:col-span-8 lg:col-start-5 xl:col-span-7 xl:col-start-5"
         >
           <Pagination
             :is-loading="isLoading"
@@ -277,76 +312,42 @@ watch(searchStatus, async (newStatus, oldStatus) => {
             navigation-position="bottom"
             @update-page="updatePage"
           >
-            <div
-              class="mb-12 flex w-full flex-wrap items-center justify-between gap-x-32 gap-y-16"
+            <Message v-if="!!searchError" severity="error">
+              {{ searchError.message }}
+            </Message>
+
+            <Message
+              severity="warn"
+              class="ris-body2-regular max-w-prose"
+              role="status"
+              aria-live="off"
             >
-              <output
-                aria-atomic="true"
-                aria-live="polite"
-                class="typo-label1-regular"
+              <p class="ris-body2-bold mt-2">
+                Dieser Service befindet sich in der Testphase.
+              </p>
+              <p>
+                Der Datenbestand ist noch nicht vollständig und die
+                Suchpriorisierung noch nicht final. Der Service ist in
+                Entwicklung. Wir arbeiten an der Ergänzung und Darstellung aller
+                Inhalte.
+              </p>
+            </Message>
+
+            <ul v-if="searchResults" aria-label="Suchergebnisse">
+              <li
+                v-for="(searchResult, index) in searchResults.member"
+                :key="getIdentifier(searchResult.item)"
+                class="my-40"
               >
-                {{ isLoading ? "Lade ..." : formattedResultCount }}
-              </output>
+                <SearchResult :search-result :order="index" />
+              </li>
+            </ul>
 
-              <div class="flex flex-wrap gap-x-32 gap-y-16">
-                <div class="flex items-center gap-8">
-                  <label :id="itemsPerPageLabelId" class="typo-label2-regular">
-                    Einträge pro Seite
-                  </label>
-                  <Select
-                    :model-value="itemsPerPage"
-                    :aria-labelledby="itemsPerPageLabelId"
-                    :options="itemsPerPageOptions"
-                    @update:model-value="updateItemsPerPage"
-                  />
-                </div>
-
-                <SearchSortSelect
-                  :model-value="sort"
-                  :document-kind
-                  @update:model-value="updateSort"
-                />
-              </div>
-            </div>
-
-            <div class="max-w-prose">
-              <Message v-if="!!searchError" severity="error">
-                {{ searchError.message }}
-              </Message>
-
-              <Message
-                severity="warn"
-                class="ris-body2-regular mt-16 max-w-prose"
-                role="status"
-                aria-live="off"
-              >
-                <p class="ris-body2-bold mt-2">
-                  Dieser Service befindet sich in der Testphase.
-                </p>
-                <p>
-                  Der Datenbestand ist noch nicht vollständig und die
-                  Suchpriorisierung noch nicht final. Der Service ist in
-                  Entwicklung. Wir arbeiten an der Ergänzung und Darstellung
-                  aller Inhalte.
-                </p>
-              </Message>
-
-              <ul v-if="searchResults" aria-label="Suchergebnisse">
-                <li
-                  v-for="(searchResult, index) in searchResults.member"
-                  :key="getIdentifier(searchResult.item)"
-                  class="my-40"
-                >
-                  <SearchResult :search-result :order="index" />
-                </li>
-              </ul>
-
-              <div
-                v-if="isLoading"
-                class="flex h-full min-h-48 w-full items-center justify-center"
-              >
-                <DelayedLoadingMessage />
-              </div>
+            <div
+              v-if="isLoading"
+              class="flex h-full min-h-48 w-full items-center justify-center"
+            >
+              <DelayedLoadingMessage />
             </div>
           </Pagination>
         </div>

--- a/frontend/src/pages/translations/[id].vue
+++ b/frontend/src/pages/translations/[id].vue
@@ -98,78 +98,78 @@ const detailsTabPanelTitleId = useId();
         <NormTranslationActionMenu class="mb-auto" />
       </div>
     </template>
-    <template #default>
-      <div class="wrapper">
-        <hgroup class="dokumentenkopf">
-          <p
-            v-if="currentTranslation?.translationOfWork"
-            class="word-wrap typo-headline3-regular mb-8 hyphens-auto"
-          >
-            {{ currentTranslation.translationOfWork }}
-          </p>
 
-          <h1
-            v-if="currentTranslation?.name"
-            class="typo-headline1-bold my-8 wrap-break-word hyphens-auto sm:mb-16 md:mb-40"
-          >
-            {{ currentTranslation.name }}
-          </h1>
-        </hgroup>
-
-        <Message
-          v-if="legislation"
-          :closable="false"
-          class="my-24 max-w-prose space-y-24 sm:my-32 md:my-40"
+    <div class="wrapper">
+      <hgroup class="dokumentenkopf">
+        <p
+          v-if="currentTranslation?.translationOfWork"
+          class="word-wrap typo-headline3-regular mb-8 hyphens-auto"
         >
-          <template #icon>
-            <IcOutlineWarning />
-          </template>
-          <p class="typo-label2-bold mt-2">Version Information</p>
-          <p class="typo-label2-regular mt-2">
-            Translations may not be updated at the same time as the German legal
-            provision.
-            <NuxtLink
-              class="ris-link2-regular 2xl:ris-link1-regular"
-              :to="`/norms/${germanOriginalWorkEli}`"
-              >Go to the German version</NuxtLink
-            >.
-          </p>
-        </Message>
-      </div>
+          {{ currentTranslation.translationOfWork }}
+        </p>
 
-      <TabsLayout :views>
-        <template #text>
-          <section
-            class="pt-32 pb-32 md:pb-56"
-            role="tabpanel"
-            :aria-labelledby="textSectionId"
-          >
-            <h2 :id="textSectionId" class="sr-only">Text</h2>
-            <section class="max-w-prose" v-html="html" />
-          </section>
-        </template>
+        <h1
+          v-if="currentTranslation?.name"
+          class="typo-headline1-bold my-8 wrap-break-word hyphens-auto sm:mb-16 md:mb-40"
+        >
+          {{ currentTranslation.name }}
+        </h1>
+      </hgroup>
 
-        <template #details>
-          <section
-            class="pt-32 pb-32 md:pb-56"
-            :aria-labelledby="detailsTabPanelTitleId"
-          >
-            <h2 :id="detailsTabPanelTitleId" class="typo-headline3-bold">
-              Details
-            </h2>
-            <DetailsList class="mt-24">
-              <DetailsListEntry
-                label="Translation provided by:"
-                :value="translatedBy"
-              />
-              <DetailsListEntry
-                label="Version information:"
-                :value="versionInformation"
-              />
-            </DetailsList>
-          </section>
+      <Message
+        v-if="legislation"
+        :closable="false"
+        class="my-24 max-w-prose space-y-24 sm:my-32 md:my-40"
+      >
+        <template #icon>
+          <IcOutlineWarning />
         </template>
-      </TabsLayout>
-    </template>
+        <p class="typo-label2-bold mt-2">Version Information</p>
+        <p class="typo-label2-regular mt-2">
+          Translations may not be updated at the same time as the German legal
+          provision.
+          <NuxtLink
+            class="ris-link2-regular 2xl:ris-link1-regular"
+            :to="`/norms/${germanOriginalWorkEli}`"
+          >
+            Go to the German version </NuxtLink
+          >.
+        </p>
+      </Message>
+    </div>
+
+    <TabsLayout :views>
+      <template #text>
+        <section
+          class="pt-32 pb-32 md:pb-56"
+          role="tabpanel"
+          :aria-labelledby="textSectionId"
+        >
+          <h2 :id="textSectionId" class="sr-only">Text</h2>
+          <section class="max-w-prose" v-html="html" />
+        </section>
+      </template>
+
+      <template #details>
+        <section
+          class="pt-32 pb-32 md:pb-56"
+          :aria-labelledby="detailsTabPanelTitleId"
+        >
+          <h2 :id="detailsTabPanelTitleId" class="typo-headline3-bold">
+            Details
+          </h2>
+          <DetailsList class="mt-24">
+            <DetailsListEntry
+              label="Translation provided by:"
+              :value="translatedBy"
+            />
+            <DetailsListEntry
+              label="Version information:"
+              :value="versionInformation"
+            />
+          </DetailsList>
+        </section>
+      </template>
+    </TabsLayout>
   </NuxtLayout>
 </template>

--- a/frontend/src/pages/translations/[id].vue
+++ b/frontend/src/pages/translations/[id].vue
@@ -145,8 +145,10 @@ const detailsTabPanelTitleId = useId();
           role="tabpanel"
           :aria-labelledby="textSectionId"
         >
-          <h2 :id="textSectionId" class="sr-only">Text</h2>
-          <section class="max-w-prose" v-html="html" />
+          <SidebarLayout>
+            <h2 :id="textSectionId" class="sr-only">Text</h2>
+            <div v-html="html" />
+          </SidebarLayout>
         </section>
       </template>
 

--- a/frontend/src/pages/translations/index.vue
+++ b/frontend/src/pages/translations/index.vue
@@ -92,80 +92,78 @@ const translationsListId = useId();
         <Breadcrumbs :items="breadcrumbItems" />
       </div>
     </template>
-    <template #default>
-      <div class="wrapper pb-32 md:pb-56">
-        <section
-          class="mt-24 max-w-prose space-y-24 md:space-y-32 2xl:space-y-48"
+
+    <div class="wrapper pb-32 md:pb-56">
+      <section
+        class="mt-24 max-w-prose space-y-24 md:space-y-32 2xl:space-y-48"
+      >
+        <h1 class="typo-headline1-bold">
+          English Translations of German Federal Laws and Regulations
+        </h1>
+        <p class="mb-8">
+          We provide translations of our German content to help you. Please note
+          that the original German versions are the only authoritative source.
+        </p>
+        <p>
+          The translations published on this website may be used in accordance
+          with the applicable copyright exceptions. In particular, single copies
+          may be made including in the form of downloads or printouts for
+          private, non-commercial use. Any reproduction, processing,
+          distribution or other type of use of these translations that does not
+          fall within the relevant copyright exceptions requires the prior
+          consent of the author or other rights holder.
+        </p>
+        <SimpleSearchInput
+          v-model="activeSearchTerm"
+          class="my-48"
+          input-label="Search term"
+          input-placeholder="Search by title or abbreviation"
+          submit-label="Search"
+        />
+      </section>
+
+      <section :aria-labelledby="translationsListId" class="mt-48">
+        <h2 :id="translationsListId" class="sr-only">Translations List</h2>
+
+        <ul
+          v-if="sortedTranslations !== null && sortedTranslations.length > 0"
+          class="mt-48 flex flex-col gap-16"
         >
-          <h1 class="typo-headline1-bold">
-            English Translations of German Federal Laws and Regulations
-          </h1>
-          <p class="mb-8">
-            We provide translations of our German content to help you. Please
-            note that the original German versions are the only authoritative
-            source.
-          </p>
-          <p>
-            The translations published on this website may be used in accordance
-            with the applicable copyright exceptions. In particular, single
-            copies may be made including in the form of downloads or printouts
-            for private, non-commercial use. Any reproduction, processing,
-            distribution or other type of use of these translations that does
-            not fall within the relevant copyright exceptions requires the prior
-            consent of the author or other rights holder.
-          </p>
-          <SimpleSearchInput
-            v-model="activeSearchTerm"
-            class="my-48"
-            input-label="Search term"
-            input-placeholder="Search by title or abbreviation"
-            submit-label="Search"
-          />
-        </section>
-
-        <section :aria-labelledby="translationsListId" class="mt-48">
-          <h2 :id="translationsListId" class="sr-only">Translations List</h2>
-
-          <ul
-            v-if="sortedTranslations !== null && sortedTranslations.length > 0"
-            class="mt-48 flex flex-col gap-16"
+          <li
+            v-for="t in sortedTranslations"
+            :key="t['@id']"
+            class="bg-white p-16 sm:py-24 md:px-24 lg:px-32"
           >
-            <li
-              v-for="t in sortedTranslations"
-              :key="t['@id']"
-              class="bg-white p-16 sm:py-24 md:px-24 lg:px-32"
-            >
-              <div class="flex max-w-prose flex-col gap-8">
-                <SearchResultHeader
-                  lang="de"
-                  :items="[
-                    { value: t['@id'] },
-                    { value: t.translationOfWork ?? '' },
-                  ]"
-                />
+            <div class="flex max-w-prose flex-col gap-8">
+              <SearchResultHeader
+                lang="de"
+                :items="[
+                  { value: t['@id'] },
+                  { value: t.translationOfWork ?? '' },
+                ]"
+              />
 
-                <NuxtLink
-                  :to="{ name: 'translations-id', params: { id: t['@id'] } }"
-                  class="typo-headline-searchresult"
-                >
-                  <h2>{{ t.name }}</h2>
-                </NuxtLink>
+              <NuxtLink
+                :to="{ name: 'translations-id', params: { id: t['@id'] } }"
+                class="typo-headline-searchresult"
+              >
+                <h2>{{ t.name }}</h2>
+              </NuxtLink>
 
-                <p class="typo-body-regular text-gray-900">
-                  {{ t.translator }}
-                </p>
-              </div>
-            </li>
-          </ul>
+              <p class="typo-body-regular text-gray-900">
+                {{ t.translator }}
+              </p>
+            </div>
+          </li>
+        </ul>
 
-          <div v-else class="mt-8">
-            <p class="typo-body-bold">We didn’t find anything.</p>
-            <p class="mb-16">
-              Try checking the spelling or using a different title.
-            </p>
-          </div>
-        </section>
-      </div>
-    </template>
+        <div v-else class="mt-8">
+          <p class="typo-body-bold">We didn’t find anything.</p>
+          <p class="mb-16">
+            Try checking the spelling or using a different title.
+          </p>
+        </div>
+      </section>
+    </div>
   </NuxtLayout>
 </template>


### PR DESCRIPTION
This is the first batch of changes to align the Portal frontend pages to a common grid:

- Introduces a new `base-grid` utility that sets common responsive properties
- Aligns the static content, document, searches and landing pages to the grid