### PR TITLE
Risdev 12074 display value from showas for caselaw

### DIFF
--- a/backend/e2e-data/caselaw/BDRE000800001/BDRE000800001.xml
+++ b/backend/e2e-data/caselaw/BDRE000800001/BDRE000800001.xml
@@ -61,7 +61,7 @@
                     <ris:aktenzeichen domainTerm="Aktenzeichen" akn:refersTo="#aktenzeichen">XVI VL 34/99</ris:aktenzeichen>
                 </ris:aktenzeichenListe>
                 <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
-                <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+                <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="BDiG Frankfurt Label">
                     <ris:gerichtstyp domainTerm="Gerichtstyp">BDiG</ris:gerichtstyp>
                     <ris:gerichtsort domainTerm="Gerichtsort">Frankfurt</ris:gerichtsort>
                     <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">16. Kammer</ris:spruchkoerper>

--- a/backend/e2e-data/caselaw/BORE040030050/BORE040030050.xml
+++ b/backend/e2e-data/caselaw/BORE040030050/BORE040030050.xml
@@ -61,7 +61,7 @@
                         <ris:aktenzeichen domainTerm="Aktenzeichen" akn:refersTo="#aktenzeichen">TT 98765</ris:aktenzeichen>
                     </ris:aktenzeichenListe>
                     <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
-                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="LG Test8 Label">
                         <ris:gerichtstyp domainTerm="Gerichtstyp">LG</ris:gerichtstyp>
                         <ris:gerichtsort domainTerm="Gerichtsort">Testort8</ris:gerichtsort>
                         <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">11. Senat</ris:spruchkoerper>

--- a/backend/e2e-data/caselaw/BORE040077910/BORE040077910.xml
+++ b/backend/e2e-data/caselaw/BORE040077910/BORE040077910.xml
@@ -61,7 +61,7 @@
                         <ris:aktenzeichen domainTerm="Aktenzeichen" akn:refersTo="#aktenzeichen">RT 567890</ris:aktenzeichen>
                     </ris:aktenzeichenListe>
                     <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
-                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="LG Hamburg Label">
                         <ris:gerichtstyp domainTerm="Gerichtstyp">LG</ris:gerichtstyp>
                         <ris:gerichtsort domainTerm="Gerichtsort">Hamburg</ris:gerichtsort>
                         <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">12. Senat</ris:spruchkoerper>

--- a/backend/e2e-data/caselaw/BORE040077911/BORE040077911.xml
+++ b/backend/e2e-data/caselaw/BORE040077911/BORE040077911.xml
@@ -63,7 +63,7 @@
                         <ris:aktenzeichen domainTerm="Aktenzeichen" akn:refersTo="#aktenzeichen">RT 567891</ris:aktenzeichen>
                     </ris:aktenzeichenListe>
                     <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
-                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="LG Hamburg Label">
                         <ris:gerichtstyp domainTerm="Gerichtstyp">LG</ris:gerichtstyp>
                         <ris:gerichtsort domainTerm="Gerichtsort">Berlin</ris:gerichtsort>
                         <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">13. Senat</ris:spruchkoerper>

--- a/backend/e2e-data/caselaw/JURE200030030/JURE200030030.xml
+++ b/backend/e2e-data/caselaw/JURE200030030/JURE200030030.xml
@@ -68,7 +68,7 @@
                         <ris:aktenzeichen domainTerm="Aktenzeichen" akn:refersTo="#aktenzeichen">AB 5678/90</ris:aktenzeichen>
                     </ris:aktenzeichenListe>
                     <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
-                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="ArbG Köln Label">
                         <ris:gerichtstyp domainTerm="Gerichtstyp">ArbG</ris:gerichtstyp>
                         <ris:gerichtsort domainTerm="Gerichtsort">Köln</ris:gerichtsort>
                         <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">5. Kammer</ris:spruchkoerper>

--- a/backend/e2e-data/caselaw/KORE600010000/KORE600010000.xml
+++ b/backend/e2e-data/caselaw/KORE600010000/KORE600010000.xml
@@ -61,7 +61,7 @@
                         <ris:aktenzeichen domainTerm="Aktenzeichen" akn:refersTo="#aktenzeichen">PS 12345678</ris:aktenzeichen>
                     </ris:aktenzeichenListe>
                     <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
