### PR TITLE
RISDEV-10394 review feedback fixes to grid alignment

### DIFF
--- a/frontend/src/assets/layout.css
+++ b/frontend/src/assets/layout.css
@@ -7,5 +7,5 @@
 }
 
 @utility content-grid-textblock {
-  @apply col-span-12 lg:col-span-8 2xl:col-span-6;
+  @apply col-span-12 lg:col-span-8 xl:col-span-7 2xl:col-span-6;
 }

--- a/frontend/src/assets/print.css
+++ b/frontend/src/assets/print.css
@@ -3,10 +3,6 @@
     --max-width-prose: 100%;
   }
 
-  body {
-    @apply text-sm;
-  }
-
   article {
     @apply break-inside-avoid-page;
 

--- a/frontend/src/pages/translations/index.vue
+++ b/frontend/src/pages/translations/index.vue
@@ -121,10 +121,7 @@ const translationsListId = useId();
         </div>
       </section>
 
-      <section
-        :aria-labelledby="translationsListId"
-        class="col-span-12 xl:col-span-8"
-      >
+      <section :aria-labelledby="translationsListId" class="col-span-12">
         <h2 :id="translationsListId" class="sr-only">Translations List</h2>
 
         <ul


### PR DESCRIPTION
Fixes remaining functional review findings:

- removes explicit font size for printing
- limit text content to 7 columns on xl breakpoint
- translation search results always span the full page width