### PR TITLE
RISDEV-0000 Ensure prefix is only removed if present

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/ChangelogService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/ChangelogService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
 import de.bund.digitalservice.ris.search.repository.objectstorage.ObjectStorage;
+import de.bund.digitalservice.ris.search.utils.StringUtils;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -95,11 +96,11 @@ public class ChangelogService<T extends ObjectStorage> {
   private Changelog stripVersionPrefix(String versionPrefix, Changelog input) {
     input.setChanged(
         input.getChanged().stream()
-            .map(e -> e.substring(versionPrefix.length()))
+            .map(e -> StringUtils.stripPrefix(e, versionPrefix))
             .collect(Collectors.toCollection(HashSet::new)));
     input.setDeleted(
         input.getDeleted().stream()
-            .map(e -> e.substring(versionPrefix.length()))
+            .map(e -> StringUtils.stripPrefix(e, versionPrefix))
             .collect(Collectors.toCollection(HashSet::new)));
     return input;
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/StringUtils.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/StringUtils.java
@@ -1,5 +1,6 @@
 package de.bund.digitalservice.ris.search.utils;
 
+/** Class for string utility functions. */
 public class StringUtils {
 
   private StringUtils() {}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/StringUtils.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/StringUtils.java
@@ -1,0 +1,22 @@
+package de.bund.digitalservice.ris.search.utils;
+
+public class StringUtils {
+
+  private StringUtils() {}
+
+  /**
+   * Removes the given prefix from the input if the input starts with the prefix. Otherwise, the
+   * input is returned unchanged.
+   *
+   * @param input with a prefix that should be removed
+   * @param prefix that should be removed from the input
+   * @return input with the prefix removed
+   */
+  public static String stripPrefix(String input, String prefix) {
+    if (input != null && prefix != null && input.startsWith(prefix)) {
+      return input.substring(prefix.length());
+    }
+
+    return input;
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/ChangelogServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/ChangelogServiceTest.java
@@ -21,6 +21,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -159,15 +161,17 @@ class ChangelogServiceTest {
     assertThat(result.getChanged()).asInstanceOf(SET).containsExactlyInAnyOrder("file1", "file2");
   }
 
-  @Test
-  void itConsidersVersionPrefixes() throws JsonProcessingException, ObjectStoreServiceException {
+  @ParameterizedTest
+  @ValueSource(strings = {"V1/file", "file"})
+  void itConsidersVersionPrefixes(String baseFilename)
+      throws JsonProcessingException, ObjectStoreServiceException {
     Instant from = Instant.parse("2026-07-03T12:00:00Z");
     Instant to = Instant.parse("2027-01-01T12:00:00Z");
 
-    Changelog expectedFirst =
-        new Changelog(new HashSet<>(List.of("V1/file1")), new HashSet<>(), false);
-    Changelog expectedSecond =
-        new Changelog(new HashSet<>(List.of("V1/file2")), new HashSet<>(), false);
+    Changelog firstChangelog =
+        new Changelog(new HashSet<>(List.of(baseFilename + "1")), new HashSet<>(), false);
+    Changelog secondChangelog =
+        new Changelog(new HashSet<>(List.of(baseFilename + "2")), new HashSet<>(), false);
 
     when(bucket.getVersionPrefix()).thenReturn("V1/");
     when(bucket.getAllKeysByPrefix(any()))
@@ -178,13 +182,14 @@ class ChangelogServiceTest {
                 "changelogs/2026-07-08T12:00:00.933434Z-norm.json"));
 
     when(bucket.getFileAsString("changelogs/2026-07-03T12:00:00.933434Z-norm.json"))
-        .thenReturn(Optional.of(objectMapper.writeValueAsString(expectedFirst)));
+        .thenReturn(Optional.of(objectMapper.writeValueAsString(firstChangelog)));
     when(bucket.getFileAsString("changelogs/2026-07-08T12:00:00.933434Z-norm.json"))
-        .thenReturn(Optional.of(objectMapper.writeValueAsString(expectedSecond)));
+        .thenReturn(Optional.of(objectMapper.writeValueAsString(secondChangelog)));
 
     ChangelogService<?> service = new ChangelogService<>(bucket, objectMapper);
     Changelog result = service.getChangesBetween(from, to);
 
+    // Should strip the version prefix only if it exists, otherwise leave the filename unchanged
     assertThat(result.getChanged()).asInstanceOf(SET).containsExactlyInAnyOrder("file1", "file2");
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/utils/StringUtilsTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/utils/StringUtilsTest.java
@@ -1,0 +1,23 @@
+package de.bund.digitalservice.ris.search.unit.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.bund.digitalservice.ris.search.utils.StringUtils;
+import org.junit.jupiter.api.Test;
+
+class StringUtilsTest {
+  @Test
+  void stripPrefixRemovesPrefixIfInputStartsWithPrefix() {
+    assertThat(StringUtils.stripPrefix("abcdefg", "abc")).isEqualTo("defg");
+  }
+
+  @Test
+  void returnsInputIfPrefixDoesNotMatch() {
+    assertThat(StringUtils.stripPrefix("abcdefg", "123")).isEqualTo("abcdefg");
+  }
+
+  @Test
+  void returnsInputIfPrefixIsNull() {
+    assertThat(StringUtils.stripPrefix("abcdefg", null)).isEqualTo("abcdefg");
+  }
+}


### PR DESCRIPTION
- fixes a bug where the filenames returned by the changelog endpoint for caselaws are missing the first few characters

RISDEV-0000