-                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="LG Test Label">
                         <ris:gerichtstyp domainTerm="Gerichtstyp">LG</ris:gerichtstyp>
                         <ris:gerichtsort domainTerm="Gerichtsort">Testort5</ris:gerichtsort>
                         <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">12. Kammer</ris:spruchkoerper>

--- a/backend/e2e-data/caselaw/KORE600500000/KORE600500000.xml
+++ b/backend/e2e-data/caselaw/KORE600500000/KORE600500000.xml
@@ -61,7 +61,7 @@
                         <ris:aktenzeichen domainTerm="Aktenzeichen" akn:refersTo="#aktenzeichen">TS 123456</ris:aktenzeichen>
                     </ris:aktenzeichenListe>
                     <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
-                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="LG Test6 Label">
                         <ris:gerichtstyp domainTerm="Gerichtstyp">LG</ris:gerichtstyp>
                         <ris:gerichtsort domainTerm="Gerichtsort">Testort6</ris:gerichtsort>
                         <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">8. Kammer</ris:spruchkoerper>

--- a/backend/e2e-data/caselaw/KORE600500001/KORE600500001.xml
+++ b/backend/e2e-data/caselaw/KORE600500001/KORE600500001.xml
@@ -61,7 +61,7 @@
                         <ris:aktenzeichen domainTerm="Aktenzeichen" akn:refersTo="#aktenzeichen">TS 234567</ris:aktenzeichen>
                     </ris:aktenzeichenListe>
                     <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
-                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="LG Testort11 Label">
                         <ris:gerichtstyp domainTerm="Gerichtstyp">LG</ris:gerichtstyp>
                         <ris:gerichtsort domainTerm="Gerichtsort">Testort11</ris:gerichtsort>
                         <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">5. Kammer</ris:spruchkoerper>

--- a/backend/e2e-data/caselaw/KORE600500002/KORE600500002.xml
+++ b/backend/e2e-data/caselaw/KORE600500002/KORE600500002.xml
@@ -61,7 +61,7 @@
                         <ris:aktenzeichen domainTerm="Aktenzeichen" akn:refersTo="#aktenzeichen">TS 345678</ris:aktenzeichen>
                     </ris:aktenzeichenListe>
                     <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
-                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="LG Testort12 Label">
                         <ris:gerichtstyp domainTerm="Gerichtstyp">LG</ris:gerichtstyp>
                         <ris:gerichtsort domainTerm="Gerichtsort">Testort12</ris:gerichtsort>
                         <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">3. Kammer</ris:spruchkoerper>

--- a/backend/e2e-data/caselaw/KORE800400600/KORE800400600.xml
+++ b/backend/e2e-data/caselaw/KORE800400600/KORE800400600.xml
@@ -61,7 +61,7 @@
                         <ris:aktenzeichen domainTerm="Aktenzeichen" akn:refersTo="#aktenzeichen">KL 1234/56</ris:aktenzeichen>
                     </ris:aktenzeichenListe>
                     <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
-                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="LG Hamburg Label">
                         <ris:gerichtstyp domainTerm="Gerichtstyp">LG</ris:gerichtstyp>
                         <ris:gerichtsort domainTerm="Gerichtsort">Hamburg</ris:gerichtsort>
                         <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">10. Senat</ris:spruchkoerper>

--- a/backend/e2e-data/caselaw/MPRE088000100/MPRE088000100.xml
+++ b/backend/e2e-data/caselaw/MPRE088000100/MPRE088000100.xml
@@ -64,7 +64,7 @@
                         <ris:aktenzeichen domainTerm="Aktenzeichen" akn:refersTo="#aktenzeichen">AB C 78/90</ris:aktenzeichen>
                     </ris:aktenzeichenListe>
                     <ris:dokumenttyp domainTerm="Dokumenttyp">Beschluss</ris:dokumenttyp>
-                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="BPatG Label">
                         <ris:gerichtstyp domainTerm="Gerichtstyp">BPatG</ris:gerichtstyp>
                         <ris:gerichtsort domainTerm="Gerichtsort">Beispielstadt</ris:gerichtsort>
                         <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">15. Senat</ris:spruchkoerper>

