### PR TITLE
RISDEV-11576 prototype navigating article versions via eId

### DIFF
--- a/doc/prototypes/norm-article-version-navigation.md
+++ b/doc/prototypes/norm-article-version-navigation.md
@@ -1,0 +1,107 @@
+# Prototype: "Time travel" between article versions
+
+Status: **prototype / proof of concept** — gated behind `usePrivateFeaturesFlag()`, no automated tests, not ready for production use.
+
+## Scope
+
+On the norm-article detail page (`[eId].vue`), a single article (`§`) of one dated wording ("Fassung"/expression) of a norm is shown, along with its own validity interval ("Gültig ab/bis"). That interval can span several expressions of the norm if the article's text didn't change across amendments — but until now there was no way to actually navigate from the article being read to the same article in an earlier or later Fassung.
+
+This prototype adds a "Andere Fassungen dieses Paragrafen" list below the article, showing every version of the norm together with a link to the same article (matched by `eId`) in that version. It was built in two iterations:
+
+1. A flat, per-version list of links (one row per expression of the norm).
+2. Grouping of consecutive versions where the article's text is unchanged, plus explicit "this article doesn't exist in this version" detection, so the list reflects genuine content changes rather than every unrelated amendment to the norm.
+
+Out of scope: renumbering detection (an article that changes eId across versions), a backend endpoint purpose-built for this (all lookups are done from the frontend against existing endpoints), and any UI beyond a plain list.
+
+## Files touched
+
+- `frontend/src/components/documents/norms/ArticleVersionList.vue` (new) — all prototype logic lives here.
+- `frontend/src/utils/norm.ts` — added `findPartByEId`, a recursive search over a `hasPart` tree.
+- `frontend/src/pages/norms/eli/.../[eId].vue` — wires the new component in, fetching all versions via the existing `useNormVersions` composable.
+
+## Approach
+
+### Data model recap
+
+- Route: `/eli/:jurisdiction/:agent/:year/:naturalIdentifier/:pointInTime/:version/:language/:eId`. `jurisdiction/agent/year/naturalIdentifier` identify the **work** (the abstract norm); `pointInTime/version/language` identify one **expression** (a specific wording valid from a date); `eId` identifies one article/part within that expression's `hasPart` tree.
+- `LegislationExpression.legislationIdentifier` is a full string, e.g. `eli/bund/bgbl-1/1975/s1760/1998-01-29/10/deu`. Splitting on `/` and taking the last three segments gives `[pointInTime, version, language]` — this is how a link to "the same article, different version" is constructed, by swapping those three route params and keeping `eId`.
+- `useNormVersions(workEli)` (pre-existing composable, `frontend/src/composables/useNormVersions.ts`) returns every expression of a work via `GET /v1/legislation/work-example/{workEli}`. This list is lightweight (`LegislationExpressionSearchSchema`-shaped) and does **not** include each expression's `hasPart` tree.
+- To know whether/how an article changed *within* a given expression, the full metadata endpoint `GET /v1/legislation/eli/{expressionEli}` is needed — this does return `hasPart`, including each part's own `temporalCoverage`.
+
+### Fetching strategy
+
+Because the version-list endpoint doesn't carry per-article data, the component fetches full metadata for **every version of the work, in parallel**, client-side only (`import.meta.client`), to look up the current `eId` in each one's `hasPart` tree. This is an N+1 pattern (N = number of expressions of the work) — deliberately accepted for a prototype, see [Limitations](#limitations-known-issues).
+
+## High-level logic
+
+### 1. Existence check: `findPartByEId`
+
+```ts
+function findPartByEId(parts, eId) {
+  for (const part of parts) {
+    if (decodeURIComponent(part.eId) === eId) return part;
+    const found = findPartByEId(part.hasPart, eId);
+    if (found) return found;
+  }
+  return undefined;
+}
+```
+
+A plain recursive DFS over `hasPart`, at any depth (not just leaf articles, since tree shape can differ between expressions — e.g. a section might get split or merged). Returns the matching part, or `undefined` if the `eId` isn't present in that expression at all.
+
+This was verified to be a **complete** existence check for this system: the `eId` coverage of `hasPart` was confirmed (by tracing the backend's OpenSearch table-of-contents mapper and the single-article HTML endpoint's XSLT matching logic) to be exactly the same set of elements — article, attachment, preamble/conclusion formula — that the article-content endpoint can resolve. No deeper content fetch is needed to answer "does this eId exist in version X".
+
+### 2. Per-version info: `loadArticleVersionInfo`
+
+For each version, once its full metadata has been fetched:
+
+```ts
+const matchedPart = findPartByEId(metadata.hasPart, eId);
+info[version.legislationIdentifier] = matchedPart
+  ? { temporalCoverage: matchedPart.temporalCoverage, exists: true }
+  : { temporalCoverage: version.temporalCoverage, exists: false };
+```
+
+- If found: store the **article's own** `temporalCoverage` (its validity interval, which is what may span several expressions unchanged).
+- If not found: mark `exists: false`, with the whole expression's `temporalCoverage` kept only as a fallback value (not used for display in this case).
+- On fetch error: optimistically assume `exists: true` with the expression's own `temporalCoverage`, so a transient network failure doesn't wrongly report an article as removed.
+- Until a version's fetch resolves, the same optimistic default (`exists: true`, expression-level `temporalCoverage`) is used, so the list renders immediately and progressively refines as data arrives, rather than blocking on 100+ requests before showing anything.
+
+### 3. Grouping: `groupedVersions`
+
+Versions are first sorted descending by `temporalCoverage` (newest first), then folded into groups in a single pass:
+
+- A **grouping key** is computed per version: the article's own `temporalCoverage` string if it exists in that version, or the sentinel `"not-found"` if it doesn't.
+- Consecutive versions (in the sorted order) with the same key are merged into one group. For existing articles this means: *the exact interval during which the text was unchanged*, which is authoritative because `temporalCoverage` on the article part is set by the backend precisely to reflect that. For "not found" runs, grouping is done purely by contiguity — any run of consecutive versions without the article collapses into one entry, regardless of how the underlying expressions' own dates differ, since "not present" is the only claim being made.
+- Each group tracks its earliest and latest member (by construction of the sorted, single-pass fold): the **earliest** version is the one that introduced the current wording (or the start of an absence), and is used both as the group's "Gültig ab" anchor and as the link target — since any member of an "unchanged" group is content-equivalent, linking to the version that introduced it is the most meaningful choice. The **latest** version's own `temporalCoverage.to` is used only for displaying an approximate range on "not found" groups, which have no single meaningful interval of their own.
+- A group is flagged `containsCurrent` if any of its members is the expression currently being viewed — that group is rendered as plain text ("Aktuelle Fassung") instead of a link.
+
+### 4. Rendering
+
+- `exists: false` groups render as **"Paragraf existiert in dieser Fassung nicht"**, with no link — this eliminates the class of dead links that would otherwise 404 against the backend's article-content endpoint.
+- `exists: true`, non-current groups render as a "Zur Fassung" link, built by swapping `pointInTime`/`version`/`language` (parsed from the group's earliest member's `legislationIdentifier`) into the current route's params, keeping the same route name and `eId`.
+- `exists: true` groups spanning more than one version show a count, e.g. *"(93 Fassungen, Paragraf unverändert)"*.
+
+## Learnings and limitations
+
+### What worked well
+
+- **`hasPart` is sufficient for existence checks.** No need to fetch or diff actual article HTML/text — the metadata tree alone answers "does this eId exist here", confirmed both by tracing backend code and by testing against real e2e data.
+- **The article's own `temporalCoverage` is already the "unchanged" signal.** No manual content diffing was needed to detect that an article is unchanged across versions — the backend already computes and exposes exactly this interval per article part; the prototype just needed to read and group by it.
+- **Validated against real data, not just synthetic cases.** Testing against the Sozialgerichtsgesetz (`eli/bund/bgbl-1/1953/s1239`, 121 expressions) surfaced a genuine real-world case: `§ 10` existed, was removed for two consecutive expressions (2004-08-06 to 2004-12-14), then reappeared. This was cross-checked directly against the raw `hasPart` data for those specific expressions and confirmed correct — a good sign the logic generalizes beyond the cases it was designed around.
+
+### Known issues / limitations
+
+- **`eId` is the only identifier available, and it is not a stable cross-version identifier.** Per the schema's own doc comment, `eId` is only guaranteed unique *within one expression*. This cuts both ways:
+  - **False negatives**: a provision that gets renumbered (e.g. § 9 → § 9a) will appear to "not exist" in later versions, even though it logically continues to exist — not fixable with `eId` matching alone.
+  - **False positives**: if an `eId` like `art-z10` is later reused (decades apart) for an unrelated provision, the current logic will happily group it as "unchanged" purely because the `eId` and `temporalCoverage` line up — there is no content comparison to catch this. This is a real, observed risk given how German norm numbering evolves, not just a theoretical one.
+  - There **is** a more stable identifier in the raw Akoma Ntoso XML — a `GUID` attribute per element, clearly intended for exactly this kind of cross-version tracking. The backend already parses it into the `Article` OpenSearch model (`NormLdmlToOpenSearchMapper.java`), but it is dropped before reaching any API (`LegislationExpressionPartSchema`/`hasPart` don't carry it). Exposing it would be the "correct" long-term fix, but requires a schema/API change, and its real-world stability (vs. only having been checked on hand-authored fixtures) is unverified.
+- **N+1 fetch pattern.** The component fetches full metadata for every version of the work in parallel, purely to read each one's `hasPart`. For norms with many expressions (the SGG test case has 121), this means 100+ background HTTP requests per article page view. Acceptable for a private-flag prototype; would need a dedicated, purpose-built backend endpoint (e.g. "all `hasPart` entries matching this `eId` across a work's expressions") before this could ship broadly.
+- **No loading/empty/error UI.** The section simply doesn't render until the version list itself has loaded successfully; per-version grouping data fills in progressively and silently as each fetch resolves, with no spinner or partial-state indicator.
+- **No tests.** Consistent with the prototype/PoC framing; would need coverage of the grouping algorithm (in particular the "not-found" contiguity grouping and the optimistic-default-while-loading behavior) before productionizing.
+
+### Tradeoffs made deliberately
+
+- Chose **eId-string matching** over investing in exposing the `GUID` field, since the goal was a fast prototype demonstrating the UX, not a production-grade identifier scheme.
+- Chose **client-side, per-version fetching** over a new backend endpoint, to keep the change contained to the frontend for this iteration.
+- Chose to **link to the earliest version in a group** rather than, say, the version closest to the one being viewed — makes the "Gültig ab" date and the link target consistent, at the cost of sometimes navigating further back in time than strictly necessary when clicking from the middle of a long unchanged period.

--- a/frontend/src/components/documents/norms/ArticleVersionList.vue
+++ b/frontend/src/components/documents/norms/ArticleVersionList.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+import { orderBy } from "lodash-es";
+import type { RouteLocationRaw } from "#vue-router";
+import type { LegislationExpression } from "~/types/api";
+
+const props = defineProps<{
+  status: string;
+  currentLegislationIdentifier: string;
+  versions: LegislationExpression[];
+  eId: string;
+}>();
+
+const route = useRoute();
+const { $risBackend } = useNuxtApp();
+
+const sortedVersions = computed(() =>
+  orderBy(props.versions, [(v) => v.temporalCoverage], ["desc"]),
+);
+
+interface ArticleVersionInfo {
+  temporalCoverage: string;
+  exists: boolean;
+}
+
+// Maps a version's legislationIdentifier to whether the current eId exists
+// in that version and, if so, the matching article's own temporalCoverage.
+// Falls back to an optimistic "exists" with the whole expression's
+// temporalCoverage until the lookup resolves, which means consecutive
+// versions only collapse into one group once we've confirmed the article
+// itself is unchanged between them.
+const articleVersionInfo = ref<Record<string, ArticleVersionInfo>>({});
+
+async function loadArticleVersionInfo(versions: LegislationExpression[]) {
+  await Promise.all(
+    versions.map(async (version) => {
+      if (articleVersionInfo.value[version.legislationIdentifier]) return;
+      const expressionEli = version.legislationIdentifier.replace(/^eli\//, "");
+      try {
+        const metadata = await $risBackend<LegislationExpression>(
+          `/v1/legislation/eli/${expressionEli}`,
+        );
+        const matchedPart = findPartByEId(metadata.hasPart, props.eId);
+        articleVersionInfo.value[version.legislationIdentifier] = matchedPart
+          ? { temporalCoverage: matchedPart.temporalCoverage, exists: true }
+          : { temporalCoverage: version.temporalCoverage, exists: false };
+      } catch {
+        // Transient fetch error: assume the article still exists rather than
+        // wrongly reporting it as removed.
+        articleVersionInfo.value[version.legislationIdentifier] = {
+          temporalCoverage: version.temporalCoverage,
+          exists: true,
+        };
+      }
+    }),
+  );
+}
+
+// Prototype-only: fetches full metadata for every version to determine
+// whether the article's text (rather than just the whole expression) changed
+// between them, and whether the article exists in that version at all.
+// Client-only since it's a UX enhancement layered on top of the
+// already-rendered list, not needed for SSR/first paint.
+if (import.meta.client) {
+  watch(() => props.versions, loadArticleVersionInfo, { immediate: true });
+}
+
+interface VersionGroup {
+  exists: boolean;
+  // Meaningful only when exists === true; the article-level temporalCoverage
+  // shared by every member of the group.
+  temporalCoverage: string;
+  // The earliest version in the group is the one that introduced this
+  // wording, matching the group's "Gültig ab" date, and serves as the link
+  // target for the whole group.
+  earliestVersion: LegislationExpression;
+  // The latest (newest) version in the group, used to derive a display range
+  // for "not found" groups, which have no single meaningful temporalCoverage.
+  latestVersion: LegislationExpression;
+  memberCount: number;
+  containsCurrent: boolean;
+}
+
+// Consecutive versions (in descending order) sharing the same article-level
+// temporalCoverage represent an unchanged article text and are collapsed
+// into a single group. Consecutive versions where the eId doesn't exist at
+// all are collapsed into their own group, regardless of their individual
+// expression dates, since "not present" is the only claim being made there.
+const groupedVersions = computed<VersionGroup[]>(() => {
+  const groups: VersionGroup[] = [];
+  for (const version of sortedVersions.value) {
+    const info = articleVersionInfo.value[version.legislationIdentifier];
+    const exists = info?.exists ?? true;
+    const coverageKey = exists
+      ? (info?.temporalCoverage ?? version.temporalCoverage)
+      : "not-found";
+    const isCurrent =
+      version.legislationIdentifier === props.currentLegislationIdentifier;
+
+    const lastGroup = groups.at(-1);
+    const sameGroup =
+      lastGroup &&
+      lastGroup.exists === exists &&
+      (!exists || lastGroup.temporalCoverage === coverageKey);
+
+    if (sameGroup) {
+      lastGroup.earliestVersion = version;
+      lastGroup.memberCount += 1;
+      lastGroup.containsCurrent ||= isCurrent;
+    } else {
+      groups.push({
+        exists,
+        temporalCoverage: coverageKey,
+        earliestVersion: version,
+        latestVersion: version,
+        memberCount: 1,
+        containsCurrent: isCurrent,
+      });
+    }
+  }
+  return groups;
+});
+
+function getRouteForVersion(
+  version: LegislationExpression,
+): RouteLocationRaw | undefined {
+  // legislationIdentifier e.g. "eli/bund/bgbl-1/1975/s1760/1998-01-29/10/deu"
+  // -> last 3 segments are [pointInTime, version, language]
+  const [pointInTime, versionSegment, language] = version.legislationIdentifier
+    .split("/")
+    .slice(-3);
+  if (!pointInTime || !versionSegment || !language) return undefined;
+
+  return {
+    name: route.name ?? undefined,
+    query: route.query,
+    params: {
+      ...route.params,
+      pointInTime,
+      version: versionSegment,
+      language,
+      eId: props.eId,
+    },
+  };
+}
+
+function formatValidity(temporalCoverage: string): string {
+  const interval = temporalCoverageToValidityInterval(temporalCoverage);
+  const from = dateFormattedDDMMYYYY(interval?.from) ?? "unbekannt";
+  const to = dateFormattedDDMMYYYY(interval?.to) ?? "unbekannt";
+  return `Gültig ab ${from} – Gültig bis ${to}`;
+}
+
+// "Not found" groups have no single meaningful temporalCoverage (each member
+// expression has its own), so this spans the group's newest-to-oldest
+// expression dates instead as an approximate range.
+function formatGroupRange(group: VersionGroup): string {
+  if (group.exists) return formatValidity(group.temporalCoverage);
+  const from = temporalCoverageToValidityInterval(
+    group.earliestVersion.temporalCoverage,
+  )?.from;
+  const to = temporalCoverageToValidityInterval(
+    group.latestVersion.temporalCoverage,
+  )?.to;
+  return `Gültig ab ${dateFormattedDDMMYYYY(from) ?? "unbekannt"} – Gültig bis ${dateFormattedDDMMYYYY(to) ?? "unbekannt"}`;
+}
+</script>
+
+<template>
+  <section
+    v-if="status === 'success' && groupedVersions.length"
+    aria-label="Andere Fassungen dieses Paragrafen"
+    class="mt-24"
+  >
+    <h2 class="typo-label1-bold mb-8">
+      Andere Fassungen dieses Paragrafen (Prototyp)
+    </h2>
+    <ul class="space-y-4">
+      <li
+        v-for="group in groupedVersions"
+        :key="group.earliestVersion.legislationIdentifier"
+        class="flex flex-wrap items-center justify-between gap-8"
+      >
+        <span class="typo-body-regular">
+          {{ formatGroupRange(group) }}
+          <template v-if="group.exists && group.memberCount > 1">
+            ({{ group.memberCount }} Fassungen, Paragraf unverändert)
+          </template>
+        </span>
+
+        <span v-if="!group.exists" class="typo-body-regular text-gray-900">
+          Paragraf existiert in dieser Fassung nicht
+        </span>
+        <span
+          v-else-if="group.containsCurrent"
+          class="typo-body-regular text-gray-900"
+        >
+          Aktuelle Fassung
+        </span>
+        <NuxtLink
+          v-else
+          :to="getRouteForVersion(group.earliestVersion)"
+          class="typo-link-regular link-hover"
+        >
+          Zur Fassung
+        </NuxtLink>
+      </li>
+    </ul>
+  </section>
+</template>

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -196,6 +196,10 @@ const validVersions =
     ? undefined
     : useValidNormVersions(norm.value?.exampleOfWork.legislationIdentifier);
 
+const articleVersions = privateFeaturesEnabled
+  ? useNormVersions(norm.value?.exampleOfWork.legislationIdentifier ?? "")
+  : undefined;
+
 const inForceNormLink = computed(() => {
   if (
     !validVersions ||
@@ -295,6 +299,14 @@ const metadataItems = computed(() => {
               </NuxtLink>
             </div>
           </nav>
+
+          <DocumentsNormsArticleVersionList
+            v-if="privateFeaturesEnabled && articleVersions && norm && eId"
+            :status="articleVersions.status.value"
+            :versions="articleVersions.sortedVersions.value"
+            :current-legislation-identifier="norm.legislationIdentifier"
+            :e-id="eId"
+          />
         </template>
 
         <template #sidebar>

--- a/frontend/src/utils/norm.ts
+++ b/frontend/src/utils/norm.ts
@@ -1,7 +1,10 @@
 import dayjs, { type Dayjs } from "dayjs";
 import { partition, sortBy } from "lodash-es";
 import type { MetadataItem } from "~/components/documents/Metadata.vue";
-import type { LegislationExpression } from "~/types/api";
+import type {
+  LegislationExpression,
+  LegislationExpressionPartSchema,
+} from "~/types/api";
 import {
   dateFormattedDDMMYYYY,
   getCurrentDateInGermany,
@@ -66,6 +69,24 @@ export function getValidityStatus(
     return "FutureInForce";
   }
 
+  return undefined;
+}
+
+/**
+ * Recursively searches a `hasPart` tree for the part matching `eId`, at any
+ * depth (not just leaf articles) since the tree shape can differ between
+ * expressions of the same work.
+ */
+export function findPartByEId(
+  parts: LegislationExpressionPartSchema[] | undefined,
+  eId: string,
+): LegislationExpressionPartSchema | undefined {
+  if (!parts) return undefined;
+  for (const part of parts) {
+    if (decodeURIComponent(part.eId) === eId) return part;
+    const found = findPartByEId(part.hasPart, eId);
+    if (found) return found;
+  }
   return undefined;
 }
 


### PR DESCRIPTION
Technical exploration of linking versions of the same article in past/future versions of a norm via their eId. Supports listing all versions of a norm containing elements with that eId, and grouping by validity time period of the article:

<img width="1608" height="954" alt="Bildschirmfoto 2026-07-21 um 16 48 14" src="https://github.com/user-attachments/assets/1ad5e27e-a07d-476f-8564-eed2b57d8223" />

Also see [Copilot session dump](https://github.com/digitalservicebund/ris-search/blob/1a111f67f31ab1eba56e733213e3cbfd5184ab7b/doc/prototypes/norm-article-version-navigation.md) and an alternative approach using Dokumentnummern: #2267 