### PR TITLE
RISDEV-11525 Move XSLT code to shared library

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/BulkExportConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/BulkExportConfig.java
@@ -11,6 +11,7 @@ import de.bund.digitalservice.ris.search.service.BulkExportJob;
 import de.bund.digitalservice.ris.search.service.BulkExportService;
 import de.bund.digitalservice.ris.search.service.ChangelogService;
 import java.util.function.Predicate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,9 +25,16 @@ public class BulkExportConfig {
    * @return BulkExportService
    */
   @Bean
-  public BulkExportService normsBulkExportService(NormsBucket source, PublicFilesBucket target) {
+  public BulkExportService normsBulkExportService(
+      NormsBucket source,
+      @Value("${s3.file-storage.norm.versionPrefix}") String versionPrefix,
+      PublicFilesBucket target) {
     return new BulkExportService(
-        source, target, DocumentKind.LEGISLATION.getBulkZipPath(), "eli", key -> true);
+        source,
+        target,
+        DocumentKind.LEGISLATION.getBulkZipPath(),
+        versionPrefix + "eli",
+        key -> true);
   }
 
   /**
@@ -36,9 +44,15 @@ public class BulkExportConfig {
    */
   @Bean
   public BulkExportService caseLawBulkExportService(
-      CaseLawBucket source, PublicFilesBucket target) {
+      CaseLawBucket source,
+      @Value("${s3.file-storage.case-law.versionPrefix}") String versionPrefix,
+      PublicFilesBucket target) {
     return new BulkExportService(
-        source, target, DocumentKind.CASE_LAW.getBulkZipPath(), "", filterChangelogFiles());
+        source,
+        target,
+        DocumentKind.CASE_LAW.getBulkZipPath(),
+        versionPrefix,
+        filterChangelogFiles());
   }
 
   /**
@@ -48,12 +62,14 @@ public class BulkExportConfig {
    */
   @Bean
   public BulkExportService adminBulkExportService(
-      AdministrativeDirectiveBucket source, PublicFilesBucket target) {
+      AdministrativeDirectiveBucket source,
+      @Value("${s3.file-storage.administrative-directive.versionPrefix}") String versionPrefix,
+      PublicFilesBucket target) {
     return new BulkExportService(
         source,
         target,
         DocumentKind.ADMINISTRATIVE_DIRECTIVE.getBulkZipPath(),
-        "",
+        versionPrefix,
         filterChangelogFiles());
   }
 
