### PR TITLE
RISDEV-7898 index ris-abbreviation and improve norm parser logging

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormLdmlToOpenSearchMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormLdmlToOpenSearchMapper.java
@@ -10,6 +10,7 @@ import de.bund.digitalservice.ris.search.models.opensearch.TableOfContentsItem;
 import de.bund.digitalservice.ris.search.utils.LdmlTemporalData;
 import de.bund.digitalservice.ris.search.utils.XmlDocument;
 import jakarta.xml.bind.ValidationException;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -31,6 +32,7 @@ import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 /**
  * The `NormLdmlToOpenSearchMapper` class is responsible for mapping and extracting data from a
@@ -57,6 +59,7 @@ import org.w3c.dom.NodeList;
  * extraction and mapping while adhering to the structure and metadata provided within XML files.
  */
 public class NormLdmlToOpenSearchMapper {
+
   private static final Logger logger = LogManager.getLogger(NormLdmlToOpenSearchMapper.class);
 
   private static final String X_PATH_SHORT_TITLE_ALTERNATE_NAME =
@@ -120,90 +123,116 @@ public class NormLdmlToOpenSearchMapper {
    *     conditions.
    */
   public static Optional<Norm> parseNorm(
-      String xmlFile, Map<String, String> attachmentFileContents, boolean isPrototype) {
+      String fileName,
+      String xmlFile,
+      Map<String, String> attachmentFileContents,
+      boolean isPrototype) {
     try {
-      var xmlDocument = new XmlDocument(xmlFile.getBytes(StandardCharsets.UTF_8));
-      @Nullable String workEli = xmlDocument.getElementByXpath(X_PATH_WORK_URI);
-      @Nullable String expressionEli = xmlDocument.getElementByXpath(X_PATH_EXPRESSION_URI);
-      @Nullable String manifestationEli = xmlDocument.getElementByXpath(X_PATH_MANIFESTATION_THIS);
+      return Optional.of(doParse(xmlFile, attachmentFileContents, isPrototype));
+    } catch (IllegalStateException e) {
+      logger.warn("Skipping parsing of '{}'", fileName, e);
+    } catch (ParserConfigurationException
+        | XPathExpressionException
+        | ValidationException
+        | IllegalArgumentException
+        | IOException
+        | SAXException e) {
+      logger.error("Error parsing norm '{}'", fileName, e);
+    }
 
-      if (workEli == null || expressionEli == null || manifestationEli == null) {
-        logger.warn("Could not parse ELI");
-        return Optional.empty();
-      }
+    return Optional.empty();
+  }
 
-      boolean isGegenstandslos = xmlDocument.getElementExistByXpath(X_PATH_GEGENSTANDSLOS);
-      boolean isBedingtesInkrafttreten =
-          xmlDocument.getElementExistByXpath(X_PATH_BEDINGTES_INKRAFTTRETEN);
+  private static Norm doParse(
+      String xmlFile, Map<String, String> attachmentFileContents, boolean isPrototype)
+      throws XPathExpressionException,
+          ParserConfigurationException,
+          IOException,
+          SAXException,
+          ValidationException {
+    var xmlDocument = new XmlDocument(xmlFile.getBytes(StandardCharsets.UTF_8));
 
-      if (isGegenstandslos) {
-        logger.warn("Ignoring Gegenstandslos until logic is defined");
-        return Optional.empty();
-      }
+    requireNotBedingtInkraftOrGegenstandslos(xmlDocument);
 
-      if (isBedingtesInkrafttreten) {
-        logger.warn("Ignoring BedingtesInkrafttreten until logic is defined");
-        return Optional.empty();
-      }
+    String workEli = xmlDocument.getNonEmptyElementOrThrow(X_PATH_WORK_URI, "Work-Eli must exist");
 
-      List<Attachment> attachments =
-          NormAttachmentMapper.parseAttachments(xmlDocument, attachmentFileContents);
+    String expressionEli =
+        xmlDocument.getNonEmptyElementOrThrow(X_PATH_EXPRESSION_URI, "Expression-Eli must exist");
 
-      // Technically a ris-abbreviation exists for every norm. It's not enforce to exist here
-      // because for testphase-documents the value is not yet present.
-      final String abbreviation = getAbbreviation(xmlDocument).orElse(null);
+    String manifestationEli =
+        xmlDocument.getNonEmptyElementOrThrow(
+            X_PATH_MANIFESTATION_THIS, "Manifestation-Eli must exist");
 
-      String indexedAt = Instant.now().toString();
+    String risAbbreviation =
+        xmlDocument.getNonEmptyElementOrThrow(
+            X_PATH_RIS_ABKUERZUNG, "Norm must have ris-abbreviation");
 
-      List<Article> articles =
-          getArticlesByXmlDocument(
-              xmlDocument, attachments, abbreviation, workEli, expressionEli, indexedAt);
-      List<String> articleNames = articles.stream().map(Article::getName).toList();
-      List<String> articleTexts = articles.stream().map(Article::getText).toList();
-      String fullCitation = xmlDocument.getElementByXpath(X_PATH_FULL_CITATION);
-      String officialToc =
-          Optional.ofNullable(xmlDocument.getElementByXpath(X_PATH_OFFICIAL_TOC))
-              .map(String::strip)
-              .map(e -> e.replaceAll("\\s+", " "))
-              .orElse(null);
-      final List<TableOfContentsItem> tableOfContents =
-          getTableOfContents(expressionEli, xmlDocument, attachments);
+    String abbreviation =
+        xmlDocument
+            .getNonEmptyElementByXpath(X_PATH_SHORT_TITLE_ABBREVIATION)
+            .orElse(risAbbreviation);
 
-      // For differentiation of legislationDate and datePublished, see comments on Norm::normsDate
-      // and Norm::datePublished
-      LocalDate entryIntoForceDate = getDateByXpath(xmlDocument, X_PATH_ENTRY_INTO_FORCE_DATE);
-      LocalDate expiryDate = getDateByXpath(xmlDocument, X_PATH_EXPIRY_DATE);
-      LocalDate legislationDate = getDateByXpath(xmlDocument, X_PATH_DATE_AUSFERTIGUNG);
-      LocalDate datePublished = getDateByXpath(xmlDocument, X_PATH_WORK_DATE);
-      LocalDate normsSortDate = isPrototype ? legislationDate : entryIntoForceDate;
+    List<Attachment> attachments =
+        NormAttachmentMapper.parseAttachments(xmlDocument, attachmentFileContents);
 
-      return Optional.of(
-          Norm.builder()
-              .id(expressionEli)
-              .tableOfContents(tableOfContents)
-              .workEli(workEli)
-              .expressionEli(expressionEli)
-              .manifestationEliExample(manifestationEli)
-              .officialTitle(getOfficialTitleByXmlDocument(xmlDocument))
-              .officialShortTitle(getOfficialShortTitleByXmlDocument(xmlDocument))
-              .officialAbbreviation(abbreviation)
-              .normsDate(legislationDate)
-              .normsSortDate(normsSortDate)
-              .datePublished(datePublished)
-              .publishedIn(getPublishedInByXmlDocument(xmlDocument, datePublished))
-              .entryIntoForceDate(entryIntoForceDate)
-              .expiryDate(expiryDate)
-              .fullCitation(fullCitation)
-              .officialToc(officialToc)
-              .articles(articles)
-              .articleNames(articleNames)
-              .articleTexts(articleTexts)
-              .officialFootNotes(getOfficialFootNotes(xmlDocument, attachments))
-              .indexedAt(indexedAt)
-              .build());
-    } catch (Exception e) {
-      logger.warn("Error to create Norms from XML content.", e);
-      return Optional.empty();
+    String indexedAt = Instant.now().toString();
+
+    List<Article> articles =
+        getArticlesByXmlDocument(
+            xmlDocument, attachments, abbreviation, workEli, expressionEli, indexedAt);
+    List<String> articleNames = articles.stream().map(Article::getName).toList();
+    List<String> articleTexts = articles.stream().map(Article::getText).toList();
+    String fullCitation = xmlDocument.getElementByXpath(X_PATH_FULL_CITATION);
+    String officialToc =
+        Optional.ofNullable(xmlDocument.getElementByXpath(X_PATH_OFFICIAL_TOC))
+            .map(String::strip)
+            .map(e -> e.replaceAll("\\s+", " "))
+            .orElse(null);
+    final List<TableOfContentsItem> tableOfContents =
+        getTableOfContents(expressionEli, xmlDocument, attachments);
+
+    // For differentiation of legislationDate and datePublished, see comments on Norm::normsDate
+    // and Norm::datePublished
+    LocalDate entryIntoForceDate = getDateByXpath(xmlDocument, X_PATH_ENTRY_INTO_FORCE_DATE);
+    LocalDate expiryDate = getDateByXpath(xmlDocument, X_PATH_EXPIRY_DATE);
+    LocalDate legislationDate = getDateByXpath(xmlDocument, X_PATH_DATE_AUSFERTIGUNG);
+    LocalDate datePublished = getDateByXpath(xmlDocument, X_PATH_WORK_DATE);
+    LocalDate normsSortDate = isPrototype ? legislationDate : entryIntoForceDate;
+
+    return Norm.builder()
+        .id(expressionEli)
+        .tableOfContents(tableOfContents)
+        .workEli(workEli)
+        .expressionEli(expressionEli)
+        .manifestationEliExample(manifestationEli)
+        .officialTitle(getOfficialTitleByXmlDocument(xmlDocument))
+        .officialShortTitle(getOfficialShortTitleByXmlDocument(xmlDocument))
+        .officialAbbreviation(abbreviation)
+        .risAbbreviation(risAbbreviation)
+        .normsDate(legislationDate)
+        .normsSortDate(normsSortDate)
+        .datePublished(datePublished)
+        .publishedIn(getPublishedInByXmlDocument(xmlDocument, datePublished))
+        .entryIntoForceDate(entryIntoForceDate)
+        .expiryDate(expiryDate)
+        .fullCitation(fullCitation)
+        .officialToc(officialToc)
+        .articles(articles)
+        .articleNames(articleNames)
+        .articleTexts(articleTexts)
+        .officialFootNotes(getOfficialFootNotes(xmlDocument, attachments))
+        .indexedAt(indexedAt)
+        .build();
+  }
+
+  private static void requireNotBedingtInkraftOrGegenstandslos(XmlDocument xmlDocument)
+      throws XPathExpressionException {
+    if (xmlDocument.getElementExistByXpath(X_PATH_GEGENSTANDSLOS)) {
+      throw new IllegalStateException("Ignoring Gegenstandslos until logic is defined");
+    }
+
+    if (xmlDocument.getElementExistByXpath(X_PATH_BEDINGTES_INKRAFTTRETEN)) {
+      throw new IllegalStateException("Ignoring BedingtesInkrafttreten until logic is defined");
     }
   }
 
@@ -277,22 +306,6 @@ public class NormLdmlToOpenSearchMapper {
         .replaceAll("[()]", " ")
         .replaceAll("\\s{2,}", " ") // collapse multiple whitespaces
         .trim();
-  }
-
-  /**
-   * Tries to extract the official abbreviation (amtliche Abkürzung) from the document. If that
-   * doesn't exist uses the ris:abkuerzung as fallback.
-   *
-   * @param xmlDocument
-   * @return official abbreviation or ris:abkuerzung (fallback)
-   */
-  private static Optional<String> getAbbreviation(XmlDocument xmlDocument) {
-    Optional<String> officialAbbreviation =
-        xmlDocument.getNonEmptyElementByXpath(X_PATH_SHORT_TITLE_ABBREVIATION);
-
-    if (officialAbbreviation.isPresent()) {
-      return officialAbbreviation;
-    } else return xmlDocument.getNonEmptyElementByXpath(X_PATH_RIS_ABKUERZUNG);
   }
 
   private static LocalDate getDateByXpath(XmlDocument xmlDocument, String xpath) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormLdmlToOpenSearchMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormLdmlToOpenSearchMapper.java
@@ -114,6 +114,7 @@ public class NormLdmlToOpenSearchMapper {
    * The method extracts and maps metadata, content, and attachments from the XML to populate the
    * properties of the {@link Norm}.
    *
+   * @param fileName filename of the xmlFile, used for logging
    * @param xmlFile A string representation of the XML file content.
    * @param attachmentFileContents A map where the keys represent the attachment names and the
    *     values contain their respective content.

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormLdmlToOpenSearchMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/NormLdmlToOpenSearchMapper.java
@@ -153,7 +153,7 @@ public class NormLdmlToOpenSearchMapper {
           ValidationException {
     var xmlDocument = new XmlDocument(xmlFile.getBytes(StandardCharsets.UTF_8));
 
-    requireNotBedingtInkraftOrGegenstandslos(xmlDocument);
+    requireNotBedingtInkraftAndNotGegenstandslos(xmlDocument);
 
     String workEli = xmlDocument.getNonEmptyElementOrThrow(X_PATH_WORK_URI, "Work-Eli must exist");
 
@@ -226,7 +226,7 @@ public class NormLdmlToOpenSearchMapper {
         .build();
   }
 
-  private static void requireNotBedingtInkraftOrGegenstandslos(XmlDocument xmlDocument)
+  private static void requireNotBedingtInkraftAndNotGegenstandslos(XmlDocument xmlDocument)
       throws XPathExpressionException {
     if (xmlDocument.getElementExistByXpath(X_PATH_GEGENSTANDSLOS)) {
       throw new IllegalStateException("Ignoring Gegenstandslos until logic is defined");

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/Norm.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/Norm.java
@@ -62,6 +62,9 @@ public final class Norm implements AbstractSearchEntity {
   @Field(name = Fields.OFFICIAL_ABBREVIATION)
   private String officialAbbreviation;
 
+  @Field(name = Fields.RIS_ABBREVIATION)
+  private String risAbbreviation;
+
   /**
    * The date of adoption or signature of the legislation. This is the date at which the text is
    * officially acknowledged to be a legislation, even though it might not even be published or in
@@ -146,6 +149,8 @@ public final class Norm implements AbstractSearchEntity {
     public static final String DATE_PUBLISHED = "date_published";
     public static final String OFFICIAL_ABBREVIATION = "official_abbreviation";
     public static final String OFFICIAL_ABBREVIATION_KEYWORD = "official_abbreviation.keyword";
+    public static final String RIS_ABBREVIATION = "ris_abbreviation";
+    public static final String RIS_ABBREVIATION_KEYWORD = "ris_abbreviation.keyword";
     public static final String OFFICIAL_SHORT_TITLE = "official_short_title";
     public static final String OFFICIAL_SHORT_TITLE_KEYWORD = "official_short_title.keyword";
     public static final String OFFICIAL_TITLE = "official_title";

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
@@ -277,14 +277,12 @@ public class IndexNormsService implements IndexService {
     }
 
     Map<String, String> attachments = getXmlAttachments(fileName, keysMatchingExpressionEli);
-    Optional<Norm> norm =
-        NormLdmlToOpenSearchMapper.parseNorm(
-            fileContent.get(), attachments, environment.acceptsProfiles(Profiles.of("prototype")));
-    if (norm.isEmpty()) {
-      logger.error("Unknown error while processing file {} during Norm import.", fileName);
-    }
 
-    return norm;
+    return NormLdmlToOpenSearchMapper.parseNorm(
+        fileName,
+        fileContent.get(),
+        attachments,
+        environment.acceptsProfiles(Profiles.of("prototype")));
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/XmlDocument.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/XmlDocument.java
@@ -197,9 +197,10 @@ public class XmlDocument {
    * Tries to extract the value at the given xpath returns it if it's not blank. Otherwise, throws
    * an {@code IllegalArgumentException} with the provided errorMessage.
    *
-   * @param xpath
-   * @param errorMessage
-   * @return
+   * @param xpath of the element to extract
+   * @param errorMessage added to the exception in case the element couldn't be extracted
+   * @return the element if found
+   * @throws IllegalArgumentException if the element was not found
    */
   public String getNonEmptyElementOrThrow(String xpath, String errorMessage) {
     Optional<String> value = getNonEmptyElementByXpath(xpath);

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/XmlDocument.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/XmlDocument.java
@@ -194,6 +194,24 @@ public class XmlDocument {
   }
 
   /**
+   * Tries to extract the value at the given xpath returns it if it's not blank. Otherwise, throws
+   * an {@code IllegalArgumentException} with the provided errorMessage.
+   *
+   * @param xpath
+   * @param errorMessage
+   * @return
+   */
+  public String getNonEmptyElementOrThrow(String xpath, String errorMessage) {
+    Optional<String> value = getNonEmptyElementByXpath(xpath);
+
+    if (value.isPresent()) {
+      return value.get();
+    }
+
+    throw new IllegalArgumentException(errorMessage);
+  }
+
+  /**
    * Returns the text value of a node, excluding text in any child nodes.
    *
    * @param node the node to extract text from

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/NormLdmlToOpenSearchMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/NormLdmlToOpenSearchMapperTest.java
@@ -39,7 +39,8 @@ class NormLdmlToOpenSearchMapperTest {
             .datePublished("1962-07-20");
 
     String xmlContent = builder.buildNormXml();
-    Optional<Norm> maybeNorm = NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), false);
+    Optional<Norm> maybeNorm =
+        NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false);
 
     assertThat(maybeNorm).isNotEmpty();
 
@@ -83,7 +84,8 @@ class NormLdmlToOpenSearchMapperTest {
     NormTestDataBuilder builder = NormTestDataBuilder.builder().officialTitle(title);
 
     String xmlContent = builder.buildNormXml();
-    Optional<Norm> maybeNorm = NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), false);
+    Optional<Norm> maybeNorm =
+        NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false);
 
     assertThat(maybeNorm).isNotEmpty();
 
@@ -101,7 +103,7 @@ class NormLdmlToOpenSearchMapperTest {
             .datePublished("  1962-07-20   ");
 
     String xmlContent = builder.buildNormXml();
-    Optional<Norm> maybeNorm = NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), true);
+    Optional<Norm> maybeNorm = NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), true);
 
     assertThat(maybeNorm).isNotEmpty();
 
@@ -112,42 +114,69 @@ class NormLdmlToOpenSearchMapperTest {
   }
 
   @Test
-  @DisplayName("Sets abbreviation to null when both abbreviations are missing")
-  void setsAbbreviationToNullWhenAbbreviationsAreMissing() {
-    NormTestDataBuilder builder =
-        NormTestDataBuilder.builder().officialAbbreviation(null).risAbbreviation(null);
+  @DisplayName("Sets ris-abbreviation")
+  void extractsRisAbbreviation() {
+    NormTestDataBuilder builder = NormTestDataBuilder.builder().risAbbreviation("RisAbbrev");
 
     String xmlContent = builder.buildNormXml();
-    Optional<Norm> maybeNorm = NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), false);
+    Optional<Norm> maybeNorm =
+        NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false);
 
     assertThat(maybeNorm).isNotEmpty();
-    assertThat(maybeNorm.get().getOfficialAbbreviation()).isNull();
+    assertThat(maybeNorm.get().getRisAbbreviation()).isEqualTo("RisAbbrev");
   }
 
   @Test
-  @DisplayName("Prefers official abbreviation over RIS abbreviation")
+  @DisplayName("Does not map norm if ris-abbreviation is missing")
+  void returnsEmptyOptionalIfRisAbbreviationIsMissing() {
+    NormTestDataBuilder builder = NormTestDataBuilder.builder().risAbbreviation(null);
+
+    String xmlContent = builder.buildNormXml();
+    Optional<Norm> maybeNorm =
+        NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false);
+
+    assertThat(maybeNorm).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Sets abbreviation to official abbreviation if both abbreviations exist")
   void prefersOfficialAbbreviationOverRisAbbreviation() {
     NormTestDataBuilder builder =
         NormTestDataBuilder.builder().officialAbbreviation("OffAbb").risAbbreviation("RisAbb");
 
     String xmlContent = builder.buildNormXml();
-    Optional<Norm> maybeNorm = NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), false);
+    Optional<Norm> maybeNorm =
+        NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false);
 
     assertThat(maybeNorm).isNotEmpty();
     assertThat(maybeNorm.get().getOfficialAbbreviation()).isEqualTo("OffAbb");
   }
 
   @Test
-  @DisplayName("Uses RIS abbreviation as fallback")
+  @DisplayName("Sets abbreviation to ris-abbreviation as fallback")
   void usesRisAbbreviationAsFallback() {
     NormTestDataBuilder builder =
         NormTestDataBuilder.builder().officialAbbreviation(null).risAbbreviation("RisAbb");
 
     String xmlContent = builder.buildNormXml();
-    Optional<Norm> maybeNorm = NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), false);
+    Optional<Norm> maybeNorm =
+        NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false);
 
     assertThat(maybeNorm).isNotEmpty();
     assertThat(maybeNorm.get().getOfficialAbbreviation()).isEqualTo("RisAbb");
+  }
+
+  @Test
+  @DisplayName("Does not map norm if no abbreviation exists")
+  void returnsEmptyOptionalWhenAbbreviationsAreMissing() {
+    NormTestDataBuilder builder =
+        NormTestDataBuilder.builder().officialAbbreviation(null).risAbbreviation(null);
+
+    String xmlContent = builder.buildNormXml();
+    Optional<Norm> maybeNorm =
+        NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false);
+
+    assertThat(maybeNorm).isEmpty();
   }
 
   @Test
@@ -156,7 +185,7 @@ class NormLdmlToOpenSearchMapperTest {
     String xmlContent =
         NormTestDataBuilder.builder().disableValidation().workEli(null).buildNormXml();
 
-    assertThat(NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), false)).isEmpty();
+    assertThat(NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false)).isEmpty();
   }
 
   @Test
@@ -165,7 +194,7 @@ class NormLdmlToOpenSearchMapperTest {
     String xmlContent =
         NormTestDataBuilder.builder().disableValidation().expressionEli(null).buildNormXml();
 
-    assertThat(NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), false)).isEmpty();
+    assertThat(NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false)).isEmpty();
   }
 
   @Test
@@ -174,14 +203,14 @@ class NormLdmlToOpenSearchMapperTest {
     String xmlContent =
         NormTestDataBuilder.builder().disableValidation().manifestationEli(null).buildNormXml();
 
-    assertThat(NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), false)).isEmpty();
+    assertThat(NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false)).isEmpty();
   }
 
   @Test
   @DisplayName("Does not create norm for invalid XML document")
   void doesNotCreateNormForInvalidXmlDocument() {
     String xml = "<akn:akomaNtoso xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de\"/>";
-    assertThat(NormLdmlToOpenSearchMapper.parseNorm(xml, Map.of(), true)).isEmpty();
+    assertThat(NormLdmlToOpenSearchMapper.parseNorm("", xml, Map.of(), true)).isEmpty();
   }
 
   @Test
@@ -189,7 +218,7 @@ class NormLdmlToOpenSearchMapperTest {
   void doesNotMapNormIfBedingtesInkrafttreten() {
     String xmlContent = NormTestDataBuilder.builder().bedingtesInkrafttreten().buildNormXml();
 
-    assertThat(NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), false)).isEmpty();
+    assertThat(NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false)).isEmpty();
   }
 
   @Test
@@ -198,7 +227,7 @@ class NormLdmlToOpenSearchMapperTest {
     String xmlContent =
         NormTestDataBuilder.builder().disableValidation().gegenstandslos().buildNormXml();
 
-    assertThat(NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), false)).isEmpty();
+    assertThat(NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false)).isEmpty();
   }
 
   @Test
@@ -209,7 +238,8 @@ class NormLdmlToOpenSearchMapperTest {
         NormTestDataBuilder.builder().inForceDate("2020-01-01").legislationDate("2050-07-31");
 
     String xmlContent = builder.buildNormXml();
-    Optional<Norm> maybeNorm = NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), false);
+    Optional<Norm> maybeNorm =
+        NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false);
 
     assertThat(maybeNorm).isNotEmpty();
 
@@ -225,7 +255,7 @@ class NormLdmlToOpenSearchMapperTest {
         NormTestDataBuilder.builder().inForceDate("2020-01-01").legislationDate("2050-07-31");
 
     String xmlContent = builder.buildNormXml();
-    Optional<Norm> maybeNorm = NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), true);
+    Optional<Norm> maybeNorm = NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), true);
 
     assertThat(maybeNorm).isNotEmpty();
 
@@ -262,7 +292,8 @@ class NormLdmlToOpenSearchMapperTest {
                 });
 
     String xmlContent = builder.buildNormXml();
-    Optional<Norm> maybeNorm = NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), false);
+    Optional<Norm> maybeNorm =
+        NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false);
 
     assertThat(maybeNorm).isNotEmpty();
 
@@ -319,7 +350,7 @@ class NormLdmlToOpenSearchMapperTest {
 
     Optional<Norm> maybeNorm =
         NormLdmlToOpenSearchMapper.parseNorm(
-            builder.buildNormXml(), builder.buildAttachmentXmls(), true);
+            "", builder.buildNormXml(), builder.buildAttachmentXmls(), true);
 
     assertThat(maybeNorm).isNotEmpty();
 
@@ -391,7 +422,7 @@ class NormLdmlToOpenSearchMapperTest {
                 List.of(AknP.withText("Attachemtn Content")));
     String xmlContent = builder.buildNormXml();
     Optional<Norm> maybeNorm =
-        NormLdmlToOpenSearchMapper.parseNorm(xmlContent, builder.buildAttachmentXmls(), false);
+        NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, builder.buildAttachmentXmls(), false);
 
     assertThat(maybeNorm).isNotEmpty();
 
@@ -450,7 +481,8 @@ class NormLdmlToOpenSearchMapperTest {
             });
 
     String xmlContent = builder.buildNormXml();
-    Optional<Norm> maybeNorm = NormLdmlToOpenSearchMapper.parseNorm(xmlContent, Map.of(), false);
+    Optional<Norm> maybeNorm =
+        NormLdmlToOpenSearchMapper.parseNorm("", xmlContent, Map.of(), false);
 
     assertThat(maybeNorm).isNotEmpty();
 
@@ -506,7 +538,7 @@ class NormLdmlToOpenSearchMapperTest {
 
     Optional<Norm> maybeNorm =
         NormLdmlToOpenSearchMapper.parseNorm(
-            builder.buildNormXml(), builder.buildAttachmentXmls(), true);
+            "", builder.buildNormXml(), builder.buildAttachmentXmls(), true);
 
     assertThat(maybeNorm).isNotEmpty();
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexNormsServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/IndexNormsServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.bund.digitalservice.ris.builder.NormTestDataBuilder;
 import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.repository.objectstorage.NormsBucket;
 import de.bund.digitalservice.ris.search.repository.opensearch.ArticlesRepository;
@@ -31,106 +32,12 @@ class IndexNormsServiceTest {
   @Mock NormsRepository repo;
   @Mock ArticlesRepository articlesRepository;
 
-  private final String testContent =
-      """
-          <?xml version="1.0" encoding="UTF-8"?>
-          <?xml-model href="../../../Grammatiken/Norms/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.8.2/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.8.2/ ../../../Grammatiken/Norms/legalDocML.de-metadaten.xsd
-                                http://Inhaltsdaten.LegalDocML.de/1.8.2/ ../../../Grammatiken/Norms/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-            <akn:act name="regelungstext">
-              <akn:meta eId="meta-1" GUID="40a13276-39ac-4fc9-aafd-3fbfea0df2b0">
-                <akn:identification eId="meta-1_ident-1" GUID="6098a736-d359-4caf-a45e-dfa3792f2bc4" source="attributsemantik-noch-undefiniert">
-                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="cc4476ce-6342-4bb9-a777-030a21e4b0fc">
-                    <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="d2bd3a22-c547-479d-85c3-ef374778c74b" value="eli/bund/bgbl-1/1992/s101/regelungstext-1"></akn:FRBRthis>
-                    <akn:FRBRuri eId="meta-1_ident-1_frbrwork-1_frbruri-1" GUID="0d015c4c-be37-453a-917f-7975287b2fcf" value="eli/bund/bgbl-1/1992/s101"></akn:FRBRuri>
-                    <akn:FRBRalias eId="meta-1_ident-1_frbrwork-1_frbralias-1" GUID="e2acf308-f9e4-4781-ba3a-5339a999f69f" name="übergreifende-id" value="f96cfae4-4fce-4c72-9186-0d84778dc11c"></akn:FRBRalias>
-                    <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="63e8780d-4225-4987-aec1-794510b4d7f6" date="1992-01-01" name="verkuendungsfassung"></akn:FRBRdate>
-                    <akn:FRBRauthor eId="meta-1_ident-1_frbrwork-1_frbrauthor-1" GUID="b6deb229-93c7-43f4-886a-b9693587ca8a" href="recht.bund.de/institution/bundesregierung"></akn:FRBRauthor>
-                    <akn:FRBRcountry eId="meta-1_ident-1_frbrwork-1_frbrcountry-1" GUID="1fd2ebf9-a423-443c-a7e5-665b86a0d9d9" value="de"></akn:FRBRcountry>
-                    <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="e7405de2-48df-4049-9621-a0ffa2d8e317" value="1"></akn:FRBRnumber>
-                    <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="fc410fa5-4236-4735-87e5-1bb5ab1402ba" value="bgbl-1"></akn:FRBRname>
-                    <akn:FRBRsubtype eId="meta-1_ident-1_frbrwork-1_frbrsubtype-1" GUID="994fe962-3694-49ad-a2d1-4e17d12b10d0" value="regelungstext-1"></akn:FRBRsubtype>
-                  </akn:FRBRWork>
-                  <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="2a16dd66-9151-40d4-ab04-3f0525b4102d">
-                    <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="b4d5b0c5-53e3-4c51-b6c6-0311563941df" value="eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/regelungstext-1"></akn:FRBRthis>
-                    <akn:FRBRuri eId="meta-1_ident-1_frbrexpression-1_frbruri-1" GUID="8909d2e8-abde-437a-8efc-f45483b4f996" value="eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu"></akn:FRBRuri>
-                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="c23228e0-af6b-46e0-aaae-93520ae758c9" name="vorherige-version-id" value="79c7f606-b47c-4c7d-8e3a-1a89b333cd85"></akn:FRBRalias>
-                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2e74b960-342e-4af1-b127-08bfef86d3ae" name="aktuelle-version-id" value="d33c67a0-2be2-4728-932d-5abae5a84422"></akn:FRBRalias>
-                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="a7a64f41-bd12-4311-9ae0-dd23e94fa018" name="nachfolgende-version-id" value="24c51028-eb62-4853-a986-6c62e6e25731"></akn:FRBRalias>
-                    <akn:FRBRauthor eId="meta-1_ident-1_frbrexpression-1_frbrauthor-1" GUID="4e8005ef-7e71-478f-bc91-b89e8c69e9e2" href="recht.bund.de/institution/bundesregierung"></akn:FRBRauthor>
-                    <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="a5bffed4-7bb4-4b74-a326-eaabfea58f94" date="1992-01-01" name="verkuendung"></akn:FRBRdate>
-                    <akn:FRBRlanguage eId="meta-1_ident-1_frbrexpression-1_frbrlanguage-1" GUID="e6cfb417-7a91-444d-8563-a0a09c55058c" language="deu"></akn:FRBRlanguage>
-                    <akn:FRBRversionNumber eId="meta-1_ident-1_frbrexpression-1_frbrersionnumber-1" GUID="6b354c1d-cc0b-4df0-83ee-c5d062cc2d0a" value="1"></akn:FRBRversionNumber>
-                  </akn:FRBRExpression>
-                  <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="a3747035-aff8-41a6-86d7-0c7b75caddf2">
-                    <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="451a75df-0eb0-4644-ba75-04743d44aadc" value="eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-01/regelungstext-1.xml"></akn:FRBRthis>
-                    <akn:FRBRuri eId="meta-1_ident-1_frbrmanifestation-1_frbruri-1" GUID="a2c90263-9bd4-48c4-974e-6d36f5a81021" value="eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-01/regelungstext-1.xml"></akn:FRBRuri>
-                    <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="4fd05b86-52c3-4c01-9251-eb8df6e2ab0c" date="1992-01-01" name="generierung"></akn:FRBRdate>
-                    <akn:FRBRauthor eId="meta-1_ident-1_frbrmanifestation-1_frbrauthor-1" GUID="54f8256b-97f1-4f73-afc3-088ae56af8c7" href="recht.bund.de"></akn:FRBRauthor>
-                    <akn:FRBRformat eId="meta-1_ident-1_frbrmanifestation-1_frbrformat-1" GUID="3cd9946c-1df1-4797-8575-5e94bd3d63c5" value="xml"></akn:FRBRformat>
-                  </akn:FRBRManifestation>
-                </akn:identification>
-                <akn:lifecycle source="attributsemantik-noch-undefiniert" GUID="f67462bc-7787-4ba9-9041-8e4fc8852ae3" eId="meta-1_lebzykl-1">
-                  <akn:eventRef date="1992-01-01" source="attributsemantik-noch-undefiniert" refersTo="ausfertigung" type="generation" eId="meta-1_lebzykl-1_ereignis-1" GUID="1b8c849d-ee5c-4568-a119-be9dbbc27e2e"></akn:eventRef>
-                </akn:lifecycle>
-                <akn:analysis source="attributsemantik-noch-undefiniert" eId="meta-1_analysis-1" GUID="04f6a82d-20b3-4bf9-88bb-e442f58247b5"></akn:analysis>
-                <akn:temporalData source="attributsemantik-noch-undefiniert" GUID="c3f9ce52-8e0c-428c-abdd-37e56ed66551" eId="meta-1_geltzeiten-1">
-                  <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="5a8e0a7b-97ca-433b-9d26-0c1501d34e7b">
-                    <akn:timeInterval start="#meta-1_lebzykl-1_ereignis-1" refersTo="geltungszeit" eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="90afcb18-ec43-468b-b914-d37d4c60bf76"></akn:timeInterval>
-                  </akn:temporalGroup>
-                </akn:temporalData>
-              </akn:meta>
-
-              <akn:preface eId="einleitung-1" GUID="a3399d47-218a-46cf-939c-685f884ed724">
-                <akn:longTitle eId="einleitung-1_doktitel-1" GUID="16586e8f-68e1-4191-a4a2-8473f6bdf4e5">
-                  <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="f312be90-0938-4ab8-a18d-e5b97e9be686">
-                    <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1">Formatting Test Document</akn:docTitle>
-                    <akn:shortTitle eId="einleitung-1_doktitel-1_text-1_kurztitel-1">(Formatting Test - <akn:inline refersTo="amtliche-abkuerzung" name="attributsemantik-noch-undefiniert" eId="einleitung-1_doktitel-1_text-1_kurztitel-1_inline-1">MFT</akn:inline>)</akn:shortTitle>
-                  </akn:p>
-                </akn:longTitle>
-                <akn:block eId="einleitung-1_block-1" GUID="50b373c9-d7a9-4ea1-a6c9-bee1fa5617c6" name="attributsemantik-noch-undefiniert">
-                  <akn:date eId="einleitung-1_block-1_datum-1" GUID="34a9b790-c90f-4177-8023-425062e13f07" refersTo="ausfertigung-datum" date="0001-01-01">0001-01-01</akn:date>
-                </akn:block>
-              </akn:preface>
-
-              <akn:body eId="hauptteil-1" GUID="2bd1d0a2-ff72-42af-b9ab-2f30cc8d7539">
-                <!-- Basic HTML elements -->
-                <akn:article eId="hauptteil-1_para-1" GUID="87cd6b3a-d198-49c3-a02f-6adfd12940cb" period="#meta-1_geltzeiten-1_geltungszeitgr-1">
-                  <akn:num eId="hauptteil-1_para-1_bezeichnung-1" GUID="0a0885f1-5bf1-476e-b12b-ce8243a47ddb">
-                    <akn:marker eId="hauptteil-1_para-1_bezeichnung-1_zaehlbez-1" GUID="1e35f3b3-ad84-4c5a-9804-092454853b84" name="1"></akn:marker> § 1 </akn:num>
-                  <akn:heading eId="hauptteil-1_para-1_überschrift-1" GUID="519116f1-968a-4eaa-a89e-71258285844f"> Basic HTML Elements </akn:heading>
-
-                  <akn:paragraph eId="hauptteil-1_para-1_abs-1" GUID="5eb21b69-8e10-4b24-8d69-14e6688a7886">
-                    <akn:num eId="hauptteil-1_para-1_abs-1_bezeichnung-1" GUID="da0afc22-6f9b-4fe6-8e25-a1b97c8fc382">
-                      <akn:marker eId="hauptteil-1_para-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="7ad2932c-a416-4dc9-a58d-cc0d6a597d71" name="1"></akn:marker>
-                    </akn:num>
-                    <akn:content eId="hauptteil-1_para-1_abs-1_inhalt-1" GUID="c07abae2-921b-47a5-9681-3ff0b2700836">
-                      <akn:p eId="hauptteil-1_para-1_abs-1_inhalt-1_text-1" GUID="7d7bea1a-182d-42ed-9f44-7844b3bb2d4c">
-                        <akn:b eId="hauptteil-1_para-1_abs-1_inhalt-1_text-1_fettschrift-1" GUID="c1c593df-c20b-4d11-9c4e-945c7041fd9b">Bold</akn:b> text. <akn:i eId="hauptteil-1_para-1_abs-1_inhalt-1_text-1_kursiv-1" GUID="726c9ef9-9cad-40ae-8654-cc058366c400">Italic</akn:i> text. <akn:u
-                          eId="hauptteil-1_para-1_abs-1_inhalt-1_text-1_u-1" GUID="c30774a1-23b9-453d-a01f-4d873e29fec5">Underlined</akn:u> text. This contains <akn:sub eId="hauptteil-1_para-1_abs-1_inhalt-1_text-1_sub-1" GUID="ad66eeaf-0217-4e53-9c48-8bcb325c0d70">subscript</akn:sub> text. This contains <akn:sup
-                          eId="hauptteil-1_para-1_abs-1_inhalt-1_text-1_sup-1" GUID="7a3eb2b3-9df7-4c21-a9d8-f2b6a1d81597">superscript</akn:sup> text. This text contains a <akn:a href="#" eId="hauptteil-1_para-1_abs-1_inhalt-1_text-1_a-1" GUID="0d9de688-e6d0-446d-a164-503420ffbb76">link</akn:a>. <akn:span
-                          eId="hauptteil-1_para-1_abs-1_inhalt-1_text-1_span-1" GUID="0ae5920a-34ed-4391-87ec-cafb2780e868">Inline container</akn:span>. <akn:br eId="hauptteil-1_para-1_abs-1_inhalt-1_text-1_br-1" GUID="263f863c-99ac-4421-a99f-a430f879ef33"></akn:br><akn:br
-                          eId="hauptteil-1_para-1_abs-1_inhalt-1_text-1_br-2" GUID="0a5685dd-08f2-41c2-aad9-8b20f85635c5"></akn:br>This text has two preceding line breaks.</akn:p>
-                    </akn:content>
-                  </akn:paragraph>
-                </akn:article>
-              </akn:body>
-            </akn:act>
-          </akn:akomaNtoso>
-          """;
-
   @Test
   void reindexAllIgnoresInvalidFiles() throws ObjectStoreServiceException {
-
-    when(this.bucket.getAllKeysByPrefix("eli/"))
-        .thenReturn(
-            List.of(
-                "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-1.xml",
-                "eli/not_an_eli"));
-    when(this.bucket.getFileAsString(
-            "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-1.xml"))
-        .thenReturn(Optional.of(testContent));
+    String validEli = "eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-1.xml";
+    when(this.bucket.getAllKeysByPrefix("eli/")).thenReturn(List.of(validEli, "eli/not_an_eli"));
+    when(this.bucket.getFileAsString(validEli))
+        .thenReturn(Optional.of(NormTestDataBuilder.builder().eli(validEli).buildNormXml()));
 
     String startingTimestamp = "2024-01-01T12:00:00Z";
     this.service.reindexAll(startingTimestamp);

--- a/backend/src/test/resources/data/LDML/norm/eli/bund/bgbl-1/1991/s101/1991-01-01/1/deu/1991-01-01/regelungstext-1.xml
+++ b/backend/src/test/resources/data/LDML/norm/eli/bund/bgbl-1/1991/s101/1991-01-01/1/deu/1991-01-01/regelungstext-1.xml
@@ -48,6 +48,11 @@
           <akn:timeInterval start="#meta-n1_lebzykl-n1_ereignis-n1" refersTo="geltungszeit" eId="meta-n1_geltzeiten-n1_geltungszeitgr-n1_gelzeitintervall-n1" GUID="90afcb18-ec43-468b-b914-d37d4c60bf76"></akn:timeInterval>
         </akn:temporalGroup>
       </akn:temporalData>
+      <akn:proprietary GUID="2983c8d3-2f94-41ba-907c-b9aee90a04eb" eId="meta-n1_proprietary-n1" source="attributsemantik-noch-undefiniert">
+        <ris:legalDocML.de_metadaten xmlns:ris="http://MetadatenRIS.LegalDocML.de/1.8.2/" xsi:schemaLocation="http://MetadatenRIS.LegalDocML.de/1.8.2/ ../ris-norms-ldml-schema-extensions/1.8.2/legalDocML.de-metadaten-ris.xsd">
+          <ris:abkuerzung refersTo="interne-abkuerzung">RisAbbrev</ris:abkuerzung>
+        </ris:legalDocML.de_metadaten>
+      </akn:proprietary>
     </akn:meta>
 
     <akn:preface eId="einleitung-n1" GUID="a3399d47-218a-46cf-939c-685f884ed724">

--- a/backend/src/test/resources/data/LDML/norm/eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-01/regelungstext-1.xml
+++ b/backend/src/test/resources/data/LDML/norm/eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-01/regelungstext-1.xml
@@ -50,6 +50,7 @@
       </akn:temporalData>
       <akn:proprietary GUID="2983c8d3-2f94-41ba-907c-b9aee90a04eb" eId="meta-n1_proprietary-n1" source="attributsemantik-noch-undefiniert">
         <ris:legalDocML.de_metadaten xmlns:ris="http://MetadatenRIS.LegalDocML.de/1.8.2/" xsi:schemaLocation="http://MetadatenRIS.LegalDocML.de/1.8.2/ ../ris-norms-ldml-schema-extensions/1.8.2/legalDocML.de-metadaten-ris.xsd">
+          <ris:abkuerzung refersTo="interne-abkuerzung">RisAbbrev</ris:abkuerzung>
           <ris:inkraft date="1992-01-01"/>
           <ris:ausserkraft date="1992-01-31"/>
         </ris:legalDocML.de_metadaten>

--- a/backend/src/test/resources/data/LDML/norm/eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-1.xml
+++ b/backend/src/test/resources/data/LDML/norm/eli/bund/bgbl-1/1992/s101/1992-01-01/1/deu/1992-01-02/regelungstext-1.xml
@@ -50,6 +50,7 @@
       </akn:temporalData>
       <akn:proprietary GUID="2983c8d3-2f94-41ba-907c-b9aee90a04eb" eId="meta-n1_proprietary-n1" source="attributsemantik-noch-undefiniert">
         <ris:legalDocML.de_metadaten xmlns:ris="http://MetadatenRIS.LegalDocML.de/1.8.2/" xsi:schemaLocation="http://MetadatenRIS.LegalDocML.de/1.8.2/ ../ris-norms-ldml-schema-extensions/1.8.2/legalDocML.de-metadaten-ris.xsd">
+          <ris:abkuerzung refersTo="interne-abkuerzung">RisAbbrev</ris:abkuerzung>
           <ris:inkraft date="1992-01-01"/>
           <ris:ausserkraft date="1992-01-31"/>
         </ris:legalDocML.de_metadaten>

--- a/backend/src/test/resources/data/LDML/norm/eli/bund/bgbl-1/1992/s101/1992-02-01/2/deu/1992-02-01/regelungstext-1.xml
+++ b/backend/src/test/resources/data/LDML/norm/eli/bund/bgbl-1/1992/s101/1992-02-01/2/deu/1992-02-01/regelungstext-1.xml
@@ -50,6 +50,7 @@
       </akn:temporalData>
       <akn:proprietary GUID="2983c8d3-2f94-41ba-907c-b9aee90a04eb" eId="meta-n1_proprietary-n1" source="attributsemantik-noch-undefiniert">
         <ris:legalDocML.de_metadaten xmlns:ris="http://MetadatenRIS.LegalDocML.de/1.8.2/" xsi:schemaLocation="http://MetadatenRIS.LegalDocML.de/1.8.2/ ../ris-norms-ldml-schema-extensions/1.8.2/legalDocML.de-metadaten-ris.xsd">
+          <ris:abkuerzung refersTo="interne-abkuerzung">RisAbbrev</ris:abkuerzung>
           <ris:inkraft date="1992-02-01"/>
           <ris:ausserkraft date="1992-12-31"/>
         </ris:legalDocML.de_metadaten>

--- a/backend/src/test/resources/data/LDML/norm/eli/bund/bgbl-1/1992/s101/1992-02-01/2/deu/1992-02-02/regelungstext-1.xml
+++ b/backend/src/test/resources/data/LDML/norm/eli/bund/bgbl-1/1992/s101/1992-02-01/2/deu/1992-02-02/regelungstext-1.xml
@@ -50,6 +50,7 @@
       </akn:temporalData>
       <akn:proprietary GUID="2983c8d3-2f94-41ba-907c-b9aee90a04eb" eId="meta-n1_proprietary-n1" source="attributsemantik-noch-undefiniert">
         <ris:legalDocML.de_metadaten xmlns:ris="http://MetadatenRIS.LegalDocML.de/1.8.2/" xsi:schemaLocation="http://MetadatenRIS.LegalDocML.de/1.8.2/ ../ris-norms-ldml-schema-extensions/1.8.2/legalDocML.de-metadaten-ris.xsd">
+          <ris:abkuerzung refersTo="interne-abkuerzung">RisAbbrev</ris:abkuerzung>
           <ris:inkraft date="1992-02-01"/>
           <ris:ausserkraft date="1992-12-31"/>
         </ris:legalDocML.de_metadaten>


### PR DESCRIPTION
- add logic to index the ris-abbreviation in a dedicated field
- simplify error handling in NormLdmlToOpenSearch mapper and IndexNormService, this partly completes RISDEV-12011

RISDEV-7898