--- a/backend/e2e-data/caselaw/MWRE000500300/MWRE000500300.xml
+++ b/backend/e2e-data/caselaw/MWRE000500300/MWRE000500300.xml
@@ -67,7 +67,7 @@
                         <ris:aktenzeichen domainTerm="Aktenzeichen" akn:refersTo="#aktenzeichen">34 X (xyz) 456/78</ris:aktenzeichen>
                     </ris:aktenzeichenListe>
                     <ris:dokumenttyp domainTerm="Dokumenttyp">Beschluss</ris:dokumenttyp>
-                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="BPatG Label">
                         <ris:gerichtstyp domainTerm="Gerichtstyp">BPatG</ris:gerichtstyp>
                         <ris:gerichtsort domainTerm="Gerichtsort">Teststadt</ris:gerichtsort>
                         <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">27. Senat</ris:spruchkoerper>

--- a/backend/e2e-data/caselaw/STRE300770800/STRE300770800.xml
+++ b/backend/e2e-data/caselaw/STRE300770800/STRE300770800.xml
@@ -62,7 +62,7 @@
                         <ris:aktenzeichen domainTerm="Aktenzeichen" akn:refersTo="#aktenzeichen">22 L 5678/90</ris:aktenzeichen>
                     </ris:aktenzeichenListe>
                     <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
