### PR TITLE
RISDEV-11805 Change opensearch to use 2 nodes (all environments)

### DIFF
--- a/backend/src/main/resources/openSearch/german_analyzer_template.json
+++ b/backend/src/main/resources/openSearch/german_analyzer_template.json
@@ -2,6 +2,8 @@
   "template": {
     "settings":
     {
+      "number_of_shards": 3,
+      "number_of_replicas": 1,
       "analysis": {
         "analyzer": {
           "custom_german_analyzer": {


### PR DESCRIPTION
* Update number_of_shards to 3 so the data can actually be distributed evenly over the 3 nodes.
* Setting number_of_replicas to 1 isn't an update, but added it to the template to make it explicit