### PR TITLE
RISDEV-11525 Move XSLT code to shared library

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/BulkExportConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/BulkExportConfig.java
@@ -10,7 +10,6 @@ import de.bund.digitalservice.ris.search.repository.objectstorage.PublicFilesBuc
 import de.bund.digitalservice.ris.search.service.BulkExportJob;
 import de.bund.digitalservice.ris.search.service.BulkExportService;
 import de.bund.digitalservice.ris.search.service.ChangelogService;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,62 +19,46 @@ public class BulkExportConfig {
 
   /**
    * @param source sourceBucket to create the document snapshot from
-   * @param versionPrefix the version prefix for the bucket
    * @param target targetBucket to create the archive in
    * @return BulkExportService
    */
   @Bean
-  public BulkExportService normsBulkExportService(
-      NormsBucket source,
-      @Value("${s3.file-storage.norm.versionPrefix}") String versionPrefix,
-      PublicFilesBucket target) {
-    return new BulkExportService(
-        source, target, DocumentKind.LEGISLATION.getBulkZipPath(), versionPrefix);
+  public BulkExportService normsBulkExportService(NormsBucket source, PublicFilesBucket target) {
+    return new BulkExportService(source, target, DocumentKind.LEGISLATION.getBulkZipPath());
   }
 
   /**
    * @param source sourceBucket to create the document snapshot from
-   * @param versionPrefix the version prefix for the bucket
    * @param target targetBucket to create the archive in
    * @return BulkExportService
    */
   @Bean
   public BulkExportService caseLawBulkExportService(
-      CaseLawBucket source,
-      @Value("${s3.file-storage.case-law.versionPrefix}") String versionPrefix,
-      PublicFilesBucket target) {
-    return new BulkExportService(
-        source, target, DocumentKind.CASE_LAW.getBulkZipPath(), versionPrefix);
+      CaseLawBucket source, PublicFilesBucket target) {
+    return new BulkExportService(source, target, DocumentKind.CASE_LAW.getBulkZipPath());
   }
 
   /**
    * @param source sourceBucket to create the document snapshot from
-   * @param versionPrefix the version prefix for the bucket
    * @param target targetBucket to create the archive in
    * @return BulkExportService
    */
   @Bean
   public BulkExportService adminBulkExportService(
-      AdministrativeDirectiveBucket source,
-      @Value("${s3.file-storage.administrative-directive.versionPrefix}") String versionPrefix,
-      PublicFilesBucket target) {
+      AdministrativeDirectiveBucket source, PublicFilesBucket target) {
     return new BulkExportService(
-        source, target, DocumentKind.ADMINISTRATIVE_DIRECTIVE.getBulkZipPath(), versionPrefix);
+        source, target, DocumentKind.ADMINISTRATIVE_DIRECTIVE.getBulkZipPath());
   }
 
   /**
    * @param source sourceBucket to create the document snapshot from
-   * @param versionPrefix the version prefix for the bucket
    * @param target targetBucket to create the archive in
    * @return BulkExportService
    */
   @Bean
   public BulkExportService literatureBulkExportService(
-      LiteratureBucket source,
-      @Value("${s3.file-storage.literature.versionPrefix}") String versionPrefix,
-      PublicFilesBucket target) {
-    return new BulkExportService(
-        source, target, DocumentKind.LITERATURE.getBulkZipPath(), versionPrefix);
+      LiteratureBucket source, PublicFilesBucket target) {
+    return new BulkExportService(source, target, DocumentKind.LITERATURE.getBulkZipPath());
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/obs/ChangelogConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/obs/ChangelogConfig.java
@@ -6,7 +6,6 @@ import de.bund.digitalservice.ris.search.repository.objectstorage.CaseLawBucket;
 import de.bund.digitalservice.ris.search.repository.objectstorage.LiteratureBucket;
 import de.bund.digitalservice.ris.search.repository.objectstorage.NormsBucket;
 import de.bund.digitalservice.ris.search.service.ChangelogService;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -16,57 +15,44 @@ public class ChangelogConfig {
 
   /**
    * @param bucket root bucket of case law files
-   * @param versionPrefix the version prefix for the bucket
    * @param om global ObjectMapper to parse the changelog files
    * @return ChangelogService configured to manage case law files
    */
   @Bean
   public ChangelogService<CaseLawBucket> caseLawChangelogService(
-      CaseLawBucket bucket,
-      @Value("${s3.file-storage.case-law.versionPrefix}") String versionPrefix,
-      ObjectMapper om) {
-    return new ChangelogService<>(bucket, versionPrefix, om);
+      CaseLawBucket bucket, ObjectMapper om) {
+    return new ChangelogService<>(bucket, om);
   }
 
   /**
    * @param bucket root bucket of norms files
-   * @param versionPrefix the version prefix for the bucket
    * @param om global ObjectMapper to parse the changelog files
    * @return IndexedChangelogService configured to manage legislation files
    */
   @Bean
-  public ChangelogService<NormsBucket> normsChangelogService(
-      NormsBucket bucket,
-      @Value("${s3.file-storage.norm.versionPrefix}") String versionPrefix,
-      ObjectMapper om) {
-    return new ChangelogService<>(bucket, versionPrefix, om);
+  public ChangelogService<NormsBucket> normsChangelogService(NormsBucket bucket, ObjectMapper om) {
+    return new ChangelogService<>(bucket, om);
   }
 
   /**
    * @param bucket root bucket of literature files
-   * @param versionPrefix the version prefix for the bucket
    * @param om global ObjectMapper to parse the changelog files
    * @return IndexedChangelogService configured to manage literature files
    */
   @Bean
   public ChangelogService<LiteratureBucket> literatureChangelogService(
-      LiteratureBucket bucket,
-      @Value("${s3.file-storage.literature.versionPrefix}") String versionPrefix,
-      ObjectMapper om) {
-    return new ChangelogService<>(bucket, versionPrefix, om);
+      LiteratureBucket bucket, ObjectMapper om) {
+    return new ChangelogService<>(bucket, om);
   }
 
   /**
    * @param bucket root bucket of administrative directive files
-   * @param versionPrefix the version prefix for the bucket
    * @param om global ObjectMapper to parse the changelog files
    * @return IndexedChangelogService configured to manage administrative directive files
    */
   @Bean
   public ChangelogService<AdministrativeDirectiveBucket> administrativeDirectiveChangelogService(
-      AdministrativeDirectiveBucket bucket,
-      @Value("${s3.file-storage.administrative-directive.versionPrefix}") String versionPrefix,
-      ObjectMapper om) {
-    return new ChangelogService<>(bucket, versionPrefix, om);
+      AdministrativeDirectiveBucket bucket, ObjectMapper om) {
+    return new ChangelogService<>(bucket, om);
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/CaseLawController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/CaseLawController.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Optional;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpStatus;
@@ -61,7 +60,6 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 public class CaseLawController {
 
   private final CaseLawService caseLawService;
-  private final String versionPrefix;
   private final CaselawXsltTransformerService xsltTransformerService;
   private final ChangelogService<CaseLawBucket> changelogService;
 
@@ -69,17 +67,14 @@ public class CaseLawController {
    * Constructor for the CaseLawController class.
    *
    * @param caseLawService the service layer responsible for case law operations
-   * @param versionPrefix the version prefix for the bucket
    * @param xsltTransformerService the service used for XSLT transformations related to case law
    */
   @Autowired
   public CaseLawController(
       CaseLawService caseLawService,
-      @Value("${s3.file-storage.case-law.versionPrefix}") String versionPrefix,
       CaselawXsltTransformerService xsltTransformerService,
       ChangelogService<CaseLawBucket> changelogService) {
     this.caseLawService = caseLawService;
-    this.versionPrefix = versionPrefix;
     this.xsltTransformerService = xsltTransformerService;
     this.changelogService = changelogService;
   }
@@ -243,7 +238,7 @@ public class CaseLawController {
 
     byte[] resource =
         caseLawService
-            .getFileByPath(versionPrefix + documentNumber + "/" + name + "." + extension)
+            .getFileByPath(documentNumber + "/" + name + "." + extension)
             .orElseGet(
                 () -> {
                   try {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/NormsController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/NormsController.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Optional;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
@@ -82,7 +81,6 @@ public class NormsController {
   public static final String NATURAL_IDENTIFIER_EXAMPLE = "s1325";
 
   private final NormsService normsService;
-  private final String versionPrefix;
   private final NormXsltTransformerService xsltTransformerService;
   private final ChangelogService<NormsBucket> changelogService;
 
@@ -90,17 +88,14 @@ public class NormsController {
    * Constructor for the NormsController class.
    *
    * @param normsService the service responsible for handling norms-related operations
-   * @param versionPrefix the version prefix for the bucket
    * @param xsltTransformerService the service responsible for transforming norms using XSLT
    */
   @Autowired
   public NormsController(
       NormsService normsService,
-      @Value("${s3.file-storage.norm.versionPrefix}") String versionPrefix,
       NormXsltTransformerService xsltTransformerService,
       ChangelogService<NormsBucket> changelogService) {
     this.normsService = normsService;
-    this.versionPrefix = versionPrefix;
     this.xsltTransformerService = xsltTransformerService;
     this.changelogService = changelogService;
   }
@@ -483,7 +478,7 @@ public class NormsController {
 
     String fileName = prefix + ".zip";
 
-    List<String> keys = normsService.getAllFilenamesByPath(versionPrefix + prefix);
+    List<String> keys = normsService.getAllFilenamesByPath(prefix);
 
     if (keys.isEmpty()) {
       return ResponseEntity.notFound().build();

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectStorage.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectStorage.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import lombok.Getter;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -30,6 +31,7 @@ public class ObjectStorage {
   public static final int MAXIMUM_CALL_ATTEMPTS = 3;
   private final Logger logger;
   private final ObjectStorageClient client;
+  @Getter // This getter is so that the ChangelogService knows how to strip off the prefix
   private final String versionPrefix;
 
   /**
@@ -47,13 +49,13 @@ public class ObjectStorage {
   }
 
   /**
-   * Retrieves a list of all keys stored in the object storage.
+   * Retrieves a list of all keys stored in the object storage under the current versionPrefix.
    *
    * @return a list of keys as strings, where each key represents an object stored in the object
    *     storage
    */
-  public List<String> getAllKeysOnCurrentVersion() {
-    return getAllKeysByPrefix(versionPrefix);
+  public List<String> getAllKeys() {
+    return getAllKeysByPrefix("");
   }
 
   /**
@@ -63,7 +65,9 @@ public class ObjectStorage {
    * @return a list of matched object keys as strings
    */
   public List<String> getAllKeysByPrefix(String path) {
-    return client.listKeysByPrefix(path);
+    return client.listKeysByPrefix(versionPrefix + path).stream()
+        .map(e -> e.substring(versionPrefix.length()))
+        .toList();
   }
 
   /**
@@ -75,7 +79,7 @@ public class ObjectStorage {
    *     their last modified timestamps
    */
   public List<ObjectKeyInfo> getAllKeyInfosByPrefix(String path) {
-    return client.listByPrefixWithLastModified(path);
+    return client.listByPrefixWithLastModified(versionPrefix + path);
   }
 
   /**
@@ -162,15 +166,15 @@ public class ObjectStorage {
   }
 
   public FilterInputStream getStream(String objectKey) throws NoSuchKeyException {
-    return client.getStream(objectKey);
+    return client.getStream(versionPrefix + objectKey);
   }
 
   public void delete(String fileName) {
-    client.delete(fileName);
+    client.delete(versionPrefix + fileName);
   }
 
   public void save(String fileName, String fileContent) {
-    client.save(fileName, fileContent);
+    client.save(versionPrefix + fileName, fileContent);
   }
 
   public void close() {
@@ -178,6 +182,6 @@ public class ObjectStorage {
   }
 
   public long putStream(String objectKey, InputStream inputStream) throws IOException {
-    return client.putStream(objectKey, inputStream);
+    return client.putStream(versionPrefix + objectKey, inputStream);
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/AdministrativeDirectiveService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/AdministrativeDirectiveService.java
@@ -14,7 +14,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.opensearch.data.client.orhlc.NativeSearchQuery;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -30,7 +29,6 @@ import org.springframework.stereotype.Service;
 public class AdministrativeDirectiveService {
   private final AdministrativeDirectiveRepository repository;
   private final AdministrativeDirectiveBucket bucket;
-  private final String versionPrefix;
   private final ElasticsearchOperations operations;
   private final SimpleSearchQueryBuilder simpleSearchQueryBuilder;
 
@@ -39,7 +37,6 @@ public class AdministrativeDirectiveService {
    *
    * @param repository Repository for AdministrativeDirective entities.
    * @param bucket Object storage bucket for AdministrativeDirective files.
-   * @param versionPrefix the version prefix for the bucket
    * @param operations Elasticsearch operations for querying the database.
    * @param simpleSearchQueryBuilder Builder for constructing simple search queries.
    */
@@ -48,12 +45,10 @@ public class AdministrativeDirectiveService {
   public AdministrativeDirectiveService(
       AdministrativeDirectiveRepository repository,
       AdministrativeDirectiveBucket bucket,
-      @Value("${s3.file-storage.administrative-directive.versionPrefix}") String versionPrefix,
       ElasticsearchOperations operations,
       SimpleSearchQueryBuilder simpleSearchQueryBuilder) {
     this.repository = repository;
     this.bucket = bucket;
-    this.versionPrefix = versionPrefix;
     this.operations = operations;
     this.simpleSearchQueryBuilder = simpleSearchQueryBuilder;
   }
@@ -89,7 +84,7 @@ public class AdministrativeDirectiveService {
    */
   public Optional<byte[]> getFileByDocumentNumber(String documentNumber) {
     try {
-      return bucket.get(String.format("%s%s.akn.xml", versionPrefix, documentNumber));
+      return bucket.get(String.format("%s.akn.xml", documentNumber));
     } catch (ObjectStoreServiceException e) {
       return Optional.empty();
     }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/BaseIndexService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/BaseIndexService.java
@@ -115,7 +115,7 @@ public abstract class BaseIndexService<T> implements IndexService {
   protected abstract Optional<T> mapFileToEntity(String filename, String fileContent);
 
   protected List<String> getAllIndexableFilenames() {
-    return objectStorage.getAllKeysOnCurrentVersion().stream()
+    return objectStorage.getAllKeys().stream()
         .filter(s -> s.endsWith(".xml") && !s.contains(ChangelogService.CHANGELOGS_PREFIX))
         .toList();
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/BulkExportService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/BulkExportService.java
@@ -31,7 +31,6 @@ public class BulkExportService {
 
   private final ObjectStorage sourceBucket;
   private final ObjectStorage destinationBucket;
-  private final String versionPrefix;
   public static final String BULK_ZIP_PREFIX = "snapshots/";
   public static final String JOB_STATE_STORAGE_PREFIX = "snapshot-job-state/";
 
@@ -44,16 +43,11 @@ public class BulkExportService {
    * @param sourceBucket the ObjectStorage bucket to read files from
    * @param destinationBucket the ObjectStorage bucket to upload the ZIP archive to
    * @param outputName the base name for the output ZIP file
-   * @param versionPrefix the prefix to filter objects in the sourceBucket
    */
   public BulkExportService(
-      ObjectStorage sourceBucket,
-      ObjectStorage destinationBucket,
-      String outputName,
-      String versionPrefix) {
+      ObjectStorage sourceBucket, ObjectStorage destinationBucket, String outputName) {
     this.sourceBucket = sourceBucket;
     this.destinationBucket = destinationBucket;
-    this.versionPrefix = versionPrefix;
     this.archivePrefix = BULK_ZIP_PREFIX + outputName;
   }
 
@@ -71,8 +65,8 @@ public class BulkExportService {
 
     logger.info("Creating snapshot");
     List<String> keysToZip =
-        sourceBucket.getAllKeysByPrefix(versionPrefix).stream()
-            .filter(key -> !key.startsWith(versionPrefix + ChangelogService.CHANGELOGS_PREFIX))
+        sourceBucket.getAllKeys().stream()
+            .filter(key -> !key.startsWith(ChangelogService.CHANGELOGS_PREFIX))
             .toList();
 
     if (keysToZip.isEmpty()) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/CaseLawService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/CaseLawService.java
@@ -29,7 +29,6 @@ import org.opensearch.search.aggregations.bucket.terms.ParsedStringTerms;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -45,7 +44,6 @@ import org.springframework.stereotype.Service;
 public class CaseLawService {
   private final CaseLawRepository caseLawRepository;
   private final CaseLawBucket caseLawBucket;
-  private final String versionPrefix;
   private final ElasticsearchOperations operations;
   private final Configurations configurations;
   private final CaseLawLdmlToOpenSearchMapper marshaller;
@@ -56,7 +54,6 @@ public class CaseLawService {
    *
    * @param caseLawRepository the repository responsible for managing CaseLaw entities
    * @param caseLawBucket the bucket for storing and managing case law data in bulk operations
-   * @param versionPrefix the version prefix for the bucket
    * @param operations the ElasticsearchOperations instance to interact with Elasticsearch
    * @param configurations the configurations required for the service
    * @param marshaller the mapper for converting CaseLaw entities to OpenSearch format
@@ -67,14 +64,12 @@ public class CaseLawService {
   public CaseLawService(
       CaseLawRepository caseLawRepository,
       CaseLawBucket caseLawBucket,
-      @Value("${s3.file-storage.case-law.versionPrefix}") String versionPrefix,
       ElasticsearchOperations operations,
       Configurations configurations,
       CaseLawLdmlToOpenSearchMapper marshaller,
       SimpleSearchQueryBuilder simpleSearchQueryBuilder) {
     this.caseLawRepository = caseLawRepository;
     this.caseLawBucket = caseLawBucket;
-    this.versionPrefix = versionPrefix;
     this.operations = operations;
     this.configurations = configurations;
     this.marshaller = marshaller;
@@ -173,8 +168,7 @@ public class CaseLawService {
    */
   public Optional<byte[]> getFileByDocumentNumber(String documentNumber)
       throws ObjectStoreServiceException {
-    return caseLawBucket.get(
-        String.format("%s%s/%s.xml", versionPrefix, documentNumber, documentNumber));
+    return caseLawBucket.get(String.format("%s/%s.xml", documentNumber, documentNumber));
   }
 
   public Optional<byte[]> getFileByPath(String path) throws ObjectStoreServiceException {
@@ -182,11 +176,11 @@ public class CaseLawService {
   }
 
   public void writeZipArchive(List<String> keys, OutputStream outputStream) throws IOException {
-    ZipManager.writeZipArchive(caseLawBucket, versionPrefix, keys, outputStream);
+    ZipManager.writeZipArchive(caseLawBucket, keys, outputStream);
   }
 
   public List<String> getAllFilenamesByDocumentNumber(String documentNumber) {
-    return caseLawBucket.getAllKeysByPrefix(versionPrefix + documentNumber);
+    return caseLawBucket.getAllKeysByPrefix(documentNumber);
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/ChangelogService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/ChangelogService.java
@@ -8,9 +8,11 @@ import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
 import de.bund.digitalservice.ris.search.repository.objectstorage.ObjectStorage;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -23,7 +25,6 @@ public class ChangelogService<T extends ObjectStorage> {
   public static final String CHANGELOGS_PREFIX = "changelogs/";
 
   private final ObjectStorage bucket;
-  private final String versionPrefix;
   private final ObjectReader changelogReader;
 
   /**
@@ -32,9 +33,8 @@ public class ChangelogService<T extends ObjectStorage> {
    * @param bucket bucket containing the changelogs
    * @param objectMapper global ObjectMapper to create a Changelog Reader
    */
-  public ChangelogService(T bucket, String versionPrefix, ObjectMapper objectMapper) {
+  public ChangelogService(T bucket, ObjectMapper objectMapper) {
     this.bucket = bucket;
-    this.versionPrefix = versionPrefix;
     this.changelogReader = objectMapper.readerFor(Changelog.class);
   }
 
@@ -53,7 +53,7 @@ public class ChangelogService<T extends ObjectStorage> {
    */
   public List<String> getNewChangelogsPaths(@NotNull String lastProcessedChangelog) {
 
-    return bucket.getAllKeysByPrefix(versionPrefix + CHANGELOGS_PREFIX).stream()
+    return bucket.getAllKeysByPrefix(CHANGELOGS_PREFIX).stream()
         .filter(e -> !CHANGELOGS_PREFIX.equals(e))
         .filter(e -> e.compareTo(lastProcessedChangelog) > 0)
         .sorted()
@@ -82,12 +82,26 @@ public class ChangelogService<T extends ObjectStorage> {
       return Optional.empty();
     } else {
       try {
-        return Optional.of(changelogReader.readValue(changelogContent.get()));
+        return Optional.of(
+            stripVersionPrefix(
+                bucket.getVersionPrefix(), changelogReader.readValue(changelogContent.get())));
       } catch (JsonProcessingException e) {
         logger.error("Error while parsing changelog file {} in bucket {}", filename, bucket, e);
         return Optional.empty();
       }
     }
+  }
+
+  private Changelog stripVersionPrefix(String versionPrefix, Changelog input) {
+    input.setChanged(
+        input.getChanged().stream()
+            .map(e -> e.substring(versionPrefix.length()))
+            .collect(Collectors.toCollection(HashSet::new)));
+    input.setDeleted(
+        input.getDeleted().stream()
+            .map(e -> e.substring(versionPrefix.length()))
+            .collect(Collectors.toCollection(HashSet::new)));
+    return input;
   }
 
   /**
@@ -101,11 +115,9 @@ public class ChangelogService<T extends ObjectStorage> {
    * @return Changelog object including all changes that were indexed
    */
   public Changelog getChangesBetween(Instant from, Instant to) throws ObjectStoreServiceException {
-    String prefix = versionPrefix + CHANGELOGS_PREFIX;
-
     var changelogs =
-        bucket.getAllKeysByPrefix(prefix).stream()
-            .filter(key -> !prefix.equals(key))
+        bucket.getAllKeysByPrefix(CHANGELOGS_PREFIX).stream()
+            .filter(key -> !CHANGELOGS_PREFIX.equals(key))
             .filter(
                 key -> {
                   Instant changelogTime = parseInstantFromKey(key);

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
@@ -11,6 +11,7 @@ import de.bund.digitalservice.ris.search.utils.BatchUtils;
 import de.bund.digitalservice.ris.search.utils.DateUtils;
 import de.bund.digitalservice.ris.search.utils.eli.EliFile;
 import de.bund.digitalservice.ris.search.utils.eli.ExpressionEli;
+import de.bund.digitalservice.ris.search.utils.eli.ManifestationEli;
 import de.bund.digitalservice.ris.search.utils.eli.WorkEli;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -29,7 +30,6 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
 import org.springframework.stereotype.Service;
@@ -44,7 +44,6 @@ public class IndexNormsService implements IndexService {
   private final NormsRepository normsRepository;
   private final ArticlesRepository articlesRepository;
   private final NormsBucket normsBucket;
-  private final String versionPrefix;
 
   // We can't use LocalDate.MIN or LocalDate.MAX because opensearch min and max differ from java
   public static final LocalDate TIME_RELEVANCE_MIN = LocalDate.of(1, Month.JANUARY, 1);
@@ -62,12 +61,10 @@ public class IndexNormsService implements IndexService {
   public IndexNormsService(
       Environment environment,
       NormsBucket normsBucket,
-      @Value("${s3.file-storage.norm.versionPrefix}") String versionPrefix,
       NormsRepository normsRepository,
       ArticlesRepository articlesRepository) {
     this.environment = environment;
     this.normsBucket = normsBucket;
-    this.versionPrefix = versionPrefix;
     this.normsRepository = normsRepository;
     this.articlesRepository = articlesRepository;
   }
@@ -79,7 +76,7 @@ public class IndexNormsService implements IndexService {
    */
   public void reindexAll(String startingTimestamp) {
     DateUtils.avoidOpenSearchSubMillisecondDateBug();
-    List<String> allFiles = normsBucket.getAllKeysByPrefix(versionPrefix + "eli/");
+    List<String> allFiles = normsBucket.getAllKeysByPrefix("eli/");
     Map<WorkEli, List<String>> workElis = groupFilesByWorkEli(allFiles.stream());
     processWorkEliUpdates(workElis, startingTimestamp);
     clearOldNorms(startingTimestamp);
@@ -94,8 +91,7 @@ public class IndexNormsService implements IndexService {
       // retrieve all file paths for the given workElis
       Map<WorkEli, List<String>> allFilesByWorkEli = new HashMap<>();
       for (WorkEli workEli : workElis) {
-        allFilesByWorkEli.put(
-            workEli, normsBucket.getAllKeysByPrefix(versionPrefix + workEli.toString() + "/"));
+        allFilesByWorkEli.put(workEli, normsBucket.getAllKeysByPrefix(workEli.toString() + "/"));
       }
       processWorkEliUpdates(allFilesByWorkEli, Instant.now().toString());
     } catch (IllegalArgumentException e) {
@@ -253,10 +249,7 @@ public class IndexNormsService implements IndexService {
 
     // Get all files for the current expression.
     final List<String> keysMatchingExpressionEli =
-        filenames.stream()
-            .filter(n -> n.startsWith(versionPrefix + expressionEli.toString()))
-            .map(e -> e.substring(versionPrefix.length()))
-            .toList();
+        filenames.stream().filter(n -> n.startsWith(expressionEli.toString())).toList();
 
     Optional<String> newestFileName =
         keysMatchingExpressionEli.stream()
@@ -268,7 +261,7 @@ public class IndexNormsService implements IndexService {
             // only get the manifestation files that represent expression xml files
             .filter(e -> e.subtype().startsWith("regelungstext-"))
             // take the manifestation with the latest pointInTimeManifestation
-            .map(e -> versionPrefix + e)
+            .map(ManifestationEli::toString)
             .max(java.util.Comparator.naturalOrder());
 
     if (newestFileName.isEmpty()) {
@@ -325,7 +318,7 @@ public class IndexNormsService implements IndexService {
    */
   public int getNumberOfIndexableDocumentsInBucket() {
     Set<ExpressionEli> norms =
-        normsBucket.getAllKeysByPrefix(versionPrefix + "eli/").stream()
+        normsBucket.getAllKeysByPrefix("eli/").stream()
             .map(EliFile::fromString)
             .flatMap(Optional::stream)
             .filter(e -> e.fileName().startsWith("regelungstext-"))

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/LiteratureService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/LiteratureService.java
@@ -20,7 +20,6 @@ import org.opensearch.data.client.orhlc.NativeSearchQuery;
 import org.opensearch.data.client.orhlc.NativeSearchQueryBuilder;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -35,7 +34,6 @@ import org.springframework.stereotype.Service;
 public class LiteratureService {
   private final LiteratureRepository literatureRepository;
   private final LiteratureBucket literatureBucket;
-  private final String versionPrefix;
   private final ElasticsearchOperations operations;
   private final SimpleSearchQueryBuilder simpleSearchQueryBuilder;
 
@@ -44,7 +42,6 @@ public class LiteratureService {
    *
    * @param literatureRepository Repository for literature data
    * @param literatureBucket Bucket for literature files
-   * @param versionPrefix the version prefix for the bucket
    * @param operations Elasticsearch operations for querying
    * @param simpleSearchQueryBuilder Builder for simple search queries
    */
@@ -53,12 +50,10 @@ public class LiteratureService {
   public LiteratureService(
       LiteratureRepository literatureRepository,
       LiteratureBucket literatureBucket,
-      @Value("${s3.file-storage.literature.versionPrefix}") String versionPrefix,
       ElasticsearchOperations operations,
       SimpleSearchQueryBuilder simpleSearchQueryBuilder) {
     this.literatureRepository = literatureRepository;
     this.literatureBucket = literatureBucket;
-    this.versionPrefix = versionPrefix;
     this.operations = operations;
     this.simpleSearchQueryBuilder = simpleSearchQueryBuilder;
   }
@@ -127,6 +122,6 @@ public class LiteratureService {
    */
   public Optional<byte[]> getFileByDocumentNumber(String documentNumber)
       throws ObjectStoreServiceException {
-    return literatureBucket.get(String.format("%s%s.akn.xml", versionPrefix, documentNumber));
+    return literatureBucket.get(String.format("%s.akn.xml", documentNumber));
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormsService.java
@@ -61,7 +61,6 @@ public class NormsService {
   private final ArticleService articleService;
   private final RestHighLevelClient openSearchRestClient;
   private final NormsBucket normsBucket;
-  private final String versionPrefix;
   private final String normsIndexName;
   private static final String DATE_FORMAT = "yyyy-MM-dd";
 
@@ -70,7 +69,6 @@ public class NormsService {
    *
    * @param normsRepository The repository for interacting with the OpenSearch norms.
    * @param normsBucket The object storage bucket for norms files.
-   * @param versionPrefix the version prefix for the bucket
    * @param operations The Elasticsearch operations for executing queries.
    * @param simpleSearchQueryBuilder The query builder for constructing search queries.
    */
@@ -78,7 +76,6 @@ public class NormsService {
   public NormsService(
       NormsRepository normsRepository,
       NormsBucket normsBucket,
-      @Value("${s3.file-storage.norm.versionPrefix}") String versionPrefix,
       ElasticsearchOperations operations,
       RestHighLevelClient openSearchRestClient,
       SimpleSearchQueryBuilder simpleSearchQueryBuilder,
@@ -86,7 +83,6 @@ public class NormsService {
       @Value("${opensearch.norms-index-name}") String normsIndexName) {
     this.normsRepository = normsRepository;
     this.normsBucket = normsBucket;
-    this.versionPrefix = versionPrefix;
     this.operations = operations;
     this.openSearchRestClient = openSearchRestClient;
     this.simpleSearchQueryBuilder = simpleSearchQueryBuilder;
@@ -142,7 +138,7 @@ public class NormsService {
    */
   public Optional<byte[]> getNormFileByEli(ManifestationEli eli)
       throws ObjectStoreServiceException {
-    return normsBucket.get(versionPrefix + eli.toString());
+    return normsBucket.get(eli.toString());
   }
 
   /**
@@ -246,7 +242,7 @@ public class NormsService {
    * @throws IOException when a given File was not able to be archived
    */
   public void writeZipArchive(List<String> keys, OutputStream outputStream) throws IOException {
-    ZipManager.writeZipArchive(normsBucket, versionPrefix, keys, outputStream);
+    ZipManager.writeZipArchive(normsBucket, keys, outputStream);
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapsUpdateJob.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapsUpdateJob.java
@@ -69,7 +69,7 @@ public class SitemapsUpdateJob implements Job {
   public void createSitemaps(ObjectStorage currentBucket, DocumentKind docKind) {
     String prefix = docKind.getSiteMapPath();
     List<String> ids =
-        currentBucket.getAllKeysOnCurrentVersion().stream()
+        currentBucket.getAllKeys().stream()
             .map(e -> DocumentKind.extractIdFromFileName(e, docKind))
             .flatMap(Optional::stream)
             .distinct()

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/eclicrawler/EcliCrawlerDocumentService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/eclicrawler/EcliCrawlerDocumentService.java
@@ -126,7 +126,7 @@ public class EcliCrawlerDocumentService {
    */
   public void writeFullDiff(String apiUrl, LocalDate day) {
     List<String> allFiles =
-        caselawBucket.getAllKeysOnCurrentVersion().stream()
+        caselawBucket.getAllKeys().stream()
             .filter(s -> s.endsWith(".xml") && !s.contains(ChangelogService.CHANGELOGS_PREFIX))
             .toList();
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/helper/ZipManager.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/helper/ZipManager.java
@@ -18,17 +18,15 @@ public class ZipManager {
    * stream.
    *
    * @param s3Bucket The S3 bucket from which to retrieve the objects.
-   * @param versionPrefix the version prefix for the bucket
    * @param keys A list of S3 keys representing the objects to be included in the zip archive.
    * @param outputStream The output stream where the zip archive will be written.
    * @throws IOException If an I/O error occurs during the process.
    */
   public static void writeZipArchive(
-      ObjectStorage s3Bucket, String versionPrefix, List<String> keys, OutputStream outputStream)
-      throws IOException {
+      ObjectStorage s3Bucket, List<String> keys, OutputStream outputStream) throws IOException {
     try (ZipOutputStream zipOut = new ZipOutputStream(outputStream)) {
       for (String key : keys) {
-        appendZipEntryFromS3(s3Bucket, versionPrefix, key, zipOut);
+        appendZipEntryFromS3(s3Bucket, key, zipOut);
       }
     } catch (IOException e) {
       throw new IOException("error building ZipOutputStream with keys %s".formatted(keys), e);
@@ -36,9 +34,8 @@ public class ZipManager {
   }
 
   private static void appendZipEntryFromS3(
-      ObjectStorage s3Bucket, String versionPrefix, String key, ZipOutputStream zipOut)
-      throws IOException {
-    ZipEntry zipEntry = new ZipEntry(key.substring(versionPrefix.length()));
+      ObjectStorage s3Bucket, String key, ZipOutputStream zipOut) throws IOException {
+    ZipEntry zipEntry = new ZipEntry(key);
     zipOut.putNextEntry(zipEntry);
 
     try (InputStream objectInputStream = s3Bucket.getStream(key)) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/xslt/NormXsltTransformerService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/xslt/NormXsltTransformerService.java
@@ -13,7 +13,6 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.stream.StreamSource;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriUtils;
 
@@ -25,7 +24,6 @@ public class NormXsltTransformerService extends XsltTransformer {
   static final String DEBUGGING_VALUE = "false";
 
   private final NormsBucket normsBucket;
-  private final String versionPrefix;
 
   @Override
   String getXsltBasePath() {
@@ -41,13 +39,9 @@ public class NormXsltTransformerService extends XsltTransformer {
    * Constructs a new instance of {@code NormXsltTransformerService}.
    *
    * @param normsBucket The object storage bucket for norms files.
-   * @param versionPrefix the version prefix for the bucket
    */
-  public NormXsltTransformerService(
-      NormsBucket normsBucket,
-      @Value("${s3.file-storage.norm.versionPrefix}") String versionPrefix) {
+  public NormXsltTransformerService(NormsBucket normsBucket) {
     this.normsBucket = normsBucket;
-    this.versionPrefix = versionPrefix;
     setCustomUriResolver();
   }
 
@@ -86,7 +80,7 @@ public class NormXsltTransformerService extends XsltTransformer {
   @NotNull
   private StreamSource resolveEliResource(EliFile eliFile) throws TransformerException {
     try {
-      var response = this.normsBucket.getStream(versionPrefix + eliFile.toString());
+      var response = this.normsBucket.getStream(eliFile.toString());
       return new StreamSource(response);
     } catch (NoSuchKeyException | NullPointerException e) {
       throw new TransformerException("Failed to resolve: " + eliFile, e);

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/BulkZipControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/BulkZipControllerTest.java
@@ -37,7 +37,7 @@ class BulkZipControllerTest extends ContainersIntegrationBase {
   void endpointShouldReturnCorrectCount() throws Exception {
     // Empty the bucket and add mock files. 2 for case law and 1 for the others. The content is not
     // relevant to test the links
-    for (String key : publicFilesBucket.getAllKeysOnCurrentVersion()) {
+    for (String key : publicFilesBucket.getAllKeys()) {
       publicFilesBucket.delete(key);
     }
     String bulkZipPattern = BulkExportService.BULK_ZIP_PREFIX + "%s_2026-01-%sT00:00:00.zip";

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/administrative_directive/AdministrativeDirectiveIndexSyncJobTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/administrative_directive/AdministrativeDirectiveIndexSyncJobTest.java
@@ -34,8 +34,8 @@ class AdministrativeDirectiveIndexSyncJobTest extends ContainersIntegrationBase 
 
   @BeforeEach
   void setup() {
-    bucket.getAllKeysOnCurrentVersion().forEach(bucket::delete);
-    portalBucket.getAllKeysOnCurrentVersion().forEach(portalBucket::delete);
+    bucket.getAllKeys().forEach(bucket::delete);
+    portalBucket.getAllKeys().forEach(portalBucket::delete);
     administrativeDirectiveRepository.deleteAll();
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/caselaw/CaseLawImportStatusTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/caselaw/CaseLawImportStatusTest.java
@@ -49,9 +49,9 @@ class CaseLawImportStatusTest extends ContainersIntegrationBase {
 
   @Test
   void createsLastSuccessFileProperly() throws ObjectStoreServiceException {
-    Assertions.assertEquals(5, caseLawBucket.getAllKeysOnCurrentVersion().size());
+    Assertions.assertEquals(5, caseLawBucket.getAllKeys().size());
     caseLawIndexSyncJob.runJob();
-    Assertions.assertEquals(5, caseLawBucket.getAllKeysOnCurrentVersion().size());
+    Assertions.assertEquals(5, caseLawBucket.getAllKeys().size());
     IndexingState result =
         indexStatusService.loadStatus(CaseLawIndexSyncJob.CASELAW_STATUS_FILENAME);
     Assertions.assertNotNull(result.lastProcessedChangelogFile());

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/literature/LiteratureImportStatusTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/literature/LiteratureImportStatusTest.java
@@ -40,9 +40,9 @@ class LiteratureImportStatusTest extends ContainersIntegrationBase {
 
   @Test
   void createsLastSuccessFileProperly() throws ObjectStoreServiceException {
-    assertThat(literatureBucket.getAllKeysOnCurrentVersion()).hasSize(2);
+    assertThat(literatureBucket.getAllKeys()).hasSize(2);
     literatureIndexSyncJob.runJob();
-    assertThat(literatureBucket.getAllKeysOnCurrentVersion()).hasSize(2);
+    assertThat(literatureBucket.getAllKeys()).hasSize(2);
     IndexingState result =
         indexStatusService.loadStatus(LiteratureIndexSyncJob.LITERATURE_STATUS_FILENAME);
     assertThat(result.lastProcessedChangelogFile()).isNotNull();

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/literature/LiteratureIndexSyncJobTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/jobs/literature/LiteratureIndexSyncJobTest.java
@@ -29,8 +29,8 @@ class LiteratureIndexSyncJobTest extends ContainersIntegrationBase {
 
   @BeforeEach
   void setup() {
-    bucket.getAllKeysOnCurrentVersion().forEach(bucket::delete);
-    portalBucket.getAllKeysOnCurrentVersion().forEach(portalBucket::delete);
+    bucket.getAllKeys().forEach(bucket::delete);
+    portalBucket.getAllKeys().forEach(portalBucket::delete);
     literatureRepository.deleteAll();
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/repository/LiteratureBucketIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/repository/LiteratureBucketIntegrationTest.java
@@ -23,20 +23,20 @@ class LiteratureBucketIntegrationTest {
 
   @BeforeEach
   void setUp() {
-    bucket.getAllKeysOnCurrentVersion().forEach(key -> bucket.delete(key));
+    bucket.getAllKeys().forEach(key -> bucket.delete(key));
   }
 
   @Test
   void getAllKeysReturnsAllKeys() {
     bucket.save("XXLU000000001.akn.xml", "");
     bucket.save("changelog.json", "");
-    assertThat(bucket.getAllKeysOnCurrentVersion())
+    assertThat(bucket.getAllKeys())
         .containsExactlyInAnyOrder("changelog.json", "XXLU000000001.akn.xml");
   }
 
   @Test
   void getAllKeysReturnsEmptyListIfBucketIsEmpty() {
-    assertThat(bucket.getAllKeysOnCurrentVersion()).isEmpty();
+    assertThat(bucket.getAllKeys()).isEmpty();
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/BulkExportServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/BulkExportServiceTest.java
@@ -38,7 +38,7 @@ class BulkExportServiceTest {
     ObjectStorage destinationBucket = mock(ObjectStorage.class);
     String outputName = "test-export";
 
-    when(sourceBucket.getAllKeysByPrefix("")).thenReturn(List.of("file1.txt", "file2.pdf"));
+    when(sourceBucket.getAllKeys()).thenReturn(List.of("file1.txt", "file2.pdf"));
     final byte[] bytes1 = "This is the content of file 1.".getBytes();
     when(sourceBucket.get("file1.txt")).thenReturn(Optional.of(bytes1));
     final byte[] bytes2 = "%PDF-1.5...".getBytes();
@@ -57,12 +57,12 @@ class BulkExportServiceTest {
             });
 
     BulkExportService bulkExportService =
-        new BulkExportService(sourceBucket, destinationBucket, outputName, "");
+        new BulkExportService(sourceBucket, destinationBucket, outputName);
 
     boolean actual = bulkExportService.updateLatestZip(clock.instant());
     assertThat(actual).isTrue();
 
-    verify(sourceBucket, times(1)).getAllKeysByPrefix("");
+    verify(sourceBucket, times(1)).getAllKeys();
     verify(sourceBucket, times(1)).get("file1.txt");
     verify(sourceBucket, times(1)).get("file2.pdf");
     verify(destinationBucket, times(1)).getAllKeysByPrefix(anyString());
@@ -84,7 +84,7 @@ class BulkExportServiceTest {
     String outputName = "test-export";
     String file1Content = "Some content";
 
-    when(sourceBucket.getAllKeysByPrefix("")).thenReturn(List.of("file1.txt"));
+    when(sourceBucket.getAllKeys()).thenReturn(List.of("file1.txt"));
     when(sourceBucket.get("file1.txt")).thenReturn(Optional.of(file1Content.getBytes()));
     when(destinationBucket.getAllKeysByPrefix(anyString()))
         .thenReturn(
@@ -96,12 +96,12 @@ class BulkExportServiceTest {
     doNothing().when(destinationBucket).delete(anyString());
 
     BulkExportService bulkExportService =
-        new BulkExportService(sourceBucket, destinationBucket, outputName, "");
+        new BulkExportService(sourceBucket, destinationBucket, outputName);
 
     boolean actual = bulkExportService.updateLatestZip(clock.instant());
     assertThat(actual).isTrue();
 
-    verify(sourceBucket, times(1)).getAllKeysByPrefix("");
+    verify(sourceBucket, times(1)).getAllKeys();
     verify(sourceBucket, times(1)).get("file1.txt");
     verify(destinationBucket, times(1)).getAllKeysByPrefix(anyString());
     verify(destinationBucket, times(1)).putStream(anyString(), any(InputStream.class));
@@ -116,11 +116,11 @@ class BulkExportServiceTest {
     ObjectStorage destinationBucket = mock(ObjectStorage.class);
     String outputName = "test-export";
 
-    when(sourceBucket.getAllKeysByPrefix(""))
+    when(sourceBucket.getAllKeys())
         .thenThrow(new RuntimeException("The mock source bucket does not want to list files"));
 
     BulkExportService bulkExportService =
-        new BulkExportService(sourceBucket, destinationBucket, outputName, "");
+        new BulkExportService(sourceBucket, destinationBucket, outputName);
 
     Instant timestamp = clock.instant();
     assertThrows(RuntimeException.class, () -> bulkExportService.updateLatestZip(timestamp));
@@ -143,7 +143,7 @@ class BulkExportServiceTest {
         .thenThrow(new IOException("The mock destination bucket threw an exception"));
 
     BulkExportService bulkExportService =
-        new BulkExportService(sourceBucket, destinationBucket, "test-export", "");
+        new BulkExportService(sourceBucket, destinationBucket, "test-export");
 
     boolean actual = bulkExportService.updateLatestZip(clock.instant());
     assertThat(actual).isFalse();
@@ -157,7 +157,7 @@ class BulkExportServiceTest {
     when(sourceBucket.getAllKeysByPrefix("")).thenReturn(List.of("file.txt"));
 
     BulkExportService bulkExportService =
-        new BulkExportService(sourceBucket, destinationBucket, "test-export", "");
+        new BulkExportService(sourceBucket, destinationBucket, "test-export");
 
     boolean actual = bulkExportService.updateLatestZip(clock.instant());
     assertThat(actual).isFalse();
@@ -172,7 +172,7 @@ class BulkExportServiceTest {
     when(sourceBucket.get("file")).thenReturn(Optional.empty());
 
     BulkExportService bulkExportService =
-        new BulkExportService(sourceBucket, destinationBucket, "test-export", "");
+        new BulkExportService(sourceBucket, destinationBucket, "test-export");
 
     boolean actual = bulkExportService.updateLatestZip(clock.instant());
     assertThat(actual).isFalse();

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/CaseLawServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/CaseLawServiceTest.java
@@ -40,7 +40,6 @@ class CaseLawServiceTest {
         new CaseLawService(
             caseLawRepositoryMock,
             caseLawBucketMock,
-            "",
             operationsMock,
             configurations,
             marshaller,

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/ChangelogServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/ChangelogServiceTest.java
@@ -35,7 +35,7 @@ class ChangelogServiceTest {
 
   @BeforeEach
   void setup() {
-    changelogService = new ChangelogService<>(bucket, "", objectMapper) {};
+    changelogService = new ChangelogService<>(bucket, objectMapper) {};
   }
 
   @Test
@@ -87,6 +87,7 @@ class ChangelogServiceTest {
     Changelog log3 = new Changelog();
     log3.setDeleted(new HashSet<>(List.of("deleted")));
 
+    when(bucket.getVersionPrefix()).thenReturn("");
     when(bucket.getFileAsString("log1"))
         .thenReturn(Optional.of(objectMapper.writeValueAsString(log1)));
     when(bucket.getFileAsString("log2"))
@@ -110,6 +111,7 @@ class ChangelogServiceTest {
     log3.setChanged(new HashSet<>(List.of("changed3")));
     log3.setDeleted(new HashSet<>(List.of("obsolete2", "deleted2")));
 
+    when(bucket.getVersionPrefix()).thenReturn("");
     when(bucket.getFileAsString("log1"))
         .thenReturn(Optional.of(objectMapper.writeValueAsString(log1)));
     when(bucket.getFileAsString("log2"))
@@ -139,6 +141,7 @@ class ChangelogServiceTest {
     Changelog expectedSecond =
         new Changelog(new HashSet<>(List.of("file2")), new HashSet<>(), false);
 
+    when(bucket.getVersionPrefix()).thenReturn("");
     when(bucket.getAllKeysByPrefix(any()))
         .thenReturn(
             List.of(
@@ -162,23 +165,24 @@ class ChangelogServiceTest {
     Instant to = Instant.parse("2027-01-01T12:00:00Z");
 
     Changelog expectedFirst =
-        new Changelog(new HashSet<>(List.of("file1")), new HashSet<>(), false);
+        new Changelog(new HashSet<>(List.of("V1/file1")), new HashSet<>(), false);
     Changelog expectedSecond =
-        new Changelog(new HashSet<>(List.of("file2")), new HashSet<>(), false);
+        new Changelog(new HashSet<>(List.of("V1/file2")), new HashSet<>(), false);
 
+    when(bucket.getVersionPrefix()).thenReturn("V1/");
     when(bucket.getAllKeysByPrefix(any()))
         .thenReturn(
             List.of(
-                "V1/changelogs/2026-07-03T11:00:00.000000Z-norm.json",
-                "V1/changelogs/2026-07-03T12:00:00.933434Z-norm.json",
-                "V1/changelogs/2026-07-08T12:00:00.933434Z-norm.json"));
+                "changelogs/2026-07-03T11:00:00.000000Z-norm.json",
+                "changelogs/2026-07-03T12:00:00.933434Z-norm.json",
+                "changelogs/2026-07-08T12:00:00.933434Z-norm.json"));
 
-    when(bucket.getFileAsString("V1/changelogs/2026-07-03T12:00:00.933434Z-norm.json"))
+    when(bucket.getFileAsString("changelogs/2026-07-03T12:00:00.933434Z-norm.json"))
         .thenReturn(Optional.of(objectMapper.writeValueAsString(expectedFirst)));
-    when(bucket.getFileAsString("V1/changelogs/2026-07-08T12:00:00.933434Z-norm.json"))
+    when(bucket.getFileAsString("changelogs/2026-07-08T12:00:00.933434Z-norm.json"))
         .thenReturn(Optional.of(objectMapper.writeValueAsString(expectedSecond)));
 
-    ChangelogService<?> service = new ChangelogService<>(bucket, "V1/", objectMapper);
+    ChangelogService<?> service = new ChangelogService<>(bucket, objectMapper);
     Changelog result = service.getChangesBetween(from, to);
 
     assertThat(result.getChanged()).asInstanceOf(SET).containsExactlyInAnyOrder("file1", "file2");
@@ -194,6 +198,7 @@ class ChangelogServiceTest {
     Changelog expectedSecond =
         new Changelog(new HashSet<>(List.of("file2")), new HashSet<>(), false);
 
+    when(bucket.getVersionPrefix()).thenReturn("");
     when(bucket.getAllKeysByPrefix(any()))
         .thenReturn(
             List.of(

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexLiteratureServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexLiteratureServiceTest.java
@@ -47,7 +47,7 @@ class IndexLiteratureServiceTest {
         LoadXmlUtils.loadXmlAsString(Literature.class, filenameA).getBytes(StandardCharsets.UTF_8);
 
     var keys = List.of(filenameA, filenameB);
-    when(this.bucket.getAllKeysOnCurrentVersion()).thenReturn(keys);
+    when(this.bucket.getAllKeys()).thenReturn(keys);
     when(this.bucket.getObjects(keys))
         .thenReturn(
             List.of(
@@ -79,8 +79,7 @@ class IndexLiteratureServiceTest {
     final byte[] xml =
         LoadXmlUtils.loadXmlAsString(Literature.class, filenameA).getBytes(StandardCharsets.UTF_8);
 
-    when(this.bucket.getAllKeysOnCurrentVersion())
-        .thenReturn(List.of(filenameA, filenameB, filenameC, filenameD));
+    when(this.bucket.getAllKeys()).thenReturn(List.of(filenameA, filenameB, filenameC, filenameD));
     when(this.bucket.getObjects(List.of(filenameA, filenameB, filenameC, filenameD)))
         .thenReturn(
             List.of(
@@ -159,7 +158,7 @@ class IndexLiteratureServiceTest {
 
   @Test
   void itReturnsRightNumberOfFiles() {
-    when(this.bucket.getAllKeysOnCurrentVersion())
+    when(this.bucket.getAllKeys())
         .thenReturn(
             List.of(
                 "XXLU000000001.akn.xml",

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexNormsServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexNormsServiceTest.java
@@ -33,7 +33,7 @@ class IndexNormsServiceTest {
 
   @BeforeEach()
   void setup() {
-    this.service = new IndexNormsService(environment, bucket, "", repo, articlesRepository);
+    this.service = new IndexNormsService(environment, bucket, repo, articlesRepository);
   }
 
   private final String testContent =

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/LiteratureServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/LiteratureServiceTest.java
@@ -45,8 +45,7 @@ class LiteratureServiceTest {
     literatureBucketMock = mock(LiteratureBucket.class);
     operationsMock = mock(ElasticsearchOperations.class);
     this.literatureService =
-        new LiteratureService(
-            literatureRepositoryMock, literatureBucketMock, "", operationsMock, null);
+        new LiteratureService(literatureRepositoryMock, literatureBucketMock, operationsMock, null);
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/SitemapsUpdateJobTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/SitemapsUpdateJobTest.java
@@ -68,11 +68,10 @@ class SitemapsUpdateJobTest {
               + "/1992-01-01/1/deu/1992-01-02/regelungstext-verkuendung-1.xml");
     }
 
-    when(administrativeDirectiveBucket.getAllKeysOnCurrentVersion())
-        .thenReturn(administrativeDirective);
-    when(caseLawBucket.getAllKeysOnCurrentVersion()).thenReturn(caseLawKeys);
-    when(literatureBucket.getAllKeysOnCurrentVersion()).thenReturn(literatureKeys);
-    when(normsBucket.getAllKeysOnCurrentVersion()).thenReturn(normsKeys);
+    when(administrativeDirectiveBucket.getAllKeys()).thenReturn(administrativeDirective);
+    when(caseLawBucket.getAllKeys()).thenReturn(caseLawKeys);
+    when(literatureBucket.getAllKeys()).thenReturn(literatureKeys);
+    when(normsBucket.getAllKeys()).thenReturn(normsKeys);
 
     sitemapsUpdateJob.runJob();
 
@@ -116,10 +115,10 @@ class SitemapsUpdateJobTest {
             "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/NOT_VALID/regelungstext-1.xml",
             "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/NOT_VALID/something-else.xml");
 
-    when(administrativeDirectiveBucket.getAllKeysOnCurrentVersion()).thenReturn(vvKeys);
-    when(caseLawBucket.getAllKeysOnCurrentVersion()).thenReturn(caselawKeys);
-    when(literatureBucket.getAllKeysOnCurrentVersion()).thenReturn(literatureKeys);
-    when(normsBucket.getAllKeysOnCurrentVersion()).thenReturn(normsKeys);
+    when(administrativeDirectiveBucket.getAllKeys()).thenReturn(vvKeys);
+    when(caseLawBucket.getAllKeys()).thenReturn(caselawKeys);
+    when(literatureBucket.getAllKeys()).thenReturn(literatureKeys);
+    when(normsBucket.getAllKeys()).thenReturn(normsKeys);
 
     sitemapsUpdateJob.runJob();
 
@@ -135,7 +134,7 @@ class SitemapsUpdateJobTest {
             "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-2.xml",
             "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/anlage-regelungstext-1.xml");
 
-    when(normsBucket.getAllKeysOnCurrentVersion()).thenReturn(normsKeys);
+    when(normsBucket.getAllKeys()).thenReturn(normsKeys);
 
     sitemapsUpdateJob.createSitemaps(normsBucket, DocumentKind.LEGISLATION);
 
@@ -152,7 +151,7 @@ class SitemapsUpdateJobTest {
             "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-verkuendung-1.xml",
             "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-03-10/regelungstext-verkuendung-1.xml");
 
-    when(normsBucket.getAllKeysOnCurrentVersion()).thenReturn(normsKeys);
+    when(normsBucket.getAllKeys()).thenReturn(normsKeys);
 
     sitemapsUpdateJob.createSitemaps(normsBucket, DocumentKind.LEGISLATION);
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/eclicrawler/EcliCrawlerDocumentServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/eclicrawler/EcliCrawlerDocumentServiceTest.java
@@ -84,7 +84,7 @@ class EcliCrawlerDocumentServiceTest {
     LocalDate day = LocalDate.of(2025, Month.JANUARY, 1);
     var filenames = IntStream.range(0, 11000).boxed().map(i -> "file_" + i + ".xml").toList();
 
-    when(caseLawBucket.getAllKeysOnCurrentVersion()).thenReturn(filenames);
+    when(caseLawBucket.getAllKeys()).thenReturn(filenames);
     when(caselawService.getFromBucket(any())).thenReturn(Optional.of(getTestDocUnit("docNumber")));
 
     when(sitemapWriter.writeUrlsToSitemap(eq(day), any(), eq(1)))

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/helper/ZipManagerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/helper/ZipManagerTest.java
@@ -67,7 +67,7 @@ class ZipManagerTest {
 
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     ZipManager.writeZipArchive(
-        bucketMock, "", List.of(keyPrefix + xmlFilename, keyPrefix + pngFilename), outputStream);
+        bucketMock, List.of(keyPrefix + xmlFilename, keyPrefix + pngFilename), outputStream);
 
     try (ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
         ZipInputStream zipInputStream = new ZipInputStream(inputStream)) {

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/xslt/NormXsltTransformerServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/xslt/NormXsltTransformerServiceTest.java
@@ -31,7 +31,7 @@ class NormXsltTransformerServiceTest {
 
   private final NormsBucket normsBucketMock = mock(NormsBucket.class);
   private final NormXsltTransformerService service =
-      new NormXsltTransformerService(normsBucketMock, "");
+      new NormXsltTransformerService(normsBucketMock);
 
   String resourcesPath = getClass().getResource("/data/XsltTransformerServiceTest/").getPath();
 

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -12,3 +12,7 @@ spring.security.oauth2.client.registration.keycloak.client-id=my-client
 spring.security.oauth2.client.registration.keycloak.client-secret=my-secret
 spring.security.oauth2.client.registration.keycloak.authorization-grant-type=client_credentials
 spring.security.oauth2.client.provider.keycloak.token-uri=http://localhost:8443/realms/ris/protocol/openid-connect/token
+s3.file-storage.norm,versionPrefix:
+s3.file-storage.case-law,versionPrefix:"V1/"
+s3.file-storage.literature,versionPrefix:
+s3.file-storage.administrative-directive,versionPrefix:


### PR DESCRIPTION
*Refactor versionPrefix so that it is contained within the ObjectStorage class. *A small exception is needed for the ChangelogService since the content of the changelog files will have the prefix which needs to be stripped off.