### PR TITLE
risdev-12046-query-work-examples-from-repo

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -8,7 +8,7 @@ RUN --mount=type=secret,id=GH_PACKAGES_REPOSITORY_USER \
     export GH_PACKAGES_REPOSITORY_TOKEN=$(cat /run/secrets/GH_PACKAGES_REPOSITORY_TOKEN) && \
     ./gradlew build -x integrationTest -x test -x spotlessCheck
 
-FROM cgr.dev/chainguard/jre@sha256:76398cee8378a3483096775e909e6c4b5736782823f1bae32d4c8ffc8a84e052
+FROM cgr.dev/chainguard/jre@sha256:61629d528c84d339bd99c4ade93bb4df8405241b92582bbd76b31b4b920a7c60
 ARG SENTRY_RELEASE
 COPY --from=backend-builder /app/build/libs/ris-search-*.jar /app/app.jar
 EXPOSE 8090

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -8,7 +8,7 @@ RUN --mount=type=secret,id=GH_PACKAGES_REPOSITORY_USER \
     export GH_PACKAGES_REPOSITORY_TOKEN=$(cat /run/secrets/GH_PACKAGES_REPOSITORY_TOKEN) && \
     ./gradlew build -x integrationTest -x test -x spotlessCheck
 
-FROM cgr.dev/chainguard/jre@sha256:61629d528c84d339bd99c4ade93bb4df8405241b92582bbd76b31b4b920a7c60
+FROM cgr.dev/chainguard/jre@sha256:76398cee8378a3483096775e909e6c4b5736782823f1bae32d4c8ffc8a84e052
 ARG SENTRY_RELEASE
 COPY --from=backend-builder /app/build/libs/ris-search-*.jar /app/app.jar
 EXPOSE 8090

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/NormsRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/NormsRepository.java
@@ -4,6 +4,7 @@ import de.bund.digitalservice.ris.search.models.opensearch.Norm;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.annotations.SourceFilters;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 /**
@@ -19,6 +20,7 @@ public interface NormsRepository extends ElasticsearchRepository<Norm, String> {
    * @param pageable pageable to manage page size and sorting
    * @return A {@link Norm}
    */