@@ -64,9 +80,15 @@ public class BulkExportConfig {
    */
   @Bean
   public BulkExportService literatureBulkExportService(
-      LiteratureBucket source, PublicFilesBucket target) {
+      LiteratureBucket source,
+      @Value("${s3.file-storage.literature.versionPrefix}") String versionPrefix,
+      PublicFilesBucket target) {
     return new BulkExportService(
-        source, target, DocumentKind.LITERATURE.getBulkZipPath(), "", filterChangelogFiles());
+        source,
+        target,
+        DocumentKind.LITERATURE.getBulkZipPath(),
+        versionPrefix,
+        filterChangelogFiles());
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/BulkExportConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/BulkExportConfig.java
@@ -21,6 +21,7 @@ public class BulkExportConfig {
 
   /**
    * @param source sourceBucket to create the document snapshot from
+   * @param versionPrefix the version prefix for the bucket
    * @param target targetBucket to create the archive in
    * @return BulkExportService
    */
@@ -39,6 +40,7 @@ public class BulkExportConfig {
 
   /**
    * @param source sourceBucket to create the document snapshot from
+   * @param versionPrefix the version prefix for the bucket
    * @param target targetBucket to create the archive in
    * @return BulkExportService
    */
@@ -57,6 +59,7 @@ public class BulkExportConfig {
 
   /**
    * @param source sourceBucket to create the document snapshot from
+   * @param versionPrefix the version prefix for the bucket
    * @param target targetBucket to create the archive in
    * @return BulkExportService
    */
@@ -75,6 +78,7 @@ public class BulkExportConfig {
 
   /**
    * @param source sourceBucket to create the document snapshot from
+   * @param versionPrefix the version prefix for the bucket
    * @param target targetBucket to create the archive in
    * @return BulkExportService
    */

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/obs/ChangelogConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/obs/ChangelogConfig.java
@@ -6,6 +6,7 @@ import de.bund.digitalservice.ris.search.repository.objectstorage.CaseLawBucket;
 import de.bund.digitalservice.ris.search.repository.objectstorage.LiteratureBucket;
 import de.bund.digitalservice.ris.search.repository.objectstorage.NormsBucket;
 import de.bund.digitalservice.ris.search.service.ChangelogService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,8 +21,10 @@ public class ChangelogConfig {
    */
   @Bean
   public ChangelogService<CaseLawBucket> caseLawChangelogService(
-      CaseLawBucket bucket, ObjectMapper om) {
-    return new ChangelogService<>(bucket, om);
+      CaseLawBucket bucket,
+      @Value("${s3.file-storage.case-law.versionPrefix}") String versionPrefix,
+      ObjectMapper om) {
+    return new ChangelogService<>(bucket, versionPrefix, om);
   }
 
   /**
@@ -30,8 +33,11 @@ public class ChangelogConfig {
    * @return IndexedChangelogService configured to manage legislation files
    */
   @Bean
-  public ChangelogService<NormsBucket> normsChangelogService(NormsBucket bucket, ObjectMapper om) {
-    return new ChangelogService<>(bucket, om);
+  public ChangelogService<NormsBucket> normsChangelogService(
+      NormsBucket bucket,
+      @Value("${s3.file-storage.norm.versionPrefix}") String versionPrefix,
+      ObjectMapper om) {
+    return new ChangelogService<>(bucket, versionPrefix, om);
   }
 
   /**
@@ -41,8 +47,10 @@ public class ChangelogConfig {
    */
   @Bean
   public ChangelogService<LiteratureBucket> literatureChangelogService(
-      LiteratureBucket bucket, ObjectMapper om) {
-    return new ChangelogService<>(bucket, om);
+      LiteratureBucket bucket,
+      @Value("${s3.file-storage.literature.versionPrefix}") String versionPrefix,
+      ObjectMapper om) {
+    return new ChangelogService<>(bucket, versionPrefix, om);
   }
 
   /**
@@ -52,7 +60,9 @@ public class ChangelogConfig {
    */
   @Bean
   public ChangelogService<AdministrativeDirectiveBucket> administrativeDirectiveChangelogService(
-      AdministrativeDirectiveBucket bucket, ObjectMapper om) {
-    return new ChangelogService<>(bucket, om);
+      AdministrativeDirectiveBucket bucket,
+      @Value("${s3.file-storage.administrative-directive.versionPrefix}") String versionPrefix,
+      ObjectMapper om) {
+    return new ChangelogService<>(bucket, versionPrefix, om);
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/obs/ChangelogConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/obs/ChangelogConfig.java
@@ -16,6 +16,7 @@ public class ChangelogConfig {
 
   /**
    * @param bucket root bucket of case law files
+   * @param versionPrefix the version prefix for the bucket
    * @param om global ObjectMapper to parse the changelog files
    * @return ChangelogService configured to manage case law files
    */
@@ -29,6 +30,7 @@ public class ChangelogConfig {
 
   /**
    * @param bucket root bucket of norms files
+   * @param versionPrefix the version prefix for the bucket
    * @param om global ObjectMapper to parse the changelog files
    * @return IndexedChangelogService configured to manage legislation files
    */
@@ -42,6 +44,7 @@ public class ChangelogConfig {
 
   /**
    * @param bucket root bucket of literature files
+   * @param versionPrefix the version prefix for the bucket
    * @param om global ObjectMapper to parse the changelog files
    * @return IndexedChangelogService configured to manage literature files
    */
@@ -55,6 +58,7 @@ public class ChangelogConfig {
 
   /**
    * @param bucket root bucket of administrative directive files
+   * @param versionPrefix the version prefix for the bucket
    * @param om global ObjectMapper to parse the changelog files
    * @return IndexedChangelogService configured to manage administrative directive files
    */

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/CaseLawController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/CaseLawController.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpStatus;
@@ -60,6 +61,7 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 public class CaseLawController {
 
   private final CaseLawService caseLawService;
+  private final String versionPrefix;
   private final CaselawXsltTransformerService xsltTransformerService;
   private final ChangelogService<CaseLawBucket> changelogService;
 
@@ -67,14 +69,17 @@ public class CaseLawController {
    * Constructor for the CaseLawController class.
    *
    * @param caseLawService the service layer responsible for case law operations
+   * @param versionPrefix the version prefix for the bucket
    * @param xsltTransformerService the service used for XSLT transformations related to case law
    */
   @Autowired
   public CaseLawController(
       CaseLawService caseLawService,
+      @Value("${s3.file-storage.case-law.versionPrefix}") String versionPrefix,
       CaselawXsltTransformerService xsltTransformerService,
       ChangelogService<CaseLawBucket> changelogService) {
     this.caseLawService = caseLawService;
+    this.versionPrefix = versionPrefix;
     this.xsltTransformerService = xsltTransformerService;
     this.changelogService = changelogService;
   }
@@ -238,7 +243,7 @@ public class CaseLawController {
 
     byte[] resource =
         caseLawService
-            .getFileByPath(documentNumber + "/" + name + "." + extension)
+            .getFileByPath(versionPrefix + documentNumber + "/" + name + "." + extension)
             .orElseGet(
                 () -> {
                   try {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/NormsController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/NormsController.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
@@ -81,6 +82,7 @@ public class NormsController {
   public static final String NATURAL_IDENTIFIER_EXAMPLE = "s1325";
 
   private final NormsService normsService;
+  private final String versionPrefix;
   private final NormXsltTransformerService xsltTransformerService;
   private final ChangelogService<NormsBucket> changelogService;
 
@@ -88,14 +90,17 @@ public class NormsController {
    * Constructor for the NormsController class.
    *
    * @param normsService the service responsible for handling norms-related operations
+   * @param versionPrefix the version prefix for the bucket
    * @param xsltTransformerService the service responsible for transforming norms using XSLT
    */
   @Autowired
   public NormsController(
       NormsService normsService,
+      @Value("${s3.file-storage.norm.versionPrefix}") String versionPrefix,
       NormXsltTransformerService xsltTransformerService,
       ChangelogService<NormsBucket> changelogService) {
     this.normsService = normsService;
+    this.versionPrefix = versionPrefix;
     this.xsltTransformerService = xsltTransformerService;
     this.changelogService = changelogService;
   }
@@ -478,7 +483,7 @@ public class NormsController {
 
     String fileName = prefix + ".zip";
 
-    List<String> keys = normsService.getAllFilenamesByPath(prefix);
+    List<String> keys = normsService.getAllFilenamesByPath(versionPrefix + prefix);
 
     if (keys.isEmpty()) {
       return ResponseEntity.notFound().build();

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectStorage.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectStorage.java
@@ -47,8 +47,8 @@ public class ObjectStorage {
    * @return a list of keys as strings, where each key represents an object stored in the object
    *     storage
    */
-  public List<String> getAllKeys() {
-    return getAllKeysByPrefix("");
+  public List<String> getAllKeysOnCurrentVersion() {
+    return getAllKeysByPrefix(versionPrefix);
   }
 
   /**
@@ -58,7 +58,7 @@ public class ObjectStorage {
    * @return a list of matched object keys as strings
    */
   public List<String> getAllKeysByPrefix(String path) {
-    return client.listKeysByPrefix(versionPrefix + path);
+    return client.listKeysByPrefix(path);
   }
 
   /**
@@ -70,7 +70,7 @@ public class ObjectStorage {
    *     their last modified timestamps
    */
   public List<ObjectKeyInfo> getAllKeyInfosByPrefix(String path) {
-    return client.listByPrefixWithLastModified(versionPrefix + path);
+    return client.listByPrefixWithLastModified(path);
   }
 
   /**
@@ -104,7 +104,7 @@ public class ObjectStorage {
         final var response = getStream(objectKey);
         return Optional.of(response.readAllBytes());
       } catch (NoSuchKeyException e) {
-        logger.warn(String.format("Object key %s does not exist", versionPrefix + objectKey));
+        logger.warn(String.format("Object key %s does not exist", objectKey));
         return Optional.empty();
       } catch (IOException | AwsServiceException | SdkClientException e) {
         logger.warn(
@@ -120,15 +120,15 @@ public class ObjectStorage {
   }
 
   public FilterInputStream getStream(String objectKey) throws NoSuchKeyException {
-    return client.getStream(versionPrefix + objectKey);
+    return client.getStream(objectKey);
   }
 
   public void delete(String fileName) {
-    client.delete(versionPrefix + fileName);
+    client.delete(fileName);
   }
 
   public void save(String fileName, String fileContent) {
-    client.save(versionPrefix + fileName, fileContent);
+    client.save(fileName, fileContent);
   }
 
   public void close() {
@@ -136,6 +136,6 @@ public class ObjectStorage {
   }
 
   public long putStream(String objectKey, InputStream inputStream) throws IOException {
-    return client.putStream(versionPrefix + objectKey, inputStream);
+    return client.putStream(objectKey, inputStream);
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/AdministrativeDirectiveService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/AdministrativeDirectiveService.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.opensearch.data.client.orhlc.NativeSearchQuery;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -29,6 +30,7 @@ import org.springframework.stereotype.Service;
 public class AdministrativeDirectiveService {
   private final AdministrativeDirectiveRepository repository;
   private final AdministrativeDirectiveBucket bucket;
+  private final String versionPrefix;
   private final ElasticsearchOperations operations;
   private final SimpleSearchQueryBuilder simpleSearchQueryBuilder;
 
@@ -37,6 +39,7 @@ public class AdministrativeDirectiveService {
    *
    * @param repository Repository for AdministrativeDirective entities.
    * @param bucket Object storage bucket for AdministrativeDirective files.
+   * @param versionPrefix the version prefix for the bucket
    * @param operations Elasticsearch operations for querying the database.
    * @param simpleSearchQueryBuilder Builder for constructing simple search queries.
    */
@@ -45,10 +48,12 @@ public class AdministrativeDirectiveService {
   public AdministrativeDirectiveService(
       AdministrativeDirectiveRepository repository,
       AdministrativeDirectiveBucket bucket,
+      @Value("${s3.file-storage.administrative-directive.versionPrefix}") String versionPrefix,
       ElasticsearchOperations operations,
       SimpleSearchQueryBuilder simpleSearchQueryBuilder) {
     this.repository = repository;
     this.bucket = bucket;
+    this.versionPrefix = versionPrefix;
     this.operations = operations;
     this.simpleSearchQueryBuilder = simpleSearchQueryBuilder;
   }
@@ -84,7 +89,7 @@ public class AdministrativeDirectiveService {
    */
   public Optional<byte[]> getFileByDocumentNumber(String documentNumber) {
     try {
-      return bucket.get(String.format("%s.akn.xml", documentNumber));
+      return bucket.get(String.format("%s%s.akn.xml", versionPrefix, documentNumber));
     } catch (ObjectStoreServiceException e) {
       return Optional.empty();
     }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/BaseIndexService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/BaseIndexService.java
@@ -111,7 +111,7 @@ public abstract class BaseIndexService<T> implements IndexService {
   protected abstract Optional<T> mapFileToEntity(String filename, String fileContent);
 
   protected List<String> getAllIndexableFilenames() {
-    return objectStorage.getAllKeys().stream()
+    return objectStorage.getAllKeysOnCurrentVersion().stream()
         .filter(s -> s.endsWith(".xml") && !s.contains(ChangelogService.CHANGELOGS_PREFIX))
         .toList();
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/CaseLawService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/CaseLawService.java
@@ -29,6 +29,7 @@ import org.opensearch.search.aggregations.bucket.terms.ParsedStringTerms;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -44,6 +45,7 @@ import org.springframework.stereotype.Service;
 public class CaseLawService {
   private final CaseLawRepository caseLawRepository;
   private final CaseLawBucket caseLawBucket;
+  private final String versionPrefix;
   private final ElasticsearchOperations operations;
   private final CourtNameAbbreviationExpander courtNameAbbreviationExpander;
   private final Configurations configurations;
@@ -55,6 +57,7 @@ public class CaseLawService {
    *
    * @param caseLawRepository the repository responsible for managing CaseLaw entities
    * @param caseLawBucket the bucket for storing and managing case law data in bulk operations
+   * @param versionPrefix the version prefix for the bucket
    * @param operations the ElasticsearchOperations instance to interact with Elasticsearch
    * @param configurations the configurations required for the service
    * @param marshaller the mapper for converting CaseLaw entities to OpenSearch format
@@ -65,12 +68,14 @@ public class CaseLawService {
   public CaseLawService(
       CaseLawRepository caseLawRepository,
       CaseLawBucket caseLawBucket,
+      @Value("${s3.file-storage.case-law.versionPrefix}") String versionPrefix,
       ElasticsearchOperations operations,
       Configurations configurations,
       CaseLawLdmlToOpenSearchMapper marshaller,
       SimpleSearchQueryBuilder simpleSearchQueryBuilder) {
     this.caseLawRepository = caseLawRepository;
     this.caseLawBucket = caseLawBucket;
+    this.versionPrefix = versionPrefix;
     this.operations = operations;
     this.configurations = configurations;
     this.courtNameAbbreviationExpander = new CourtNameAbbreviationExpander();
@@ -164,7 +169,8 @@ public class CaseLawService {
 
   public Optional<byte[]> getFileByDocumentNumber(String documentNumber)
       throws ObjectStoreServiceException {
-    return caseLawBucket.get(String.format("%s/%s.xml", documentNumber, documentNumber));
+    return caseLawBucket.get(
+        String.format("%s%s/%s.xml", versionPrefix, documentNumber, documentNumber));
   }
 
   public Optional<byte[]> getFileByPath(String path) throws ObjectStoreServiceException {
@@ -176,7 +182,7 @@ public class CaseLawService {
   }
 
   public List<String> getAllFilenamesByDocumentNumber(String documentNumber) {
-    return caseLawBucket.getAllKeysByPrefix(documentNumber);
+    return caseLawBucket.getAllKeysByPrefix(versionPrefix + documentNumber);
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/CaseLawService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/CaseLawService.java
@@ -167,6 +167,12 @@ public class CaseLawService {
     return caseLawRepository.findByDocumentNumber(documentNumber);
   }
 
+  /**
+   * Get a file by its document number.
+   *
+   * @param documentNumber the document number of the file to get
+   * @return the file
+   */
   public Optional<byte[]> getFileByDocumentNumber(String documentNumber)
       throws ObjectStoreServiceException {
     return caseLawBucket.get(

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/ChangelogService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/ChangelogService.java
@@ -20,10 +20,10 @@ public class ChangelogService<T extends ObjectStorage> {
 
   private static final Logger logger = LogManager.getLogger(ChangelogService.class);
 
-  private final ObjectStorage bucket;
-
   public static final String CHANGELOGS_PREFIX = "changelogs/";
 
+  private final ObjectStorage bucket;
+  private final String versionPrefix;
   private final ObjectReader changelogReader;
 
   /**
@@ -32,8 +32,9 @@ public class ChangelogService<T extends ObjectStorage> {
    * @param bucket bucket containing the changelogs
    * @param objectMapper global ObjectMapper to create a Changelog Reader
    */
-  public ChangelogService(T bucket, ObjectMapper objectMapper) {
+  public ChangelogService(T bucket, String versionPrefix, ObjectMapper objectMapper) {
     this.bucket = bucket;
+    this.versionPrefix = versionPrefix;
     this.changelogReader = objectMapper.readerFor(Changelog.class);
   }
 
@@ -52,7 +53,7 @@ public class ChangelogService<T extends ObjectStorage> {
    */
   public List<String> getNewChangelogsPaths(@NotNull String lastProcessedChangelog) {
 
-    return bucket.getAllKeysByPrefix(CHANGELOGS_PREFIX).stream()
+    return bucket.getAllKeysByPrefix(versionPrefix + CHANGELOGS_PREFIX).stream()
         .filter(e -> !CHANGELOGS_PREFIX.equals(e))
         .filter(e -> e.compareTo(lastProcessedChangelog) > 0)
         .sorted()
@@ -102,7 +103,7 @@ public class ChangelogService<T extends ObjectStorage> {
   public Changelog getChangesBetween(Instant from, Instant to) throws ObjectStoreServiceException {
 
     var changelogs =
-        bucket.getAllKeysByPrefix(CHANGELOGS_PREFIX).stream()
+        bucket.getAllKeysByPrefix(versionPrefix + CHANGELOGS_PREFIX).stream()
             .filter(e -> !CHANGELOGS_PREFIX.equals(e))
             .filter(
                 e -> {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
@@ -11,7 +11,6 @@ import de.bund.digitalservice.ris.search.utils.BatchUtils;
 import de.bund.digitalservice.ris.search.utils.DateUtils;
 import de.bund.digitalservice.ris.search.utils.eli.EliFile;
 import de.bund.digitalservice.ris.search.utils.eli.ExpressionEli;
-import de.bund.digitalservice.ris.search.utils.eli.ManifestationEli;
 import de.bund.digitalservice.ris.search.utils.eli.WorkEli;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -30,6 +29,7 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
 import org.springframework.stereotype.Service;
@@ -44,6 +44,7 @@ public class IndexNormsService implements IndexService {
   private final NormsRepository normsRepository;
   private final ArticlesRepository articlesRepository;
   private final NormsBucket normsBucket;
+  private final String versionPrefix;
 
   // We can't use LocalDate.MIN or LocalDate.MAX because opensearch min and max differ from java
   public static final LocalDate TIME_RELEVANCE_MIN = LocalDate.of(1, Month.JANUARY, 1);
@@ -61,10 +62,12 @@ public class IndexNormsService implements IndexService {
   public IndexNormsService(
       Environment environment,
       NormsBucket normsBucket,
+      @Value("${s3.file-storage.norm.versionPrefix}") String versionPrefix,
       NormsRepository normsRepository,
       ArticlesRepository articlesRepository) {
     this.environment = environment;
     this.normsBucket = normsBucket;
+    this.versionPrefix = versionPrefix;
     this.normsRepository = normsRepository;
     this.articlesRepository = articlesRepository;
   }
@@ -76,7 +79,7 @@ public class IndexNormsService implements IndexService {
    */
   public void reindexAll(String startingTimestamp) {
     DateUtils.avoidOpenSearchSubMillisecondDateBug();
-    List<String> allFiles = normsBucket.getAllKeysByPrefix("eli/");
+    List<String> allFiles = normsBucket.getAllKeysByPrefix(versionPrefix + "eli/");
     Map<WorkEli, List<String>> workElis = groupFilesByWorkEli(allFiles.stream());
     processWorkEliUpdates(workElis, startingTimestamp);
     clearOldNorms(startingTimestamp);
@@ -91,7 +94,8 @@ public class IndexNormsService implements IndexService {
       // retrieve all file paths for the given workElis
       Map<WorkEli, List<String>> allFilesByWorkEli = new HashMap<>();
       for (WorkEli workEli : workElis) {
-        allFilesByWorkEli.put(workEli, normsBucket.getAllKeysByPrefix(workEli.toString() + "/"));
+        allFilesByWorkEli.put(
+            workEli, normsBucket.getAllKeysByPrefix(versionPrefix + workEli.toString() + "/"));
       }
       processWorkEliUpdates(allFilesByWorkEli, Instant.now().toString());
     } catch (IllegalArgumentException e) {
@@ -249,7 +253,10 @@ public class IndexNormsService implements IndexService {
 
     // Get all files for the current expression.
     final List<String> keysMatchingExpressionEli =
-        filenames.stream().filter(n -> n.startsWith(expressionEli.toString())).toList();
+        filenames.stream()
+            .filter(n -> n.startsWith(versionPrefix + expressionEli.toString()))
+            .map(e -> e.substring(versionPrefix.length()))
+            .toList();
 
     Optional<String> newestFileName =
         keysMatchingExpressionEli.stream()
@@ -261,7 +268,7 @@ public class IndexNormsService implements IndexService {
             // only get the manifestation files that represent expression xml files
             .filter(e -> e.subtype().startsWith("regelungstext-"))
             // take the manifestation with the latest pointInTimeManifestation
-            .map(ManifestationEli::toString)
+            .map(e -> versionPrefix + e)
             .max(java.util.Comparator.naturalOrder());
 
     if (newestFileName.isEmpty()) {
@@ -318,7 +325,7 @@ public class IndexNormsService implements IndexService {
    */
   public int getNumberOfIndexableDocumentsInBucket() {
     Set<ExpressionEli> norms =
-        normsBucket.getAllKeysByPrefix("eli/").stream()
+        normsBucket.getAllKeysByPrefix(versionPrefix + "eli/").stream()
             .map(EliFile::fromString)
             .flatMap(Optional::stream)
             .filter(e -> e.fileName().startsWith("regelungstext-"))

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/LiteratureService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/LiteratureService.java
@@ -20,6 +20,7 @@ import org.opensearch.data.client.orhlc.NativeSearchQuery;
 import org.opensearch.data.client.orhlc.NativeSearchQueryBuilder;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -34,6 +35,7 @@ import org.springframework.stereotype.Service;
 public class LiteratureService {
   private final LiteratureRepository literatureRepository;
   private final LiteratureBucket literatureBucket;
+  private final String versionPrefix;
   private final ElasticsearchOperations operations;
   private final SimpleSearchQueryBuilder simpleSearchQueryBuilder;
 
@@ -42,6 +44,7 @@ public class LiteratureService {
    *
    * @param literatureRepository Repository for literature data
    * @param literatureBucket Bucket for literature files
+   * @param versionPrefix the version prefix for the bucket
    * @param operations Elasticsearch operations for querying
    * @param simpleSearchQueryBuilder Builder for simple search queries
    */
@@ -50,10 +53,12 @@ public class LiteratureService {
   public LiteratureService(
       LiteratureRepository literatureRepository,
       LiteratureBucket literatureBucket,
+      @Value("${s3.file-storage.literature.versionPrefix}") String versionPrefix,
       ElasticsearchOperations operations,
       SimpleSearchQueryBuilder simpleSearchQueryBuilder) {
     this.literatureRepository = literatureRepository;
     this.literatureBucket = literatureBucket;
+    this.versionPrefix = versionPrefix;
     this.operations = operations;
     this.simpleSearchQueryBuilder = simpleSearchQueryBuilder;
   }
@@ -122,6 +127,6 @@ public class LiteratureService {
    */
   public Optional<byte[]> getFileByDocumentNumber(String documentNumber)
       throws ObjectStoreServiceException {
-    return literatureBucket.get(String.format("%s.akn.xml", documentNumber));
+    return literatureBucket.get(String.format("%s%s.akn.xml", versionPrefix, documentNumber));
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormsService.java
@@ -61,6 +61,7 @@ public class NormsService {
   private final ArticleService articleService;
   private final RestHighLevelClient openSearchRestClient;
   private final NormsBucket normsBucket;
+  private final String versionPrefix;
   private final String normsIndexName;
   private static final String DATE_FORMAT = "yyyy-MM-dd";
 
@@ -69,6 +70,7 @@ public class NormsService {
    *
    * @param normsRepository The repository for interacting with the OpenSearch norms.
    * @param normsBucket The object storage bucket for norms files.
+   * @param versionPrefix the version prefix for the bucket
    * @param operations The Elasticsearch operations for executing queries.
    * @param simpleSearchQueryBuilder The query builder for constructing search queries.
    */
@@ -76,6 +78,7 @@ public class NormsService {
   public NormsService(
       NormsRepository normsRepository,
       NormsBucket normsBucket,
+      @Value("${s3.file-storage.norm.versionPrefix}") String versionPrefix,
       ElasticsearchOperations operations,
       RestHighLevelClient openSearchRestClient,
       SimpleSearchQueryBuilder simpleSearchQueryBuilder,
@@ -83,6 +86,7 @@ public class NormsService {
       @Value("${opensearch.norms-index-name}") String normsIndexName) {
     this.normsRepository = normsRepository;
     this.normsBucket = normsBucket;
+    this.versionPrefix = versionPrefix;
     this.operations = operations;
     this.openSearchRestClient = openSearchRestClient;
     this.simpleSearchQueryBuilder = simpleSearchQueryBuilder;
@@ -138,7 +142,7 @@ public class NormsService {
    */
   public Optional<byte[]> getNormFileByEli(ManifestationEli eli)
       throws ObjectStoreServiceException {
-    return normsBucket.get(eli.toString());
+    return normsBucket.get(versionPrefix + eli.toString());
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapsUpdateJob.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapsUpdateJob.java
@@ -69,7 +69,7 @@ public class SitemapsUpdateJob implements Job {
   public void createSitemaps(ObjectStorage currentBucket, DocumentKind docKind) {
     String prefix = docKind.getSiteMapPath();
     List<String> ids =
-        currentBucket.getAllKeys().stream()
+        currentBucket.getAllKeysOnCurrentVersion().stream()
             .map(e -> DocumentKind.extractIdFromFileName(e, docKind))
             .flatMap(Optional::stream)
             .distinct()

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/eclicrawler/EcliCrawlerDocumentService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/eclicrawler/EcliCrawlerDocumentService.java
@@ -126,7 +126,7 @@ public class EcliCrawlerDocumentService {
    */
   public void writeFullDiff(String apiUrl, LocalDate day) {
     List<String> allFiles =
-        caselawBucket.getAllKeys().stream()
+        caselawBucket.getAllKeysOnCurrentVersion().stream()
             .filter(s -> s.endsWith(".xml") && !s.contains(ChangelogService.CHANGELOGS_PREFIX))
             .toList();
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/xslt/NormXsltTransformerService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/xslt/NormXsltTransformerService.java
@@ -13,6 +13,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.stream.StreamSource;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriUtils;
 
@@ -24,6 +25,7 @@ public class NormXsltTransformerService extends XsltTransformer {
   static final String DEBUGGING_VALUE = "false";
 
   private final NormsBucket normsBucket;
+  private final String versionPrefix;
 
   @Override
   String getXsltBasePath() {
@@ -35,9 +37,17 @@ public class NormXsltTransformerService extends XsltTransformer {
     return "ris-portal.xsl";
   }
 
-  /** Key for the resource path parameter passed to the XSLT transformer. */
-  public NormXsltTransformerService(NormsBucket normsBucket) {
+  /**
+   * Constructs a new instance of {@code NormXsltTransformerService}.
+   *
+   * @param normsBucket The object storage bucket for norms files.
+   * @param versionPrefix the version prefix for the bucket
+   */
+  public NormXsltTransformerService(
+      NormsBucket normsBucket,
+      @Value("${s3.file-storage.norm.versionPrefix}") String versionPrefix) {
     this.normsBucket = normsBucket;
+    this.versionPrefix = versionPrefix;
     setCustomUriResolver();
   }
 
@@ -76,7 +86,7 @@ public class NormXsltTransformerService extends XsltTransformer {
   @NotNull
   private StreamSource resolveEliResource(EliFile eliFile) throws TransformerException {
     try {
-      var response = this.normsBucket.getStream(eliFile.toString());
+      var response = this.normsBucket.getStream(versionPrefix + eliFile.toString());
       return new StreamSource(response);
     } catch (NoSuchKeyException | NullPointerException e) {
       throw new TransformerException("Failed to resolve: " + eliFile, e);

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/BulkZipControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/BulkZipControllerTest.java
@@ -37,7 +37,7 @@ class BulkZipControllerTest extends ContainersIntegrationBase {
   void endpointShouldReturnCorrectCount() throws Exception {
     // Empty the bucket and add mock files. 2 for case law and 1 for the others. The content is not
     // relevant to test the links
-    for (String key : publicFilesBucket.getAllKeys()) {
+    for (String key : publicFilesBucket.getAllKeysOnCurrentVersion()) {
       publicFilesBucket.delete(key);
     }
     String bulkZipPattern = BulkExportService.BULK_ZIP_PREFIX + "%s_2026-01-%sT00:00:00.zip";

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/administrative_directive/AdministrativeDirectiveIndexSyncJobTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/administrative_directive/AdministrativeDirectiveIndexSyncJobTest.java
@@ -34,8 +34,8 @@ class AdministrativeDirectiveIndexSyncJobTest extends ContainersIntegrationBase 
 
   @BeforeEach
   void setup() {
-    bucket.getAllKeys().forEach(bucket::delete);
-    portalBucket.getAllKeys().forEach(portalBucket::delete);
+    bucket.getAllKeysOnCurrentVersion().forEach(bucket::delete);
+    portalBucket.getAllKeysOnCurrentVersion().forEach(portalBucket::delete);
     administrativeDirectiveRepository.deleteAll();
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/caselaw/CaseLawImportStatusTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/caselaw/CaseLawImportStatusTest.java
@@ -49,9 +49,9 @@ class CaseLawImportStatusTest extends ContainersIntegrationBase {
 
   @Test
   void createsLastSuccessFileProperly() throws ObjectStoreServiceException {
-    Assertions.assertEquals(5, caseLawBucket.getAllKeys().size());
+    Assertions.assertEquals(5, caseLawBucket.getAllKeysOnCurrentVersion().size());
     caseLawIndexSyncJob.runJob();
-    Assertions.assertEquals(5, caseLawBucket.getAllKeys().size());
+    Assertions.assertEquals(5, caseLawBucket.getAllKeysOnCurrentVersion().size());
     IndexingState result =
         indexStatusService.loadStatus(CaseLawIndexSyncJob.CASELAW_STATUS_FILENAME);
     Assertions.assertNotNull(result.lastProcessedChangelogFile());

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/literature/LiteratureImportStatusTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/literature/LiteratureImportStatusTest.java
@@ -40,9 +40,9 @@ class LiteratureImportStatusTest extends ContainersIntegrationBase {
 
   @Test
   void createsLastSuccessFileProperly() throws ObjectStoreServiceException {
-    assertThat(literatureBucket.getAllKeys()).hasSize(2);
+    assertThat(literatureBucket.getAllKeysOnCurrentVersion()).hasSize(2);
     literatureIndexSyncJob.runJob();
-    assertThat(literatureBucket.getAllKeys()).hasSize(2);
+    assertThat(literatureBucket.getAllKeysOnCurrentVersion()).hasSize(2);
     IndexingState result =
         indexStatusService.loadStatus(LiteratureIndexSyncJob.LITERATURE_STATUS_FILENAME);
     assertThat(result.lastProcessedChangelogFile()).isNotNull();

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/literature/LiteratureIndexSyncJobTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/literature/LiteratureIndexSyncJobTest.java
@@ -29,8 +29,8 @@ class LiteratureIndexSyncJobTest extends ContainersIntegrationBase {
 
   @BeforeEach
   void setup() {
-    bucket.getAllKeys().forEach(bucket::delete);
-    portalBucket.getAllKeys().forEach(portalBucket::delete);
+    bucket.getAllKeysOnCurrentVersion().forEach(bucket::delete);
+    portalBucket.getAllKeysOnCurrentVersion().forEach(portalBucket::delete);
     literatureRepository.deleteAll();
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/repository/LiteratureBucketIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/repository/LiteratureBucketIntegrationTest.java
@@ -21,20 +21,20 @@ class LiteratureBucketIntegrationTest {
 
   @BeforeEach
   void setUp() {
-    bucket.getAllKeys().forEach(key -> bucket.delete(key));
+    bucket.getAllKeysOnCurrentVersion().forEach(key -> bucket.delete(key));
   }
 
   @Test
   void getAllKeysReturnsAllKeys() {
     bucket.save("XXLU000000001.akn.xml", "");
     bucket.save("changelog.json", "");
-    assertThat(bucket.getAllKeys())
+    assertThat(bucket.getAllKeysOnCurrentVersion())
         .containsExactlyInAnyOrder("changelog.json", "XXLU000000001.akn.xml");
   }
 
   @Test
   void getAllKeysReturnsEmptyListIfBucketIsEmpty() {
-    assertThat(bucket.getAllKeys()).isEmpty();
+    assertThat(bucket.getAllKeysOnCurrentVersion()).isEmpty();
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/repository/LiteratureBucketDummyTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/repository/LiteratureBucketDummyTest.java
@@ -16,7 +16,7 @@ class LiteratureBucketDummyTest {
   @Test
   void getAllKeysAlwaysReturnsEmptyList() {
     bucket.save("foo.xml", "");
-    assertThat(bucket.getAllKeys()).isEmpty();
+    assertThat(bucket.getAllKeysOnCurrentVersion()).isEmpty();
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/CaseLawServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/CaseLawServiceTest.java
@@ -40,6 +40,7 @@ class CaseLawServiceTest {
         new CaseLawService(
             caseLawRepositoryMock,
             caseLawBucketMock,
+            "",
             operationsMock,
             configurations,
             marshaller,

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/ChangelogServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/ChangelogServiceTest.java
@@ -35,7 +35,7 @@ class ChangelogServiceTest {
 
   @BeforeEach
   void setup() {
-    changelogService = new ChangelogService(bucket, objectMapper) {};
+    changelogService = new ChangelogService(bucket, "", objectMapper) {};
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexLiteratureServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexLiteratureServiceTest.java
@@ -43,7 +43,7 @@ class IndexLiteratureServiceTest {
     var filenameB = "XXLU000000002.akn.xml";
     final String xml = LoadXmlUtils.loadXmlAsString(Literature.class, filenameA);
 
-    when(this.bucket.getAllKeys()).thenReturn(List.of(filenameA, filenameB));
+    when(this.bucket.getAllKeysOnCurrentVersion()).thenReturn(List.of(filenameA, filenameB));
     when(this.bucket.getFileAsString(filenameA)).thenReturn(Optional.of(xml));
     when(this.bucket.getFileAsString(filenameB)).thenReturn(Optional.of("this will not parse"));
 
@@ -69,7 +69,8 @@ class IndexLiteratureServiceTest {
     var filenameD = "XXXLU000000002.akn.xml";
     final String xml = LoadXmlUtils.loadXmlAsString(Literature.class, filenameA);
 
-    when(this.bucket.getAllKeys()).thenReturn(List.of(filenameA, filenameB, filenameC, filenameD));
+    when(this.bucket.getAllKeysOnCurrentVersion())
+        .thenReturn(List.of(filenameA, filenameB, filenameC, filenameD));
     when(this.bucket.getFileAsString(filenameA)).thenReturn(Optional.of(xml));
     when(this.bucket.getFileAsString(filenameB)).thenReturn(Optional.of(xml));
     when(this.bucket.getFileAsString(filenameC)).thenReturn(Optional.of(xml));
@@ -137,7 +138,7 @@ class IndexLiteratureServiceTest {
 
   @Test
   void itReturnsRightNumberOfFiles() {
-    when(this.bucket.getAllKeys())
+    when(this.bucket.getAllKeysOnCurrentVersion())
         .thenReturn(
             List.of(
                 "XXLU000000001.akn.xml",

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexNormsServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexNormsServiceTest.java
@@ -33,7 +33,7 @@ class IndexNormsServiceTest {
 
   @BeforeEach()
   void setup() {
-    this.service = new IndexNormsService(environment, bucket, repo, articlesRepository);
+    this.service = new IndexNormsService(environment, bucket, "", repo, articlesRepository);
   }
 
   private final String testContent =

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/LiteratureServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/LiteratureServiceTest.java
@@ -45,7 +45,8 @@ class LiteratureServiceTest {
     literatureBucketMock = Mockito.mock(LiteratureBucket.class);
     operationsMock = Mockito.mock(ElasticsearchOperations.class);
     this.literatureService =
-        new LiteratureService(literatureRepositoryMock, literatureBucketMock, operationsMock, null);
+        new LiteratureService(
+            literatureRepositoryMock, literatureBucketMock, "", operationsMock, null);
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/SitemapsUpdateJobTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/SitemapsUpdateJobTest.java
@@ -68,10 +68,11 @@ class SitemapsUpdateJobTest {
               + "/1992-01-01/1/deu/1992-01-02/regelungstext-verkuendung-1.xml");
     }
 
-    when(administrativeDirectiveBucket.getAllKeys()).thenReturn(administrativeDirective);
-    when(caseLawBucket.getAllKeys()).thenReturn(caseLawKeys);
-    when(literatureBucket.getAllKeys()).thenReturn(literatureKeys);
-    when(normsBucket.getAllKeys()).thenReturn(normsKeys);
+    when(administrativeDirectiveBucket.getAllKeysOnCurrentVersion())
+        .thenReturn(administrativeDirective);
+    when(caseLawBucket.getAllKeysOnCurrentVersion()).thenReturn(caseLawKeys);
+    when(literatureBucket.getAllKeysOnCurrentVersion()).thenReturn(literatureKeys);
+    when(normsBucket.getAllKeysOnCurrentVersion()).thenReturn(normsKeys);
 
     sitemapsUpdateJob.runJob();
 
@@ -115,10 +116,10 @@ class SitemapsUpdateJobTest {
             "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/NOT_VALID/regelungstext-1.xml",
             "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/NOT_VALID/something-else.xml");
 
-    when(administrativeDirectiveBucket.getAllKeys()).thenReturn(vvKeys);
-    when(caseLawBucket.getAllKeys()).thenReturn(caselawKeys);
-    when(literatureBucket.getAllKeys()).thenReturn(literatureKeys);
-    when(normsBucket.getAllKeys()).thenReturn(normsKeys);
+    when(administrativeDirectiveBucket.getAllKeysOnCurrentVersion()).thenReturn(vvKeys);
+    when(caseLawBucket.getAllKeysOnCurrentVersion()).thenReturn(caselawKeys);
+    when(literatureBucket.getAllKeysOnCurrentVersion()).thenReturn(literatureKeys);
+    when(normsBucket.getAllKeysOnCurrentVersion()).thenReturn(normsKeys);
 
     sitemapsUpdateJob.runJob();
 
@@ -134,7 +135,7 @@ class SitemapsUpdateJobTest {
             "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-2.xml",
             "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/anlage-regelungstext-1.xml");
 
-    when(normsBucket.getAllKeys()).thenReturn(normsKeys);
+    when(normsBucket.getAllKeysOnCurrentVersion()).thenReturn(normsKeys);
 
     sitemapsUpdateJob.createSitemaps(normsBucket, DocumentKind.LEGISLATION);
 
@@ -151,7 +152,7 @@ class SitemapsUpdateJobTest {
             "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-verkuendung-1.xml",
             "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-03-10/regelungstext-verkuendung-1.xml");
 
-    when(normsBucket.getAllKeys()).thenReturn(normsKeys);
+    when(normsBucket.getAllKeysOnCurrentVersion()).thenReturn(normsKeys);
 
     sitemapsUpdateJob.createSitemaps(normsBucket, DocumentKind.LEGISLATION);
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/eclicrawler/EcliCrawlerDocumentServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/eclicrawler/EcliCrawlerDocumentServiceTest.java
@@ -84,7 +84,7 @@ class EcliCrawlerDocumentServiceTest {
     LocalDate day = LocalDate.of(2025, Month.JANUARY, 1);
     var filenames = IntStream.range(0, 11000).boxed().map(i -> "file_" + i + ".xml").toList();
 
-    when(caseLawBucket.getAllKeys()).thenReturn(filenames);
+    when(caseLawBucket.getAllKeysOnCurrentVersion()).thenReturn(filenames);
     when(caselawService.getFromBucket(any())).thenReturn(Optional.of(getTestDocUnit("docNumber")));
 
     when(sitemapWriter.writeUrlsToSitemap(eq(day), any(), eq(1)))

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/xslt/NormXsltTransformerServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/xslt/NormXsltTransformerServiceTest.java
@@ -29,7 +29,7 @@ class NormXsltTransformerServiceTest {
 
   private final NormsBucket normsBucketMock = Mockito.mock(NormsBucket.class);
   private final NormXsltTransformerService service =
-      new NormXsltTransformerService(normsBucketMock);
+      new NormXsltTransformerService(normsBucketMock, "");
 
   String resourcesPath = getClass().getResource("/data/XsltTransformerServiceTest/").getPath();
 


### PR DESCRIPTION
*Refactor the bucket versionPrefix to be the responsibility of the caller. Due to the cahngelog files having the full file path it would get confusing to have it as a low level invisible prefix.