### PR TITLE
RISDEV-11960 NormTestDataBuilder review feedback part 3

### DIFF
--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/NormTestDataBuilder.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/NormTestDataBuilder.java
@@ -76,7 +76,7 @@ public class NormTestDataBuilder {
 
   private NormTestDataBuilder(boolean enforceValidation) {
     this.enforceValidation = enforceValidation;
-    this.document.setAct(Act.builder().meta(Meta.builder().build()).build());
+    this.document.setAct(Act.builder().meta(new Meta()).build());
   }
 
   public static NormTestDataBuilder builder() {
@@ -476,13 +476,7 @@ public class NormTestDataBuilder {
     AkomaNtoso attachment = new AkomaNtoso();
     attachment.setDoc(
         Doc.builder()
-            .meta(
-                Meta.builder()
-                    .lifecycle(null)
-                    .temporalData(null)
-                    .proprietary(null)
-                    .identification(new Identification(manifestationEli))
-                    .build())
+            .meta(new Meta(Identification.fromEli(manifestationEli)))
             .preface(
                 Preface.builder()
                     .longTitle(null)

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/NormTestDataBuilder.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/NormTestDataBuilder.java
@@ -332,8 +332,7 @@ public class NormTestDataBuilder {
    */
   public NormTestDataBuilder formula(String text) {
     Preamble preamble =
-        Optional.ofNullable(this.document.getAct().getPreamble())
-            .orElse(Preamble.builder().build());
+        Optional.ofNullable(this.document.getAct().getPreamble()).orElse(new Preamble());
     preamble.addFormula(text);
     this.document.getAct().setPreamble(preamble);
 
@@ -348,8 +347,7 @@ public class NormTestDataBuilder {
    */
   public NormTestDataBuilder toc(Consumer<Toc> tocConsumer) {
     Preamble preamble =
-        Optional.ofNullable(this.document.getAct().getPreamble())
-            .orElse(Preamble.builder().build());
+        Optional.ofNullable(this.document.getAct().getPreamble()).orElse(new Preamble());
     Toc toc = preamble.addToc();
     tocConsumer.accept(toc);
 
@@ -476,7 +474,7 @@ public class NormTestDataBuilder {
     AkomaNtoso attachment = new AkomaNtoso();
     attachment.setDoc(
         Doc.builder()
-            .meta(new Meta(Identification.fromEli(manifestationEli)))
+            .meta(new Meta(new Identification(manifestationEli)))
             .preface(
                 Preface.builder()
                     .longTitle(null)

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/NormTestDataBuilder.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/NormTestDataBuilder.java
@@ -453,33 +453,25 @@ public class NormTestDataBuilder {
       String heading,
       List<BodyElement> mainBodyChildren) {
     DocTitle attachmentTitle =
-        DocTitle.builder()
-            .eId("einleitung-n1_block-n1_doctitel-n1")
-            .children(
-                List.of(
-                    new Inline(
-                        "einleitung-n1_block-n1_doctitel-n1_inline-n1",
-                        "anlageregelungstext-num",
-                        num),
-                    new Inline(
-                        "einleitung-n1_block-n1_doctitel-n1_inline-n2",
-                        "anlageregelungstext-bezug",
-                        bezug),
-                    new Inline(
-                        "einleitung-n1_block-n1_doctitel-n1_inline-n3",
-                        "anlageregelungstext-heading",
-                        heading)))
-            .build();
+        new DocTitle(
+            "einleitung-n1_block-n1_doctitel-n1",
+            List.of(
+                new Inline(
+                    "einleitung-n1_block-n1_doctitel-n1_inline-n1", "anlageregelungstext-num", num),
+                new Inline(
+                    "einleitung-n1_block-n1_doctitel-n1_inline-n2",
+                    "anlageregelungstext-bezug",
+                    bezug),
+                new Inline(
+                    "einleitung-n1_block-n1_doctitel-n1_inline-n3",
+                    "anlageregelungstext-heading",
+                    heading)));
 
     AkomaNtoso attachment = new AkomaNtoso();
     attachment.setDoc(
         Doc.builder()
             .meta(new Meta(new Identification(manifestationEli)))
-            .preface(
-                Preface.builder()
-                    .longTitle(null)
-                    .block(new Block("einleitung-n1_block-n1", List.of(attachmentTitle)))
-                    .build())
+            .preface(new Preface(new Block("einleitung-n1_block-n1", List.of(attachmentTitle))))
             .body(new Body(mainBodyChildren))
             .build());
 
@@ -501,7 +493,7 @@ public class NormTestDataBuilder {
    * @return this builder for chaining
    */
   public NormTestDataBuilder conclusion(String text) {
-    this.document.getAct().setConclusions(Conclusions.withText(text));
+    this.document.getAct().setConclusions(new Conclusions(text));
     return this;
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/Act.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/Act.java
@@ -31,7 +31,7 @@ public class Act {
 
   @Builder.Default
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
-  private Preface preface = Preface.builder().build();
+  private Preface preface = new Preface();
 
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
   private Preamble preamble;

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/Act.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/Act.java
@@ -27,7 +27,7 @@ public class Act {
 
   @Builder.Default
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
-  private Meta meta = Meta.builder().build();
+  private Meta meta = new Meta();
 
   @Builder.Default
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/Conclusions.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/Conclusions.java
@@ -5,17 +5,13 @@ import de.bund.digitalservice.ris.builder.models.common.BaseElement;
 import de.bund.digitalservice.ris.builder.models.preamble.Formula;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /** Represents the {@code akn:conclusions} element holding the norm's closing formula. */
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class Conclusions extends BaseElement {
 
-  @Builder.Default @XmlAttribute private String eId = "schluss-n1";
+  @XmlAttribute private String eId = "schluss-n1";
 
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
   private Formula formula;
@@ -24,11 +20,8 @@ public class Conclusions extends BaseElement {
    * Creates conclusions containing a single closing formula with the given text.
    *
    * @param text the closing formula text
-   * @return the built {@link Conclusions}
    */
-  public static Conclusions withText(String text) {
-    return Conclusions.builder()
-        .formula(new Formula("schluss-n1_formel-n1", "schlussformel", text))
-        .build();
+  public Conclusions(String text) {
+    this.formula = new Formula("schluss-n1_formel-n1", "schlussformel", text);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/Conclusions.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/Conclusions.java
@@ -1,7 +1,6 @@
 package de.bund.digitalservice.ris.builder.models;
 
 import de.bund.digitalservice.ris.builder.NormTestDataBuilder;
-import de.bund.digitalservice.ris.builder.models.common.AknP;
 import de.bund.digitalservice.ris.builder.models.common.BaseElement;
 import de.bund.digitalservice.ris.builder.models.preamble.Formula;
 import jakarta.xml.bind.annotation.XmlAttribute;
@@ -29,12 +28,7 @@ public class Conclusions extends BaseElement {
    */
   public static Conclusions withText(String text) {
     return Conclusions.builder()
-        .formula(
-            Formula.builder()
-                .eId("schluss-n1_formel-n1")
-                .refersTo("schlussformel")
-                .paragraph(new AknP(text))
-                .build())
+        .formula(new Formula("schluss-n1_formel-n1", "schlussformel", text))
         .build();
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/body/AknNum.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/body/AknNum.java
@@ -1,22 +1,19 @@
 package de.bund.digitalservice.ris.builder.models.body;
 
+import de.bund.digitalservice.ris.builder.models.common.BaseElement;
+import jakarta.xml.bind.annotation.XmlAnyElement;
 import jakarta.xml.bind.annotation.XmlAttribute;
-import jakarta.xml.bind.annotation.XmlValue;
-import java.util.UUID;
 import lombok.NoArgsConstructor;
 
 /** Represents an {@code akn:num} element, e.g. the number of an article or paragraph. */
 @NoArgsConstructor
-public class AknNum {
-
-  @XmlAttribute(name = "GUID")
-  protected String guid = UUID.randomUUID().toString();
+public class AknNum extends BaseElement {
 
   @XmlAttribute private String eId = "art-z1_bezeichnung-n1";
 
   @XmlAttribute private String refersTo;
 
-  @XmlValue private String value = "§ 1";
+  @XmlAnyElement private String value = "§ 1";
 
   /**
    * Creates a num element derived from the given parent eId and display value.

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/Meta.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/Meta.java
@@ -37,6 +37,10 @@ public class Meta extends BaseElement {
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
   private Proprietary proprietary = new Proprietary();
 
+  /**
+   * Creates a Meta with the given identification, omitting lifecycle, temporal data and
+   * proprietary.
+   */
   public Meta(Identification identification) {
     this.identification = identification;
     this.lifecycle = null;

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/Meta.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/Meta.java
@@ -11,7 +11,6 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -19,27 +18,29 @@ import lombok.Setter;
 /** Represents the {@code akn:meta} element, holding identification, lifecycle and RIS metadata. */
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
 @Getter
 @Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Meta extends BaseElement {
 
-  @Builder.Default @XmlAttribute private String eId = "meta-n1";
+  @XmlAttribute private String eId = "meta-n1";
 
-  @Builder.Default
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
   private Identification identification = new Identification();
 
-  @Builder.Default
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
-  private Lifecycle lifecycle = Lifecycle.builder().build();
+  private Lifecycle lifecycle = new Lifecycle();
 
-  @Builder.Default
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
-  private TemporalData temporalData = TemporalData.builder().build();
+  private TemporalData temporalData = new TemporalData();
 
-  @Builder.Default
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
-  private Proprietary proprietary = Proprietary.builder().build();
+  private Proprietary proprietary = new Proprietary();
+
+  public Meta(Identification identification) {
+    this.identification = identification;
+    this.lifecycle = null;
+    this.temporalData = null;
+    this.proprietary = null;
+  }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/proprietary/Proprietary.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/proprietary/Proprietary.java
@@ -5,23 +5,18 @@ import de.bund.digitalservice.ris.builder.models.common.BaseElement;
 import de.bund.digitalservice.ris.builder.models.meta.proprietary.ris.RisMetadata;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /** Represents the {@code akn:proprietary} element, holding RIS-specific metadata. */
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
-@Getter
 public class Proprietary extends BaseElement {
 
-  @Builder.Default @XmlAttribute private String eId = "meta-n1_proprietary-n1";
+  @XmlAttribute private String eId = "meta-n1_proprietary-n1";
 
-  @Builder.Default @XmlAttribute private String source = "attributsemantik-noch-undefiniert";
+  @XmlAttribute private String source = "attributsemantik-noch-undefiniert";
 
-  @Builder.Default
   @XmlElement(name = "legalDocML.de_metadaten", namespace = NormTestDataBuilder.RIS_NS)
-  private RisMetadata risMetadata = RisMetadata.builder().build();
+  @Getter
+  private RisMetadata risMetadata = new RisMetadata();
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/proprietary/ris/RisAbkuerzung.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/proprietary/ris/RisAbkuerzung.java
@@ -2,17 +2,17 @@ package de.bund.digitalservice.ris.builder.models.meta.proprietary.ris;
 
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlValue;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /** Represents the {@code ris:abkuerzung} element, the norm's internal RIS abbreviation. */
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class RisAbkuerzung {
 
-  @Builder.Default @XmlAttribute private String refersTo = "interne-abkuerzung";
+  @XmlAttribute private String refersTo = "interne-abkuerzung";
 
-  @Builder.Default @XmlValue private String abbreviation = "RisAbk";
+  @XmlValue private String abbreviation = "RisAbk";
+
+  public RisAbkuerzung(String abbreviation) {
+    this.abbreviation = abbreviation;
+  }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/proprietary/ris/RisDate.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/proprietary/ris/RisDate.java
@@ -2,14 +2,12 @@ package de.bund.digitalservice.ris.builder.models.meta.proprietary.ris;
 
 import jakarta.xml.bind.annotation.XmlAttribute;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /** Represents a RIS date element, e.g. {@code ris:inkraft} or {@code ris:ausserkraft}. */
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class RisDate {
 
-  @Builder.Default @XmlAttribute private String date = "2024-01-06";
+  @XmlAttribute private String date = "2024-01-06";
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/proprietary/ris/RisMetadata.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/proprietary/ris/RisMetadata.java
@@ -3,24 +3,19 @@ package de.bund.digitalservice.ris.builder.models.meta.proprietary.ris;
 import static de.bund.digitalservice.ris.builder.NormTestDataBuilder.RIS_NS;
 
 import jakarta.xml.bind.annotation.XmlElement;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
  * Represents the {@code ris:legalDocML.de_metadaten} element, holding RIS-specific norm metadata.
  */
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class RisMetadata {
 
   private static class EmptyElement {}
 
-  @Builder.Default
   @XmlElement(name = "abkuerzung", namespace = RIS_NS)
-  private RisAbkuerzung internalAbbreviation = RisAbkuerzung.builder().build();
+  private RisAbkuerzung internalAbbreviation = new RisAbkuerzung();
 
   /**
    * Sets the RIS-internal abbreviation, or removes it if {@code null}.
@@ -31,7 +26,7 @@ public class RisMetadata {
     if (abbreviation == null) {
       this.internalAbbreviation = null;
     } else {
-      this.internalAbbreviation = RisAbkuerzung.builder().abbreviation(abbreviation).build();
+      this.internalAbbreviation = new RisAbkuerzung(abbreviation);
     }
   }
 
@@ -44,7 +39,7 @@ public class RisMetadata {
    * @param date the in-force date value
    */
   public void setInForce(String date) {
-    this.inForceDate = RisDate.builder().date(date).build();
+    this.inForceDate = new RisDate(date);
   }
 
   @XmlElement(name = "ausserkraft", namespace = RIS_NS)
@@ -56,7 +51,7 @@ public class RisMetadata {
    * @param date the out-of-force date value
    */
   public void setOutOfForce(String date) {
-    this.outOfForceDate = RisDate.builder().date(date).build();
+    this.outOfForceDate = new RisDate(date);
   }
 
   @Setter

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/temporal/TemporalData.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/temporal/TemporalData.java
@@ -7,27 +7,21 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /** Represents the {@code akn:temporalData} element, a container of {@link TemporalGroup}s. */
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class TemporalData extends BaseElement {
 
   // Starting with 2 to account for the default group
-  @Builder.Default @XmlTransient private int temporalGroupsCounter = 2;
+  @XmlTransient private int temporalGroupsCounter = 2;
 
-  @Builder.Default @XmlAttribute private String eId = "meta-n1_geltzeiten-n1";
+  @XmlAttribute private String eId = "meta-n1_geltzeiten-n1";
 
-  @Builder.Default @XmlAttribute private String source = "attributsemantik-noch-undefiniert";
+  @XmlAttribute private String source = "attributsemantik-noch-undefiniert";
 
-  @Builder.Default
   @XmlElement(name = "temporalGroup", namespace = NormTestDataBuilder.AKN_NS)
-  private List<TemporalGroup> temporalGroups =
-      new ArrayList<>(List.of(TemporalGroup.builder().build()));
+  private List<TemporalGroup> temporalGroups = new ArrayList<>(List.of(new TemporalGroup()));
 
   /**
    * Adds a temporal group linking the given lifecycle events and returns its eId.

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/temporal/TemporalGroup.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/temporal/TemporalGroup.java
@@ -5,25 +5,19 @@ import de.bund.digitalservice.ris.builder.models.common.BaseElement;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /** Represents an {@code akn:temporalGroup} element, wrapping a {@link TimeInterval}. */
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class TemporalGroup extends BaseElement {
 
-  @Builder.Default @XmlAttribute private String eId = "meta-n1_geltzeiten-n1_geltungszeitgr-n1";
+  @XmlAttribute private String eId = "meta-n1_geltzeiten-n1_geltungszeitgr-n1";
 
-  @Builder.Default
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
-  private TimeInterval timeInterval = TimeInterval.builder().build();
+  private TimeInterval timeInterval = new TimeInterval();
 
   static TemporalGroup withEventRefs(String startEventEId, String endEventEId, String groupEId) {
-    return TemporalGroup.builder()
-        .eId(groupEId)
-        .timeInterval(TimeInterval.withEventRefs(startEventEId, endEventEId, groupEId))
-        .build();
+    return new TemporalGroup(groupEId, new TimeInterval(startEventEId, endEventEId, groupEId));
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/temporal/TimeInterval.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/meta/temporal/TimeInterval.java
@@ -3,21 +3,18 @@ package de.bund.digitalservice.ris.builder.models.meta.temporal;
 import de.bund.digitalservice.ris.builder.models.common.BaseElement;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /** Represents an {@code akn:timeInterval} element, defining a period of validity. */
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class TimeInterval extends BaseElement {
 
-  @Builder.Default @XmlAttribute
-  private String eId = "meta-n1_geltzeiten-n1_geltungszeitgr-n1_gelzeitintervall-n1";
+  @XmlAttribute private String eId = "meta-n1_geltzeiten-n1_geltungszeitgr-n1_gelzeitintervall-n1";
 
-  @Builder.Default @XmlAttribute private String refersTo = "geltungszeit";
+  @XmlAttribute private String refersTo = "geltungszeit";
 
-  @Builder.Default @XmlAttribute private String start = "#meta-n1_lebzykl-n1_ereignis-n2";
+  @XmlAttribute private String start = "#meta-n1_lebzykl-n1_ereignis-n2";
 
   @XmlAttribute private String end;
 
@@ -27,14 +24,10 @@ public class TimeInterval extends BaseElement {
    * @param startEventEId reference to the event the interval starts at
    * @param endEventEId reference to the event the interval ends at
    * @param parentEId eId of the enclosing {@link TemporalGroup}, used to derive this element's eId
-   * @return the built {@link TimeInterval}
    */
-  public static TimeInterval withEventRefs(
-      String startEventEId, String endEventEId, String parentEId) {
-    return TimeInterval.builder()
-        .eId(parentEId + "_gelzeitintervall-n1")
-        .start(startEventEId)
-        .end(endEventEId)
-        .build();
+  public TimeInterval(String startEventEId, String endEventEId, String parentEId) {
+    this.eId = parentEId + "_gelzeitintervall-n1";
+    this.start = startEventEId;
+    this.end = endEventEId;
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preamble/BlockContainer.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preamble/BlockContainer.java
@@ -6,26 +6,24 @@ import de.bund.digitalservice.ris.builder.models.common.Heading;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /** Represents an {@code akn:blockContainer} element holding the table of contents. */
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class BlockContainer extends BaseElement {
 
-  @Builder.Default @XmlAttribute private String eId = "präambel-n1_blockcontainer-n1";
+  @XmlAttribute private String eId = "präambel-n1_blockcontainer-n1";
 
-  @Builder.Default @XmlAttribute private String refersTo = "inhaltsuebersicht";
+  @XmlAttribute private String refersTo = "inhaltsuebersicht";
 
-  @Builder.Default
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
   private Heading heading =
       new Heading("präambel-n1_blockcontainer-n1_überschrift-n1", List.of("Inhaltsverzeichnis"));
 
-  @Builder.Default
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
-  private Toc toc = Toc.builder().build();
+  private Toc toc = new Toc();
+
+  public BlockContainer(Toc toc) {
+    this.toc = toc;
+  }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preamble/Formula.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preamble/Formula.java
@@ -5,32 +5,41 @@ import de.bund.digitalservice.ris.builder.models.common.AknP;
 import de.bund.digitalservice.ris.builder.models.common.BaseElement;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /** Represents an {@code akn:formula} element, e.g. the norm's enacting formula (Eingangsformel). */
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class Formula extends BaseElement {
 
-  @Builder.Default @XmlAttribute private String eId = "präambel-n1_formel-n1";
+  @XmlAttribute private String eId = "präambel-n1_formel-n1";
 
-  @Builder.Default @XmlAttribute private String refersTo = "eingangsformel";
+  @XmlAttribute private String refersTo = "eingangsformel";
 
-  @Builder.Default @XmlAttribute private String name = "attributsemantik-noch-undefiniert";
+  @XmlAttribute private String name = "attributsemantik-noch-undefiniert";
 
   @XmlElement(name = "p", namespace = NormTestDataBuilder.AKN_NS)
   private AknP paragraph;
 
   /**
+   * Creates a formula with the given eId,.
+   *
+   * @param eId the Elements eId
+   * @param refersTo what the formula refers to
+   * @param text the formula text
+   */
+  public Formula(String eId, String refersTo, String text) {
+    this(text);
+    this.eId = eId;
+    this.refersTo = refersTo;
+  }
+
+  /**
    * Creates a formula containing a single paragraph with the given text.
    *
    * @param text the formula text
-   * @return the built {@link Formula}
    */
-  public static Formula withText(String text) {
-    return Formula.builder().paragraph(new AknP("präambel-n1_formel-n1", text)).build();
+  public Formula(String text) {
+    this();
+    this.paragraph = new AknP("präambel-n1_formel-n1", text);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preamble/Preamble.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preamble/Preamble.java
@@ -4,17 +4,13 @@ import de.bund.digitalservice.ris.builder.NormTestDataBuilder;
 import de.bund.digitalservice.ris.builder.models.common.BaseElement;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /** Represents the {@code akn:preamble} element, holding the table of contents and formula. */
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class Preamble extends BaseElement {
 
-  @Builder.Default @XmlAttribute private String eId = "präambel-n1";
+  @XmlAttribute private String eId = "präambel-n1";
 
   // This holds the ToC
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
@@ -24,7 +20,7 @@ public class Preamble extends BaseElement {
   private Formula formula;
 
   public void addFormula(String text) {
-    this.formula = Formula.withText(text);
+    this.formula = new Formula(text);
   }
 
   /**
@@ -33,8 +29,8 @@ public class Preamble extends BaseElement {
    * @return the created {@link Toc}
    */
   public Toc addToc() {
-    Toc toc = Toc.builder().build();
-    this.blockContainer = BlockContainer.builder().toc(toc).build();
+    Toc toc = new Toc();
+    this.blockContainer = new BlockContainer(toc);
 
     return toc;
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preamble/Toc.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preamble/Toc.java
@@ -4,24 +4,19 @@ import de.bund.digitalservice.ris.builder.NormTestDataBuilder;
 import de.bund.digitalservice.ris.builder.models.common.BaseElement;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlTransient;
 import java.util.ArrayList;
 import java.util.List;
-import kotlin.jvm.Transient;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /** Represents the {@code akn:toc} element, the norm's table of contents. */
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class Toc extends BaseElement {
 
-  @Builder.Default @Transient private int tocEntriesCounter = 0;
+  @XmlTransient private int tocEntriesCounter = 0;
 
-  @Builder.Default @XmlAttribute private String eId = "präambel-n1_blockcontainer-n1_inhuebs-n1";
+  @XmlAttribute private String eId = "präambel-n1_blockcontainer-n1_inhuebs-n1";
 
-  @Builder.Default
   @XmlElement(name = "tocItem", namespace = NormTestDataBuilder.AKN_NS)
   private List<TocItem> tocItems = new ArrayList<>();
 
@@ -35,7 +30,7 @@ public class Toc extends BaseElement {
   public Toc addEntry(String text, String level) {
     this.tocEntriesCounter++;
     tocItems.add(
-        TocItem.withTextAndLevel(
+        new TocItem(
             text, level, "präambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n" + tocEntriesCounter));
 
     return this;

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preamble/TocItem.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preamble/TocItem.java
@@ -5,23 +5,18 @@ import de.bund.digitalservice.ris.builder.models.common.BaseElement;
 import de.bund.digitalservice.ris.builder.models.common.Span;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /** Represents an {@code akn:tocItem} element, a single entry in the table of contents. */
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class TocItem extends BaseElement {
 
-  @Builder.Default @XmlAttribute private String eId = "eintrag-n1";
+  @XmlAttribute private String eId = "eintrag-n1";
 
-  @Builder.Default @XmlAttribute private String href = "";
+  @XmlAttribute private String href = "";
 
-  @Builder.Default @XmlAttribute private String level = "1";
+  @XmlAttribute private String level = "1";
 
-  @Builder.Default
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
   private Span span = new Span("Eintrag 1");
 
@@ -33,7 +28,9 @@ public class TocItem extends BaseElement {
    * @param eId the eId of the entry
    * @return the built {@link TocItem}
    */
-  public static TocItem withTextAndLevel(String text, String level, String eId) {
-    return TocItem.builder().level(level).eId(eId).span(new Span(eId + "_span-n1", text)).build();
+  public TocItem(String text, String level, String eId) {
+    this.eId = eId;
+    this.span = new Span(eId + "_span-n1", text);
+    this.level = level;
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preface/DocStage.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preface/DocStage.java
@@ -1,24 +1,15 @@
 package de.bund.digitalservice.ris.builder.models.preface;
 
 import de.bund.digitalservice.ris.builder.NormTestDataBuilder;
+import de.bund.digitalservice.ris.builder.models.common.BaseElement;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /** Represents the {@code akn:docStage} element, e.g. the norm's promulgation stage marker. */
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
 @XmlRootElement(namespace = NormTestDataBuilder.AKN_NS)
-public class DocStage {
+public class DocStage extends BaseElement {
 
-  @Builder.Default
-  @XmlAttribute(name = "GUID")
-  String guid = UUID.randomUUID().toString();
-
-  @Builder.Default @XmlAttribute
-  private String eId = "einleitung-n1_doktitel-n1_text-n1_docstadium-n1";
+  @XmlAttribute private String eId = "einleitung-n1_doktitel-n1_text-n1_docstadium-n1";
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preface/DocTitle.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preface/DocTitle.java
@@ -1,32 +1,27 @@
 package de.bund.digitalservice.ris.builder.models.preface;
 
 import de.bund.digitalservice.ris.builder.NormTestDataBuilder;
+import de.bund.digitalservice.ris.builder.models.common.BaseElement;
 import jakarta.xml.bind.annotation.XmlAnyElement;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /** Represents the {@code akn:docTitle} element, the norm's official title (Langtitel). */
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
-@Getter
 @XmlRootElement(namespace = NormTestDataBuilder.AKN_NS)
-public class DocTitle {
+public class DocTitle extends BaseElement {
 
-  @Builder.Default
-  @XmlAttribute(name = "GUID")
-  private String guid = UUID.randomUUID().toString();
+  @XmlAttribute private String eId = "einleitung-n1_doktitel-n1_text-n1_doctitel-n1";
 
-  @Builder.Default @XmlAttribute
-  private String eId = "einleitung-n1_doktitel-n1_text-n1_doctitel-n1";
+  @XmlAnyElement @Getter private List<Object> children = new ArrayList<>(List.of("Test Gesetz"));
 
-  @Builder.Default @XmlAnyElement
-  private List<Object> children = new ArrayList<>(List.of("Test Gesetz"));
+  public DocTitle(List<Object> children) {
+    this.children = new ArrayList<>(children);
+  }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preface/LongTitle.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preface/LongTitle.java
@@ -34,11 +34,7 @@ public class LongTitle extends BaseElement {
   @XmlElement(name = "p", namespace = NormTestDataBuilder.AKN_NS)
   private AknP paragraph =
       new AknP(
-          "einleitung-n1_doktitel-n1",
-          List.of(
-              DocStage.builder().build(),
-              DocTitle.builder().build(),
-              ShortTitle.builder().build()));
+          "einleitung-n1_doktitel-n1", List.of(new DocStage(), new DocTitle(), new ShortTitle()));
 
   /**
    * Sets the official title and rebuilds the paragraph.
@@ -49,8 +45,7 @@ public class LongTitle extends BaseElement {
     if (officialTitle == null) {
       this.officialTitle = null;
     } else {
-      this.officialTitle =
-          DocTitle.builder().children(new ArrayList<>(List.of(officialTitle))).build();
+      this.officialTitle = new DocTitle(List.of(officialTitle));
     }
 
     setTitlesAndAbbreviation();
@@ -78,7 +73,7 @@ public class LongTitle extends BaseElement {
 
   private void setTitlesAndAbbreviation() {
     List<Object> childElements = new ArrayList<>();
-    childElements.add(DocStage.builder().build());
+    childElements.add(new DocStage());
 
     if (this.officialTitle != null) {
       childElements.add(this.officialTitle);

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preface/Preface.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preface/Preface.java
@@ -9,30 +9,27 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 /** Represents the {@code akn:preface} element, holding the norm's title and legislation date. */
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
-@Setter
-@Getter
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Preface extends BaseElement {
 
-  @Builder.Default @XmlAttribute private String eId = "einleitung-n1";
+  @XmlAttribute private String eId = "einleitung-n1";
 
-  @Builder.Default
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
-  private LongTitle longTitle = LongTitle.builder().build();
+  @Getter
+  private LongTitle longTitle = new LongTitle();
 
-  @Builder.Default
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
   private Block block = buildLegislationDateBlock("2002-01-01");
+
+  public Preface(Block block) {
+    this.longTitle = null;
+    this.block = block;
+  }
 
   public void setLegislationDate(String date) {
     this.block = buildLegislationDateBlock(date);

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preface/Preface.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preface/Preface.java
@@ -26,6 +26,7 @@ public class Preface extends BaseElement {
   @XmlElement(namespace = NormTestDataBuilder.AKN_NS)
   private Block block = buildLegislationDateBlock("2002-01-01");
 
+  /** Creates a Preface with the given block, without a long title. */
   public Preface(Block block) {
     this.longTitle = null;
     this.block = block;

--- a/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preface/ShortTitle.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/builder/models/preface/ShortTitle.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.builder.models.preface;
 
 import de.bund.digitalservice.ris.builder.NormTestDataBuilder;
+import de.bund.digitalservice.ris.builder.models.common.BaseElement;
 import de.bund.digitalservice.ris.builder.models.common.Inline;
 import jakarta.xml.bind.annotation.XmlAnyElement;
 import jakarta.xml.bind.annotation.XmlAttribute;
@@ -9,18 +10,13 @@ import jakarta.xml.bind.annotation.XmlSeeAlso;
 import jakarta.xml.bind.annotation.XmlTransient;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /** Represents the {@code akn:shortTitle} element, the norm's short title (Kurztitel). */
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @XmlSeeAlso({Inline.class})
 @XmlRootElement(namespace = NormTestDataBuilder.AKN_NS)
-public class ShortTitle {
+public class ShortTitle extends BaseElement {
 
   @XmlTransient private String shortTitle;
 
@@ -28,15 +24,9 @@ public class ShortTitle {
 
   @XmlTransient private Inline abbreviation;
 
-  @Builder.Default @XmlAttribute
-  private String eId = "einleitung-n1_doktitel-n1_text-n1_kurztitel-n1";
+  @XmlAttribute private String eId = "einleitung-n1_doktitel-n1_text-n1_kurztitel-n1";
 
-  @Builder.Default
-  @XmlAttribute(name = "GUID")
-  private String guid = UUID.randomUUID().toString();
-
-  @Builder.Default @XmlAnyElement
-  private List<Object> children = List.of("Short Title of the Legislation");
+  @XmlAnyElement private List<Object> children = List.of("Short Title of the Legislation");
 
   /**
    * Sets the short title text and suffix, and rebuilds the element's children.


### PR DESCRIPTION
- on the remaining model classes, use normal constructors when less than 4 arguments are needed for construction

RISDEV-11960