-                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="FG Berlin Label">
                         <ris:gerichtstyp domainTerm="Gerichtstyp">FG</ris:gerichtstyp>
                         <ris:gerichtsort domainTerm="Gerichtsort">Berlin</ris:gerichtsort>
                         <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">10. Senat</ris:spruchkoerper>

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/ldml/caselaw/RisGericht.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/ldml/caselaw/RisGericht.java
@@ -26,8 +26,12 @@ public class RisGericht {
   @XmlAttribute private String domainTerm;
 
   /** Reference to a formal definition or IRI within the Akoma Ntoso namespace. */
-  @XmlAttribute(name = "refersTo", namespace = CaseLawLdmlNamespaces.AKN_NS)
+  @XmlAttribute(name = "refersTo")
   private String refersTo;
+
+  /** Reference to a formal definition or IRI within the Akoma Ntoso namespace. */
+  @XmlAttribute(name = "showAs")
+  private String showAs;
 
   /** The type of court (e.g., Amtsgericht, Landgericht). */
   @XmlElement(name = "gerichtstyp", namespace = CaseLawLdmlNamespaces.RIS_NS)

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/ldml/caselaw/RisMeta.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/ldml/caselaw/RisMeta.java
@@ -69,11 +69,7 @@ public class RisMeta {
    * @return the combined court keyword
    */
   public String getCourtKeyword() {
-    if (risGericht == null) return null;
-    if (risGericht.getGerichtsort() == null) {
-      return risGericht.getGerichtstyp();
-    }
-    return String.format("%s %s", risGericht.getGerichtstyp(), risGericht.getGerichtsort());
+    return risGericht.getShowAs();
   }
 
   public List<String> getAktenzeichen() {

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/CaseLawLdmlToOpenSearchMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/CaseLawLdmlToOpenSearchMapperTest.java
@@ -40,7 +40,7 @@ class CaseLawLdmlToOpenSearchMapperTest {
     assertThat(caseLaw.fileNumbers()).hasToString("[Test file number 1, Test file number 2]");
     assertThat(caseLaw.courtType()).isEqualTo("Test court type");
     assertThat(caseLaw.location()).isEqualTo("Test court location");
-    assertThat(caseLaw.courtKeyword()).isEqualTo("Test court type Test court location");
+    assertThat(caseLaw.courtKeyword()).isEqualTo("Test court label");
     assertThat(caseLaw.documentType()).isEqualTo("Urteil");
     assertThat(caseLaw.outline()).isEqualTo("Example Gliederung/Outline");
     assertThat(caseLaw.judicialBody()).isEqualTo("Test judicial body");

--- a/backend/src/test/resources/templates/case-law/includes/akn-meta.xml
+++ b/backend/src/test/resources/templates/case-law/includes/akn-meta.xml
@@ -146,7 +146,7 @@
             <ris:aktenzeichen domainTerm="Aktenzeichen" refersTo="#aktenzeichen">Test file number 2</ris:aktenzeichen>
         </ris:aktenzeichenListe>
         <ris:dokumenttyp domainTerm="Dokumenttyp">{% if documentType %}{{ documentType }}{% else %}Urteil{% endif %}</ris:dokumenttyp>
-        <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation">
+        <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-courttype-courtlocation" showAs="{% if courtLabel %}{{ courtLabel }}{% else %}Test court label{% endif %}">
             <ris:gerichtstyp domainTerm="Gerichtstyp">{% if courtType %}{{ courtType }}{% else %}Test court type{% endif %}</ris:gerichtstyp>
             <ris:gerichtsort domainTerm="Gerichtsort">{% if location %}{{ location }}{% else %}Test court location{% endif%}</ris:gerichtsort>
             <ris:spruchkoerper domainTerm="Spruchkörper" refersTo="#spruchkoerper">Test judicial body</ris:spruchkoerper>

--- a/frontend/e2e/erweiterteSuche.spec.ts
+++ b/frontend/e2e/erweiterteSuche.spec.ts
@@ -519,7 +519,7 @@ test.describe("searching caselaw", () => {
 
     // Header
     await expect(searchResult).toHaveText(/Beschluss/);
-    await expect(searchResult).toHaveText(/BPatG Teststadt/);
+    await expect(searchResult).toHaveText(/BPatG Label/);
     await expect(searchResult).toHaveText(/09.04.2025/);
     await expect(searchResult).toHaveText(/34 X \(xyz\) 456\/78/);
     await expect(searchResult).toHaveText(/Beispielentscheid/);

--- a/frontend/e2e/gerichtsentscheidungen.spec.ts
+++ b/frontend/e2e/gerichtsentscheidungen.spec.ts
@@ -157,7 +157,7 @@ test("can view metadata", async ({ page }) => {
     metadataList.getByRole("term").or(metadataList.getByRole("definition")),
   ).toHaveText([
     "Gericht",
-    "LG Testort6",
+    "LG Test6 Label",
     "Dokumenttyp",
     "Urteil",
     "Entscheidungsdatum",

--- a/frontend/e2e/suche.spec.ts
+++ b/frontend/e2e/suche.spec.ts
@@ -482,7 +482,7 @@ test.describe("searching caselaw", () => {
 
     // Header
     await expect(searchResult).toHaveText(/Beschluss/);
-    await expect(searchResult).toHaveText(/BPatG Teststadt/);
+    await expect(searchResult).toHaveText(/BPatG Label/);
     await expect(searchResult).toHaveText(/09.04.2025/);
     await expect(searchResult).toHaveText(/34 X \(xyz\) 456\/78/);
     await expect(searchResult).toHaveText(/Beispielentscheid/);
@@ -598,12 +598,14 @@ test.describe("searching caselaw", () => {
     await navigate(page, "/suche?documentKind=R");
 
     await page.getByRole("combobox", { name: "Bundesgericht" }).fill("LG");
-    await page.getByRole("option", { name: "Landgericht Hamburg" }).click();
+    await page
+      .getByRole("option", { name: "Landgericht Hamburg Label" })
+      .click();
 
     await expect(page).toHaveURL(/court=LG\+Hamburg/);
 
     await expect(getSearchResults(page)).toHaveText(
-      Array(2).fill(/LG Hamburg/),
+      Array(3).fill(/LG Hamburg Label/),
     );
   });
 
@@ -717,10 +719,10 @@ test.describe("searching caselaw", () => {
     // Start with caselaw search with typeGroup, date filter, and court
     await navigate(
       page,
-      "/suche?documentKind=R&typeGroup=urteil&court=LG+Hamburg&dateFilterType=period&dateFilterFrom=2025-01-01&dateFilterTo=2025-12-31",
+      "/suche?documentKind=R&typeGroup=urteil&court=LG+Hamburg+Label&dateFilterType=period&dateFilterFrom=2025-01-01&dateFilterTo=2025-12-31",
     );
 
-    await expect(getResultCounter(page)).toHaveText("2 Suchergebnisse");
+    await expect(getResultCounter(page)).toHaveText("3 Suchergebnisse");
 
     // Switch to All Documents
     await page


### PR DESCRIPTION
This PR starts to read the court name from newly created showAs attribute in the caselaw LDML. Result will be that there are locations in the court name of federal courts e.g. `Bundesverfassungsgericht Karlsruhe` will be just `Bundesverfassungsgericht`