+  @SourceFilters(excludes = {"articleTexts", "articleNames"})
   Page<Norm> getByWorkEliKeyword(String workEli, Pageable pageable);
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/NormsRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/NormsRepository.java
@@ -1,7 +1,6 @@
 package de.bund.digitalservice.ris.search.repository.opensearch;
 
 import de.bund.digitalservice.ris.search.models.opensearch.Norm;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,9 +16,10 @@ public interface NormsRepository extends ElasticsearchRepository<Norm, String> {
    * Returns all {@link Norm} matching the given work ELI.
    *
    * @param workEli The work-level ELI identifier.
+   * @param pageable pageable to manage page size and sorting
    * @return A {@link Norm}
    */
-  List<Norm> getByWorkEliKeyword(String workEli);
+  Page<Norm> getByWorkEliKeyword(String workEli, Pageable pageable);
 
   /**
    * Returns a {@link Norm} by its expression-level ELI keyword.

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormsService.java
@@ -9,39 +9,28 @@ import de.bund.digitalservice.ris.search.models.opensearch.Norm;
 import de.bund.digitalservice.ris.search.repository.objectstorage.NormsBucket;
 import de.bund.digitalservice.ris.search.repository.opensearch.NormsRepository;
 import de.bund.digitalservice.ris.search.service.helper.ZipManager;
-import de.bund.digitalservice.ris.search.utils.DateUtils;
 import de.bund.digitalservice.ris.search.utils.PageUtils;
 import de.bund.digitalservice.ris.search.utils.eli.ExpressionEli;
 import de.bund.digitalservice.ris.search.utils.eli.ManifestationEli;
 import de.bund.digitalservice.ris.search.utils.eli.WorkEli;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
-import org.opensearch.OpenSearchException;
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
-import org.opensearch.common.document.DocumentField;
 import org.opensearch.data.client.orhlc.NativeSearchQuery;
-import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.search.builder.SearchSourceBuilder;
-import org.opensearch.search.sort.SortOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -59,10 +48,7 @@ public class NormsService {
   private final ElasticsearchOperations operations;
   private final SimpleSearchQueryBuilder simpleSearchQueryBuilder;
   private final ArticleService articleService;
-  private final RestHighLevelClient openSearchRestClient;
   private final NormsBucket normsBucket;
-  private final String normsIndexName;
-  private static final String DATE_FORMAT = "yyyy-MM-dd";
 
   /**
    * Constructs a new instance of {@code NormsService}.
@@ -84,9 +70,7 @@ public class NormsService {
     this.normsRepository = normsRepository;
     this.normsBucket = normsBucket;
     this.operations = operations;
-    this.openSearchRestClient = openSearchRestClient;
     this.simpleSearchQueryBuilder = simpleSearchQueryBuilder;
-    this.normsIndexName = normsIndexName;
     this.articleService = articleService;
   }
 
@@ -152,86 +136,13 @@ public class NormsService {
    * @return Paginated Norms containing work_example metadata
    */
   public Page<Norm> getWorkExpressions(WorkEli workEli, Pageable pageable) {
-    SearchSourceBuilder sourceBuilder =
-        new SearchSourceBuilder()
-            .query(QueryBuilders.termQuery(Norm.Fields.WORK_ELI_KEYWORD, workEli.toString()))
-            .sort(Norm.Fields.ENTRY_INTO_FORCE_DATE, SortOrder.DESC)
-            .docValueField(Norm.Fields.EXPRESSION_ELI_KEYWORD)
-            .docValueField(Norm.Fields.WORK_ELI_KEYWORD)
-            .docValueField(Norm.Fields.ENTRY_INTO_FORCE_DATE, DATE_FORMAT)
-            .docValueField(Norm.Fields.EXPIRY_DATE, DATE_FORMAT)
-            .docValueField(Norm.Fields.OFFICIAL_TITLE_KEYWORD)
-            .docValueField(Norm.Fields.DATE_PUBLISHED, DATE_FORMAT)
-            .docValueField(Norm.Fields.OFFICIAL_SHORT_TITLE_KEYWORD)
-            .docValueField(Norm.Fields.NORMS_DATE, DATE_FORMAT)
-            .docValueField(Norm.Fields.OFFICIAL_ABBREVIATION_KEYWORD)
-            .docValueField(Norm.Fields.LATEST_MANIFESTATION_ELI_KEYWORD)
-            .fetchSource(false)
-            .from(pageable.getPageNumber() * pageable.getPageSize())
-            .size(pageable.getPageSize());
+    Pageable sortedPageable =
+        PageRequest.of(
+            pageable.getPageNumber(),
+            pageable.getPageSize(),
+            Sort.by(Sort.Direction.DESC, "entryIntoForceDate"));
 
-    SearchRequest searchRequest = new SearchRequest(normsIndexName).source(sourceBuilder);
-
-    try {
-      SearchResponse response = openSearchRestClient.search(searchRequest, RequestOptions.DEFAULT);
-      var hits = response.getHits();
-      var norms =
-          Arrays.stream(hits.getHits())
-              .map(
-                  hit -> {
-                    var fields = hit.getFields();
-
-                    String returnedWorkEli = getField(fields, Norm.Fields.WORK_ELI_KEYWORD);
-                    String expressionEli = getField(fields, Norm.Fields.EXPRESSION_ELI_KEYWORD);
-                    LocalDate entryIntoForceDate =
-                        DateUtils.nullSafeParseyyyyMMdd(
-                            getField(fields, Norm.Fields.ENTRY_INTO_FORCE_DATE));
-                    LocalDate expiryDate =
-                        DateUtils.nullSafeParseyyyyMMdd(getField(fields, Norm.Fields.EXPIRY_DATE));
-                    LocalDate datePublished =
-                        DateUtils.nullSafeParseyyyyMMdd(
-                            getField(fields, Norm.Fields.DATE_PUBLISHED));
-                    LocalDate normsDate =
-                        DateUtils.nullSafeParseyyyyMMdd(getField(fields, Norm.Fields.NORMS_DATE));
-
-                    String officialTitle = getField(fields, Norm.Fields.OFFICIAL_TITLE_KEYWORD);
-                    String shortTitle = getField(fields, Norm.Fields.OFFICIAL_SHORT_TITLE_KEYWORD);
-                    String manifestationEli =
-                        getField(fields, Norm.Fields.LATEST_MANIFESTATION_ELI_KEYWORD);
-                    String abbreviation =
-                        getField(fields, Norm.Fields.OFFICIAL_ABBREVIATION_KEYWORD);
-                    return Norm.builder()
-                        .id(hit.getId())
-                        .workEli(returnedWorkEli)
-                        .officialAbbreviation(abbreviation)
-                        .officialShortTitle(shortTitle)
-                        .officialTitle(officialTitle)
-                        .datePublished(datePublished)
-                        .expressionEli(expressionEli)
-                        .normsDate(normsDate)
-                        .entryIntoForceDate(entryIntoForceDate)
-                        .expiryDate(expiryDate)
-                        .manifestationEliExample(manifestationEli)
-                        .build();
-                  })
-              .toList();
-
-      long totalHits = Objects.isNull(hits.getTotalHits()) ? 0 : hits.getTotalHits().value();
-      return new PageImpl<>(norms, pageable, totalHits);
-    } catch (IOException e) {
-      throw new OpenSearchException(e);
-    }
-  }
-
-  /**
-   * Returns the Optional of the string value of a DocumentField if it is part of the fields Map
-   *
-   * @param fields Map of Fieldname and DocumentField of a Searchhit
-   * @param field the field to retrieve from the Map
-   * @return Optional of a the string value of DocumentField
-   */
-  private @Nullable String getField(Map<String, DocumentField> fields, String field) {
-    return fields.get(field) != null ? fields.get(field).getValue() : null;
+    return normsRepository.getByWorkEliKeyword(workEli.toString(), sortedPageable);
   }
 
   /**

--- a/backend/src/main/resources/openSearch/norms_index_template.json
+++ b/backend/src/main/resources/openSearch/norms_index_template.json
@@ -6,6 +6,12 @@
   "priority": 500,
   "template": {
     "mappings": {
+      "_source": {
+        "excludes": [
+          "article_texts",
+          "article_names"
+        ]
+      },
       "properties": {
         "AL": {
           "type": "alias",

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/service/IndexNormsServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/service/IndexNormsServiceTest.java
@@ -9,7 +9,6 @@ import de.bund.digitalservice.ris.search.models.opensearch.Norm;
 import de.bund.digitalservice.ris.search.service.IndexNormsService;
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +16,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Tag("integration")
@@ -40,7 +41,8 @@ class IndexNormsServiceTest extends ContainersIntegrationBase {
 
     normsBucket.save(manifestationEli, normXml);
     indexNormsService.reindexAll(SharedTestConstants.TIMESTAMP_2024_01_01_AS_STRING);
-    List<Norm> expressions = normsRepository.getByWorkEliKeyword(workEli);
+    List<Norm> expressions =
+        normsRepository.getByWorkEliKeyword(workEli, Pageable.unpaged()).toList();
     assertThat(expressions).hasSize(1);
     assertThat(expressions.getFirst().getTimeRelevanceStartDate())
         .isEqualTo(IndexNormsService.TIME_RELEVANCE_MIN);
@@ -52,10 +54,11 @@ class IndexNormsServiceTest extends ContainersIntegrationBase {
   @DisplayName("Three expressions cover full time relevance window")
   void threeExpressionsCoverFullTimeRelevanceWindow() {
     indexNormsService.reindexAll(SharedTestConstants.TIMESTAMP_2024_01_01_AS_STRING);
-    List<Norm> expressions = normsRepository.getByWorkEliKeyword("eli/bund/bgbl-1/1991/s102");
+    List<Norm> expressions =
+        normsRepository
+            .getByWorkEliKeyword("eli/bund/bgbl-1/1991/s102", Pageable.unpaged(Sort.by("id")))
+            .getContent();
     assertThat(expressions).hasSize(3);
-
-    expressions.sort(Comparator.comparing(Norm::getId));
 
     assertThat(expressions.getFirst().getTimeRelevanceStartDate())
         .isEqualTo(IndexNormsService.TIME_RELEVANCE_MIN);


### PR DESCRIPTION
This PR changes how we retrieve all expressions for a specific work. Instead of manually querying doc_value fields we use the repository to retrieve expressions. 
This makes sure that all fields we retrieve are in the same format, since keyword and text fields might be normalized differently.
To minimize the performance impact we exclude artice_texts and article_names on query time. 
The next index recreation will also remove it from the index _source to generally improve storage usage and query time.