### PR TITLE
RISDEV-10550 fix visual issues in mobile overlay

### DIFF
--- a/frontend/e2e/suche.spec.ts
+++ b/frontend/e2e/suche.spec.ts
@@ -1195,6 +1195,45 @@ test.describe("mobile filter and sort drawers", () => {
     );
   });
 
+  test("aligns the court suggestions overlay with the input field", async ({
+    page,
+  }) => {
+    await navigate(page, "/suche?documentKind=R");
+
+    await page.getByRole("button", { name: "Filtern" }).click();
+    const dialog = page.getByRole("dialog", { name: "Filtern" });
+    await expect(dialog).toBeVisible();
+
+    const field = dialog.getByTestId("court-filter-field");
+    await dialog.getByRole("combobox", { name: "Bundesgericht" }).fill("LG");
+
+    // The overlay is teleported to <body>, so it's not a descendant of the
+    // dialog - only one instance of it can be open at a time though. Its
+    // `role="listbox"` sits on the inner options list, which is inset from
+    // the outer panel by padding, so the panel (identified by the marker
+    // class CourtFilter.vue applies for its own alignment fix) is what
+    // needs to line up with the field, not the listbox itself.
+    const overlayPanel = page.locator(".court-filter-overlay");
+
+    // Wait for the actual search results, not just the overlay shell - the
+    // option list keeps resizing (and re-triggering PrimeVue's own,
+    // overridden alignment) until the debounced search resolves.
+    await expect(
+      page.getByRole("option", { name: "Landgericht Hamburg Label" }),
+    ).toBeVisible();
+
+    const fieldBox = await field.boundingBox();
+    const overlayBox = await overlayPanel.boundingBox();
+    expect(fieldBox).not.toBeNull();
+    expect(overlayBox).not.toBeNull();
+
+    expect(overlayBox!.x).toBeCloseTo(fieldBox!.x, 0);
+    expect(overlayBox!.x + overlayBox!.width).toBeCloseTo(
+      fieldBox!.x + fieldBox!.width,
+      0,
+    );
+  });
+
   test("applies a date filter from the filter drawer", async ({ page }) => {
     await navigate(page, "/suche?documentKind=R");
 

--- a/frontend/src/components/search/CourtFilter.vue
+++ b/frontend/src/components/search/CourtFilter.vue
@@ -92,39 +92,130 @@ const suggestions = computed<AutoCompleteSuggestion[]>(() =>
 );
 
 const id = useId();
+
+/*
+ * When appendTo="body", PrimeVue's own overlay positioning (alignOverlay in
+ * primevue/autocomplete) anchors off the bare <input> element rather than the
+ * whole field (which also includes the dropdown button and the field's
+ * padding/border), and only sets a min-width rather than a width. Without an
+ * explicit width, the overlay's suggestion list (rendered with white-space:
+ * nowrap) can grow well beyond the field, and PrimeVue then mis-detects a
+ * right-edge overflow and clamps the overlay flush to the viewport's left edge
+ * instead of aligning it with the field.
+ *
+ * We correct both by measuring the field ourselves and applying the result
+ * directly to the overlay's `style`, ignoring whatever PrimeVue computed.
+ * PrimeVue re-runs its own (wrong) calculation - and overwrites both properties
+ * - on every re-render while the overlay is open (see its `updated()` hook),
+ * e.g. whenever the suggestion list changes, so a one-off correction isn't
+ * enough.
+ *
+ * Correcting the overlay only once it's fully open (e.g. on a "show" event,
+ * which fires after PrimeVue's enter transition finishes) would mean the wrong
+ * position is visible - and painted - for the whole transition, causing a jump
+ * right at the end. Instead, a MutationObserver watches document.body for the
+ * overlay being inserted, and immediately attaches a second observer to its
+ * `style` attribute. Since MutationObserver callbacks run as microtasks (before
+ * the browser's next paint, even for changes made by Vue/PrimeVue earlier in
+ * the same task), the very first (wrong) style PrimeVue sets is corrected
+ * before it can ever be painted, and every later re-alignment is caught the
+ * same way.
+ */
+const OVERLAY_MARKER_CLASS = "court-filter-overlay";
+const fieldRef = useTemplateRef<HTMLElement>("fieldRef");
+let bodyObserver: MutationObserver | undefined;
+let styleObserver: MutationObserver | undefined;
+
+const correctOverlayPosition = (overlayEl: HTMLElement) => {
+  const rect = fieldRef.value?.getBoundingClientRect();
+  if (!rect) return;
+  const left = `${rect.left + window.scrollX}px`;
+  const width = `${rect.width}px`;
+  if (overlayEl.style.insetInlineStart !== left) {
+    overlayEl.style.insetInlineStart = left;
+  }
+  if (overlayEl.style.width !== width) {
+    overlayEl.style.width = width;
+  }
+};
+
+const watchOverlayPosition = (overlayEl: HTMLElement) => {
+  correctOverlayPosition(overlayEl);
+  styleObserver?.disconnect();
+  styleObserver = new MutationObserver(() => correctOverlayPosition(overlayEl));
+  styleObserver.observe(overlayEl, {
+    attributes: true,
+    attributeFilter: ["style"],
+  });
+};
+
+const watchForBodyOverlay = () => {
+  if (appendTo !== "body") return;
+  bodyObserver?.disconnect();
+  bodyObserver = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (
+          node instanceof HTMLElement &&
+          node.classList.contains(OVERLAY_MARKER_CLASS)
+        ) {
+          bodyObserver?.disconnect();
+          watchOverlayPosition(node);
+          return;
+        }
+      }
+    }
+  });
+  bodyObserver.observe(document.body, { childList: true });
+};
+
+const stopAligningBodyOverlay = () => {
+  bodyObserver?.disconnect();
+  bodyObserver = undefined;
+  styleObserver?.disconnect();
+  styleObserver = undefined;
+};
+
+onBeforeUnmount(stopAligningBodyOverlay);
 </script>
 
 <template>
   <div class="flex flex-col gap-8">
     <label :id="id" class="typo-label2-bold">Bundesgericht</label>
