### PR TITLE
RISDEV-0000 interrupt page setup when data can't be loaded

### DIFF
--- a/frontend/src/composables/useFetchNormContent.spec.ts
+++ b/frontend/src/composables/useFetchNormContent.spec.ts
@@ -147,6 +147,17 @@ describe("useFetchNormContent", () => {
     expect(mockFetch).toHaveBeenCalledWith("/v1/legislation/eli/test-eli");
   });
 
+  it("does not return partial data when the HTML request fails", async () => {
+    mockFetch.mockReturnValueOnce(mockMetadata);
+    mockFetch.mockRejectedValueOnce(new Error("HTML request failed"));
+
+    const { data, error } = await useFetchNormContent(expressionEli);
+
+    expect(data.value).toBeUndefined();
+    expect(error.value?.message).toBe("HTML request failed");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
   it.each([
     ["simple footnote", 15],
     ["<span>with html</span>", 9],

--- a/frontend/src/pages/administrative-directives/[documentNumber].vue
+++ b/frontend/src/pages/administrative-directives/[documentNumber].vue
@@ -18,13 +18,13 @@ definePageMeta({
 const route = useRoute();
 
 const documentNumber = route.params.documentNumber as string;
-if (!documentNumber) showError({ status: 404 });
+if (!documentNumber) throw createError({ status: 404 });
 
 const documentMetadataUrl = `/v1/administrative-directive/${documentNumber}`;
 
 const { data, error: metadataError } =
   await useRisBackend<AdministrativeDirective>(documentMetadataUrl);
-if (metadataError?.value) showError(metadataError.value);
+if (metadataError?.value) throw createError(metadataError.value);
 
 useAdministrativeDirectiveSeo({
   documentType: data.value?.documentType,
@@ -36,7 +36,7 @@ const { data: html, error: contentError } = await useRisBackend<string>(
   `${documentMetadataUrl}.html`,
   { headers: { Accept: "text/html" } },
 );
-if (contentError?.value) showError(contentError.value);
+if (contentError?.value) throw createError(contentError.value);
 
 // Page contents ------------------------------------------
 

--- a/frontend/src/pages/case-law/[documentNumber].vue
+++ b/frontend/src/pages/case-law/[documentNumber].vue
@@ -20,17 +20,17 @@ definePageMeta({
 const route = useRoute();
 
 const documentNumber = route.params.documentNumber?.toString();
-if (!documentNumber) showError({ status: 404 });
+if (!documentNumber) throw createError({ status: 404 });
 
 const { data: caseLaw, error: metadataError } = await useRisBackend<CaseLaw>(
   `/v1/case-law/${documentNumber}`,
 );
-if (metadataError?.value) showError(metadataError.value);
+if (metadataError?.value) throw createError(metadataError.value);
 
 const { data: html, error: contentError } = await useRisBackend<string>(
   `/v1/case-law/${documentNumber}.html`,
 );
-if (contentError?.value) showError(contentError.value);
+if (contentError?.value) throw createError(contentError.value);
 
 const document = computed(() => {
   if (html.value) {

--- a/frontend/src/pages/literature/[documentNumber].vue
+++ b/frontend/src/pages/literature/[documentNumber].vue
@@ -18,13 +18,13 @@ definePageMeta({
 const route = useRoute();
 
 const documentNumber = route.params.documentNumber?.toString();
-if (!documentNumber) showError({ status: 404 });
+if (!documentNumber) throw createError({ status: 404 });
 
 const documentMetadataUrl = `/v1/literature/${documentNumber}`;
 
 const { data: literature, error: metadataError } =
   await useRisBackend<Literature>(documentMetadataUrl);
-if (metadataError?.value) showError(metadataError.value);
+if (metadataError?.value) throw createError(metadataError.value);
 
 useLiteratureSeo({
   documentTypes: literature.value?.documentTypes ?? [],
@@ -37,7 +37,7 @@ const { data: html, error: contentError } = await useRisBackend<string>(
   `${documentMetadataUrl}.html`,
   { headers: { Accept: "text/html" } },
 );
-if (contentError?.value) showError(contentError.value);
+if (contentError?.value) throw createError(contentError.value);
 
 // Page contents ------------------------------------------
 

--- a/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/norms/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -43,7 +43,7 @@ const { data, error } = await useFetchNormContent(expressionEli, {
 });
 
 if (error.value || !data.value) {
-  showError({ status: error.value?.status ?? 500 });
+  throw createError({ status: error.value?.status ?? 500 });
 }
 
 const metadata: Ref<LegislationExpression> = computed(() => {


### PR DESCRIPTION
Fixes an issue where the page setup would continue to run in the background, even though required data could not be loaded. This PR changes the error handling so it throws an error instead of asynchronously redirecting to an error page, ensuring the setup is interrupted immediately and nothing silently crashes in the background.