### PR TITLE
RISDEV-10578 Abbreviation filter for legislation endpoint

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/api/parameters/NormsSearchParams.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/api/parameters/NormsSearchParams.java
@@ -64,6 +64,9 @@ public class NormsSearchParams {
   @Schema(description = MOST_RELEVANT_ON_DESCRIPTION)
   LocalDate mostRelevantOn;
 
+  @Schema(description = "Filters the result set by the given abbreviation.")
+  String abbreviation;
+
   /**
    * Validates the temporal coverage range for the search parameters.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormSimpleSearchType.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormSimpleSearchType.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.search.service;
 
 import static org.opensearch.index.query.QueryBuilders.matchQuery;
+import static org.opensearch.index.query.QueryBuilders.termQuery;
 
 import de.bund.digitalservice.ris.search.models.api.parameters.NormsSearchParams;
 import de.bund.digitalservice.ris.search.models.opensearch.Norm;
@@ -47,10 +48,18 @@ public class NormSimpleSearchType implements SimpleSearchType {
     if (normsSearchParams == null) {
       return;
     }
+
     if (normsSearchParams.getEli() != null) {
       query.must(
           matchQuery(Norm.Fields.WORK_ELI, normsSearchParams.getEli()).operator(Operator.AND));
     }
+
+    if (normsSearchParams.getAbbreviation() != null) {
+      query.must(
+          termQuery(
+              Norm.Fields.OFFICIAL_ABBREVIATION_KEYWORD, normsSearchParams.getAbbreviation()));
+    }
+
     if (normsSearchParams.getMostRelevantOn() != null) {
       BoolQueryBuilder isNotNorm =
           QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(Norm.Fields.EXPRESSION_ELI));

--- a/backend/src/main/resources/openSearch/german_analyzer_template.json
+++ b/backend/src/main/resources/openSearch/german_analyzer_template.json
@@ -113,12 +113,22 @@
             "type": "pattern_replace",
             "pattern": "\\u20AC",
             "replacement": "eur"
+          },
+          "whitespace_to_underscore": {
+            "type": "pattern_replace",
+            "pattern": "\\s+",
+            "replacement": "_"
           }
         },
         "normalizer": {
           "normalized_keyword": {
             "type": "custom",
             "char_filter": [],
+            "filter": ["asciifolding", "lowercase"]
+          },
+          "norm_abbreviation_normalized_keyword": {
+            "type": "custom",
+            "char_filter": ["whitespace_to_underscore"],
             "filter": ["asciifolding", "lowercase"]
           }
         }

--- a/backend/src/main/resources/openSearch/norms_index_template.json
+++ b/backend/src/main/resources/openSearch/norms_index_template.json
@@ -93,7 +93,7 @@
           "fields": {
             "keyword": {
               "type": "keyword",
-              "normalizer": "normalized_keyword"
+              "normalizer": "norm_abbreviation_normalized_keyword"
             }
           }
         },

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/NormsControllerApiTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/NormsControllerApiTest.java
@@ -366,6 +366,43 @@ class NormsControllerApiTest extends ContainersIntegrationBase {
   }
 
   @Test
+  @DisplayName("Should allow filtering norms by abbreviation")
+  void shouldReturnNormsFilteringByAbbreviation() throws Exception {
+    final String uri = ApiConfig.Paths.LEGISLATION + "?abbreviation=Teg";
+    mockMvc
+        .perform(get(uri).contentType(MediaType.APPLICATION_JSON))
+        .andExpectAll(
+            status().isOk(),
+            jsonPath("$.member", hasSize(1)),
+            jsonPath("$.member[0]['item'].abbreviation", is("TeG")));
+  }
+
+  @Test
+  @DisplayName("Should allow filtering norms by abbreviation and most relevantOn date")
+  void shouldReturnNormsFilteringByAbbreviationAndMostRelevantOn() throws Exception {
+    // Note a Norm with the same abbreviation but different date is
+    // already added via the ContainerIntegrationBase class
+    LocalDate date = LocalDate.of(2025, Month.NOVEMBER, 3);
+    normsRepository.save(
+        Norm.builder()
+            .id("eli/2024/teg/4/exp")
+            .officialAbbreviation("TeG")
+            .officialTitle("This is it")
+            .entryIntoForceDate(date)
+            .expiryDate(date)
+            .build());
+
+    final String uri = ApiConfig.Paths.LEGISLATION + "?abbreviation=Teg&mostRelevantOn=2025-11-03";
+    mockMvc
+        .perform(get(uri).contentType(MediaType.APPLICATION_JSON))
+        .andExpectAll(
+            status().isOk(),
+            jsonPath("$.member", hasSize(1)),
+            jsonPath("$.member[0]['item'].abbreviation", is("TeG")),
+            jsonPath("$.member[0]['item'].name", is("This is it")));
+  }
+
+  @Test
   @DisplayName("Should find a norm when searching for its expression ELI explicitly")
   void shouldFindNormByExpressionEli() throws Exception {
     final String eli = NormsTestData.allNorms.getFirst().getExpressionEli();

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/service/NormsServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/service/NormsServiceTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -52,7 +54,7 @@ class NormsServiceTest extends ContainersIntegrationBase {
             .datePublished(LocalDate.of(2022, Month.JANUARY, 1))
             .officialShortTitle("latest short title")
             .normsDate(LocalDate.of(2022, Month.JANUARY, 1))
-            .officialAbbreviation("latest abbr")
+            .officialAbbreviation("latest_abbr")
             .workEli("eli/bund/bgbl-1/2020/s1126")
             .build();
 
@@ -68,7 +70,7 @@ class NormsServiceTest extends ContainersIntegrationBase {
             .datePublished(LocalDate.of(2020, Month.JANUARY, 1))
             .officialShortTitle("oldest short title")
             .normsDate(LocalDate.of(2020, Month.JANUARY, 1))
-            .officialAbbreviation("oldest abbr")
+            .officialAbbreviation("oldest_abbr")
             .workEli("eli/bund/bgbl-1/2020/s1126")
             .build();
     repository.save(olderExpression);
@@ -141,5 +143,42 @@ class NormsServiceTest extends ContainersIntegrationBase {
 
     Article firstArticle = (Article) searchHits.getFirst().getContent();
     assertThat(firstArticle.getName()).contains(articleName);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"FooBar 2009", "foobar 2009", "foobar_2009"})
+  void shouldFilterNormByAbbreviation(String abbreviationParam) {
+    repository.save(Norm.builder().officialAbbreviation("FooBar 2009").build());
+
+    repository.save(Norm.builder().officialAbbreviation("FooBar").build());
+
+    repository.save(Norm.builder().officialAbbreviation("BarBaz 2009").build());
+
+    NormsSearchParams params = new NormsSearchParams();
+    params.setAbbreviation(abbreviationParam);
+    var result =
+        normsService.simpleSearchNorms(new UniversalSearchParams(), params, Pageable.unpaged());
+
+    assertThat(result).hasSize(1);
+    assertThat(
+            result
+                .getSearchHits()
+                .getSearchHits()
+                .getFirst()
+                .getContent()
+                .getOfficialAbbreviation())
+        .isEqualTo("FooBar 2009");
+  }
+
+  @Test
+  void shouldFilterOnlyOnFullKeywordMatchesByAbbreviation() {
+    repository.save(Norm.builder().officialAbbreviation("FooBar Baz 2009").build());
+
+    NormsSearchParams params = new NormsSearchParams();
+    params.setAbbreviation("Baz");
+    var result =
+        normsService.simpleSearchNorms(new UniversalSearchParams(), params, Pageable.unpaged());
+
+    assertThat(result).isEmpty();
   }
 }

--- a/frontend/src/public/openapi.json
+++ b/frontend/src/public/openapi.json
@@ -360,6 +360,15 @@
             "description" : "Filters the result set so every work returns exactly one expression. Most relevant is defined as : The expression in force on that date if it exists, then the expression that would next be in force if that exists, then the most recent expression that was in force. If other filters are used the work may return 0 expressions due to the most relevant expression being filtered out."
           }
         }, {
+          "name" : "abbreviation",
+          "in" : "query",
+          "description" : "Filters the result set by the given abbreviation.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "description" : "Filters the result set by the given abbreviation."
+          }
+        }, {
           "name" : "searchTerm",
           "in" : "query",
           "description" : "Searches for the given tokens in searchTerm. If searchTerm contains more than one token, all tokens must be in the document for the document to match.",

--- a/frontend/src/types/api-generated.d.ts
+++ b/frontend/src/types/api-generated.d.ts
@@ -2166,6 +2166,8 @@ export interface operations {
          * relevant expression being filtered out.
          */
         mostRelevantOn?: string;
+        /** Filters the result set by the given abbreviation. */
+        abbreviation?: string;
         /**
          * Searches for the given tokens in searchTerm. If searchTerm contains
          * more than one token, all tokens must be in the document for the


### PR DESCRIPTION
- add an abbreviation filter parameter to the legislation search endpoint, this allows to filter returned norms by an abbreviation

RISDEV-10578