-    <AutoComplete
-      v-model="model"
-      :aria-labelledby="id"
-      :append-to="appendTo"
-      :suggestions
-      dropdown
-      dropdown-mode="blank"
-      placeholder="Auswählen oder suchen"
-      :pt="
-        appendTo === 'body'
-          ? {
-              // AutoComplete isn't customized by ris-ui, so this reproduces
-              // its default overlay classes without `w-full` - which forces
-              // the panel to the viewport's width when appended to body,
-              // pushing it flush against the screen edges instead of aligning
-              // with the field. Providing pt.overlay.class here replaces
-              // rather than merges with the default, so all of the classes
-              // need to be repeated.
-              overlay: {
-                class: 'mt-12 overflow-auto bg-white px-8 py-12 shadow-md',
-              },
-            }
-          : undefined
-      "
-      typeahead
-      @complete="onComplete"
-      @dropdown-click="onDropdownClick"
-      @item-select="onItemSelect"
-    />
+    <div ref="fieldRef" data-testid="court-filter-field">
+      <AutoComplete
+        v-model="model"
+        :aria-labelledby="id"
+        :append-to="appendTo"
+        :suggestions
+        dropdown
+        dropdown-mode="blank"
+        placeholder="Auswählen oder suchen"
+        :pt="
+          appendTo === 'body'
+            ? {
+                // AutoComplete isn't customized by ris-ui, so this reproduces
+                // its default overlay classes, minus the theme's own
+                // `min-width: 100%` rule (which would otherwise force the panel
+                // to the viewport's width when appended to body). Providing
+                // pt.overlay.class here replaces rather than merges with the
+                // default, so all of the other classes need to be repeated too.
+                // The marker class lets watchForBodyOverlay find this element
+                // again; width/position are then corrected in JS, see the
+                // comment above.
+                overlay: {
+                  class: `mt-12 overflow-auto bg-white px-8 py-12 shadow-md ${OVERLAY_MARKER_CLASS}`,
+                },
+              }
+            : undefined
+        "
+        typeahead
+        @before-show="watchForBodyOverlay"
+        @complete="onComplete"
+        @dropdown-click="onDropdownClick"
+        @hide="stopAligningBodyOverlay"
+        @item-select="onItemSelect"
+      />
+    </div>
   </div>
 </template>

--- a/frontend/src/components/search/MobileActionDrawer.vue
+++ b/frontend/src/components/search/MobileActionDrawer.vue
@@ -61,7 +61,7 @@ function handleApply() {
       position="bottom"
       v-model:visible="visible"
     >
-      <div class="flex flex-col gap-24">
+      <div class="space-y-24">
         <slot />
       </div>
 


### PR DESCRIPTION
- removes wrong whitespace on first render in mobile Safari
- overrides PrimeVue's buggy autocomplete overlay positioning logic

---

(the issue is that PrimeVue's autocomplete positioning logic somehow doesn't consider margins and paddings, leading to wrong absolute positioning of the overlay. Adding a patch that overrides the logic. I know it's ugly, but I couldn't find a better way, and we're likely to remove PrimeVue soon anyway.)