### PR TITLE
Risdev 11805 search deterministically across shards

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/AdministrativeDirective.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/AdministrativeDirective.java
@@ -34,6 +34,7 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 public record AdministrativeDirective(
     @Id @Field(name = Fields.ID) String id,
     @Field(name = Fields.DOCUMENT_NUMBER) String documentNumber,
+    @Field(name = Literature.Fields.DOCUMENT_NUMBER_KEYWORD) String documentNumberKeyword,
     @Nullable @Field(name = Fields.HEADLINE) String headline,
     @Field(name = Fields.DOCUMENT_TYPE) String documentType,
     @Nullable @Field(name = Fields.DOCUMENT_TYPE_DETAIL) String documentTypeDetail,

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/CaseLawDocumentationUnit.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/CaseLawDocumentationUnit.java
@@ -21,6 +21,7 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 public record CaseLawDocumentationUnit(
     @JsonIgnore @Id @Field(name = Fields.ID) String id,
     @Field(name = Fields.DOCUMENT_NUMBER) String documentNumber,
+    @Field(name = Literature.Fields.DOCUMENT_NUMBER_KEYWORD) String documentNumberKeyword,
     @Field(name = Fields.ECLI) String ecli,
     @Field(name = Fields.CASE_FACTS) String caseFacts,
     @Field(name = Fields.DECISION_GROUNDS) String decisionGrounds,

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/Literature.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/Literature.java
@@ -18,6 +18,7 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 public record Literature(
     @Id @Field(name = Fields.ID) String id,
     @Field(name = Fields.DOCUMENT_NUMBER) String documentNumber,
+    @Field(name = Fields.DOCUMENT_NUMBER_KEYWORD) String documentNumberKeyword,
     @ElementCollection @Field(name = Fields.YEARS_OF_PUBLICATION) List<String> yearsOfPublication,
     @Field(name = Fields.FIRST_PUBLICATION_DATE, type = FieldType.Date, format = DateFormat.date)
         LocalDate firstPublicationDate,

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/Norm.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/Norm.java
@@ -32,8 +32,14 @@ public final class Norm implements AbstractSearchEntity {
   @Field(name = Fields.WORK_ELI)
   private String workEli;
 
+  @Field(name = Fields.WORK_ELI_KEYWORD, type = FieldType.Keyword)
+  private String workEliKeyword;
+
   @Field(name = Fields.EXPRESSION_ELI)
   private String expressionEli;
+
+  @Field(name = Fields.EXPRESSION_ELI_KEYWORD, type = FieldType.Keyword)
+  private String expressionEliKeyword;
 
   /**
    * The documents represented by this class represent legislation expressions, meaning concrete

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/DocumentRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/DocumentRepository.java
@@ -35,10 +35,10 @@ public interface DocumentRepository<T> extends ElasticsearchRepository<T, String
   void deleteAllById(@NotNull Iterable<? extends String> ids);
 
   /**
-   * Find documents by their document number.
+   * Find documents by their document number keyword.
    *
    * @param documentNumber the document number to search for
    * @return list of matching documents; may be empty
    */
-  List<T> findByDocumentNumber(String documentNumber);
+  List<T> findByDocumentNumberKeyword(String documentNumber);
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/NormsRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/NormsRepository.java
@@ -19,15 +19,15 @@ public interface NormsRepository extends ElasticsearchRepository<Norm, String> {
    * @param workEli The work-level ELI identifier.
    * @return A {@link Norm}
    */
-  List<Norm> getByWorkEli(String workEli);
+  List<Norm> getByWorkEliKeyword(String workEli);
 
   /**
-   * Returns a {@link Norm} by its expression-level ELI.
+   * Returns a {@link Norm} by its expression-level ELI keyword.
    *
    * @param expressionEli The expression-level ELI identifier.
    * @return A {@link Norm}
    */
-  Norm getByExpressionEli(String expressionEli);
+  Norm getByExpressionEliKeyword(String expressionEli);
 
   /**
    * Returns all legislation in a {@link Page}.

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/AdministrativeDirectiveService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/AdministrativeDirectiveService.java
@@ -91,6 +91,6 @@ public class AdministrativeDirectiveService {
   }
 
   public List<AdministrativeDirective> getByDocumentNumber(String documentNumber) {
-    return repository.findByDocumentNumber(documentNumber);
+    return repository.findByDocumentNumberKeyword(documentNumber);
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/ArticleService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/ArticleService.java
@@ -19,6 +19,8 @@ import org.opensearch.index.query.Operator;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.collapse.CollapseBuilder;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -87,6 +89,9 @@ public class ArticleService {
         new InnerHitBuilder()
             .setName("top_three_articles")
             .setSize(3)
+            .addSort(SortBuilders.scoreSort().order(SortOrder.DESC))
+            // Secondary tie-breaker sort (e.g., by eid)
+            .addSort(SortBuilders.fieldSort("eid").order(SortOrder.ASC))
             .setHighlightBuilder(highlightBuilder);
 
     CollapseBuilder collapseBuilder =

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/ArticleService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/ArticleService.java
@@ -90,8 +90,8 @@ public class ArticleService {
             .setName("top_three_articles")
             .setSize(3)
             .addSort(SortBuilders.scoreSort().order(SortOrder.DESC))
-            // Secondary tie-breaker sort (e.g., by eid)
-            .addSort(SortBuilders.fieldSort("eid").order(SortOrder.ASC))
+            // Secondary tie-breaker sort
+            .addSort(SortBuilders.fieldSort("_id").order(SortOrder.ASC))
             .setHighlightBuilder(highlightBuilder);
 
     CollapseBuilder collapseBuilder =

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/CaseLawService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/CaseLawService.java
@@ -155,7 +155,7 @@ public class CaseLawService {
   }
 
   public List<CaseLawDocumentationUnit> getByDocumentNumber(String documentNumber) {
-    return caseLawRepository.findByDocumentNumber(documentNumber);
+    return caseLawRepository.findByDocumentNumberKeyword(documentNumber);
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/LiteratureService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/LiteratureService.java
@@ -110,7 +110,7 @@ public class LiteratureService {
    * @return the list of items
    */
   public List<Literature> getByDocumentNumber(String documentNumber) {
-    return literatureRepository.findByDocumentNumber(documentNumber);
+    return literatureRepository.findByDocumentNumberKeyword(documentNumber);
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/NormsService.java
@@ -121,7 +121,7 @@ public class NormsService {
    * @return an {@link Optional} containing the Norm if found, or empty if not found
    */
   public Optional<Norm> getByExpressionEli(final ExpressionEli expressionEli) {
-    Norm result = normsRepository.getByExpressionEli(expressionEli.toString());
+    Norm result = normsRepository.getByExpressionEliKeyword(expressionEli.toString());
     if (result != null) {
       result.setArticles(articleService.findAllByExpressionEli(result.getExpressionEli()));
     }

--- a/backend/src/main/resources/openSearch/article_norms_index_template.json
+++ b/backend/src/main/resources/openSearch/article_norms_index_template.json
@@ -29,7 +29,7 @@
           "path": "name"
         },
         "eid": {
-          "type": "text"
+          "type": "keyword"
         },
         "guid": {
           "type": "text"

--- a/backend/src/main/resources/openSearch/german_analyzer_template.json
+++ b/backend/src/main/resources/openSearch/german_analyzer_template.json
@@ -2,6 +2,8 @@
   "template": {
     "settings":
     {
+      "number_of_shards": 3,
+      "number_of_replicas": 1,
       "analysis": {
         "analyzer": {
           "custom_german_analyzer": {

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/AllDocumentsSearchControllerMultiMatchAPITest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/AllDocumentsSearchControllerMultiMatchAPITest.java
@@ -7,6 +7,8 @@ import de.bund.digitalservice.ris.search.config.ApiConfig;
 import de.bund.digitalservice.ris.search.integration.config.ContainersIntegrationBase;
 import de.bund.digitalservice.ris.search.models.opensearch.CaseLawDocumentationUnit;
 import de.bund.digitalservice.ris.search.models.opensearch.Norm;
+import java.time.LocalDate;
+import java.time.Month;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -49,14 +51,17 @@ class AllDocumentsSearchControllerMultiMatchAPITest extends ContainersIntegratio
                 .tenor("Mord")
                 .headline("Totschlag")
                 .guidingPrinciple("Raub")
+                .decisionDate(LocalDate.of(2025, Month.JANUARY, 3))
                 .build(),
             CaseLawDocumentationUnit.builder()
                 .documentNumber("case_sameField {m,t,r} in one field")
                 .tenor("Mord, Totschlag, Raub")
+                .decisionDate(LocalDate.of(2025, Month.JANUARY, 2))
                 .build(),
             CaseLawDocumentationUnit.builder()
                 .documentNumber("case_sameFieldReordered {m,t,r} in one field but different order")
                 .tenor("Raub, Mord, Totschlag")
+                .decisionDate(LocalDate.of(2025, Month.JANUARY, 1))
                 .build());
     var normsData =
         List.of(
@@ -65,18 +70,21 @@ class AllDocumentsSearchControllerMultiMatchAPITest extends ContainersIntegratio
                 .expressionEli("N1 {m,t} in one field")
                 .officialTitle("Mord Totschlag")
                 .tableOfContents(Collections.emptyList())
+                .normsSortDate(LocalDate.of(2025, Month.JANUARY, 1))
                 .build(),
             Norm.builder()
                 .workEli("N2 {r} in one field")
                 .expressionEli("N2 {r} in one field")
                 .officialTitle("Raub")
                 .tableOfContents(Collections.emptyList())
+                .normsSortDate(LocalDate.of(2025, Month.JANUARY, 2))
                 .build(),
             Norm.builder()
                 .workEli("N3 {r} in one field")
                 .expressionEli("N3 {r} in one field")
                 .officialTitle("Raub")
                 .tableOfContents(Collections.emptyList())
+                .normsSortDate(LocalDate.of(2025, Month.JANUARY, 3))
                 .build());
 
     caseLawRepository.saveAll(caseLawData);

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/service/IndexCaseLawServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/service/IndexCaseLawServiceTest.java
@@ -49,7 +49,7 @@ class IndexCaseLawServiceTest extends ContainersIntegrationBase {
     this.service.reindexAll(startingTimestamp);
 
     assertThat(repo.count()).isEqualTo(1);
-    assertThat(repo.findByDocumentNumber("TEST080020093")).hasSize(1);
+    assertThat(repo.findByDocumentNumberKeyword("TEST080020093")).hasSize(1);
     verify(repo, times(1)).deleteByIndexedAtBefore(startingTimestamp);
   }
 
@@ -63,7 +63,7 @@ class IndexCaseLawServiceTest extends ContainersIntegrationBase {
     changelog.setChanged(Sets.newHashSet(List.of("TEST080020093.xml")));
     service.indexChangelog(changelog);
     assertThat(repo.count()).isEqualTo(1);
-    assertThat(repo.findByDocumentNumber("TEST080020093")).hasSize(1);
+    assertThat(repo.findByDocumentNumberKeyword("TEST080020093")).hasSize(1);
   }
 
   @Test
@@ -76,7 +76,7 @@ class IndexCaseLawServiceTest extends ContainersIntegrationBase {
     changelog.setChangeAll(true);
     service.indexChangelog(changelog);
     assertThat(repo.count()).isEqualTo(1);
-    assertThat(repo.findByDocumentNumber("TEST080020093")).hasSize(1);
+    assertThat(repo.findByDocumentNumberKeyword("TEST080020093")).hasSize(1);
   }
 
   @Test
@@ -92,7 +92,7 @@ class IndexCaseLawServiceTest extends ContainersIntegrationBase {
     service.indexChangelog(changelog);
 
     assertThat(repo.count()).isEqualTo(1);
-    assertThat(repo.findByDocumentNumber("TEST080020093")).hasSize(1);
+    assertThat(repo.findByDocumentNumberKeyword("TEST080020093")).hasSize(1);
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/service/IndexNormsServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/service/IndexNormsServiceTest.java
@@ -40,7 +40,7 @@ class IndexNormsServiceTest extends ContainersIntegrationBase {
 
     normsBucket.save(manifestationEli, normXml);
     indexNormsService.reindexAll(SharedTestConstants.TIMESTAMP_2024_01_01_AS_STRING);
-    List<Norm> expressions = normsRepository.getByWorkEli(workEli);
+    List<Norm> expressions = normsRepository.getByWorkEliKeyword(workEli);
     assertThat(expressions).hasSize(1);
     assertThat(expressions.getFirst().getTimeRelevanceStartDate())
         .isEqualTo(IndexNormsService.TIME_RELEVANCE_MIN);
@@ -52,7 +52,7 @@ class IndexNormsServiceTest extends ContainersIntegrationBase {
   @DisplayName("Three expressions cover full time relevance window")
   void threeExpressionsCoverFullTimeRelevanceWindow() {
     indexNormsService.reindexAll(SharedTestConstants.TIMESTAMP_2024_01_01_AS_STRING);
-    List<Norm> expressions = normsRepository.getByWorkEli("eli/bund/bgbl-1/1991/s102");
+    List<Norm> expressions = normsRepository.getByWorkEliKeyword("eli/bund/bgbl-1/1991/s102");
     assertThat(expressions).hasSize(3);
 
     expressions.sort(Comparator.comparing(Norm::getId));
@@ -76,7 +76,7 @@ class IndexNormsServiceTest extends ContainersIntegrationBase {
   void fullCitationIndexesProperly() {
     indexNormsService.reindexAll(SharedTestConstants.TIMESTAMP_2024_01_01_AS_STRING);
     Norm expression =
-        normsRepository.getByExpressionEli("eli/bund/bgbl-1/1991/s102/1991-01-01/1/deu");
+        normsRepository.getByExpressionEliKeyword("eli/bund/bgbl-1/1991/s102/1991-01-01/1/deu");
     assertThat(expression.getFullCitation()).startsWith("Verordnung");
   }
 
@@ -85,7 +85,7 @@ class IndexNormsServiceTest extends ContainersIntegrationBase {
   void officialTocIndexesProperly() {
     indexNormsService.reindexAll(SharedTestConstants.TIMESTAMP_2024_01_01_AS_STRING);
     Norm expression =
-        normsRepository.getByExpressionEli("eli/bund/bgbl-1/1991/s102/1991-01-01/1/deu");
+        normsRepository.getByExpressionEliKeyword("eli/bund/bgbl-1/1991/s102/1991-01-01/1/deu");
     assertThat(expression.getOfficialToc()).startsWith("Abschnitt 1");
   }
 
@@ -94,7 +94,7 @@ class IndexNormsServiceTest extends ContainersIntegrationBase {
   void officialFootNotesIndexProperly() {
     indexNormsService.reindexAll(SharedTestConstants.TIMESTAMP_2024_01_01_AS_STRING);
     Norm expression =
-        normsRepository.getByExpressionEli("eli/bund/bgbl-1/1991/s102/1991-01-01/1/deu");
+        normsRepository.getByExpressionEliKeyword("eli/bund/bgbl-1/1991/s102/1991-01-01/1/deu");
     assertThat(expression.getOfficialFootNotes())
         .isEqualTo(
             "Authorial note in the norm title. Authorial note in an article title. Authorial note in attachment contents");

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/LiteratureServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/LiteratureServiceTest.java
@@ -79,7 +79,8 @@ class LiteratureServiceTest {
   @DisplayName("Should return an existing literature item by its document number")
   void shouldReturnLiteratureByDocumentNumber() {
     var expectedResult = List.of(Literature.builder().build());
-    when(literatureRepositoryMock.findByDocumentNumber("XXLU000000001")).thenReturn(expectedResult);
+    when(literatureRepositoryMock.findByDocumentNumberKeyword("XXLU000000001"))
+        .thenReturn(expectedResult);
 
     var actual = literatureService.getByDocumentNumber("XXLU000000001");
     Assertions.assertEquals(expectedResult, actual);


### PR DESCRIPTION
* use keyword search when applicable
* use _id as tie breaker in article inner search
* change eid to keyword in article index to replace intermediate _id after rebuilding the index
* set date tie breaker sort in MultiMatch test