### PR TITLE
RISDEV-0000 disable insecure request upgrading during development

### DIFF
--- a/frontend/config/security.ts
+++ b/frontend/config/security.ts
@@ -11,6 +11,7 @@ export const security: Partial<ModuleOptions> = {
   headers: {
     referrerPolicy: "same-origin",
     contentSecurityPolicy: {
+      "upgrade-insecure-requests": !isDevelopment,
       "default-src": "'self'",
       "style-src": ["'self'", "https:", "'unsafe-inline'"],
       "img-src": ["'self'", "data:", "'unsafe-inline'"],


### PR DESCRIPTION
This is ignored by Chrome anyway and makes the page unusable in Safari. Disabling it during development.