### PR TITLE
RISDEV-11065 show validity end date in search result header

### DIFF
--- a/frontend/e2e/suche.spec.ts
+++ b/frontend/e2e/suche.spec.ts
@@ -319,6 +319,20 @@ test.describe("searching legislation", () => {
     ).toBeVisible();
   });
 
+  test("shows from and to date when it exists and private features are enabled", async ({
+    page,
+    privateFeaturesEnabled,
+  }) => {
+    test.skip(!privateFeaturesEnabled);
+    await navigate(
+      page,
+      "/suche?query=Heimaturlaubsberechtigung&documentKind=N",
+    );
+
+    const searchResult = getSearchResults(page).first();
+    await expect(searchResult).toHaveText(/01\.04\.1990 - 31\.12\.1990/);
+  });
+
   test("doesn't show article highlights without a direct text match when private features are enabled", async ({
     page,
     privateFeaturesEnabled,

--- a/frontend/src/components/search/NormSearchResult.spec.ts
+++ b/frontend/src/components/search/NormSearchResult.spec.ts
@@ -134,6 +134,24 @@ describe("NormSearchResult", () => {
     expect(highlightSection).toHaveLength(4);
   });
 
+  describe("temporal coverage date display with private features enabled", () => {
+    beforeEach(() => {
+      mocks.usePrivateFeaturesFlag.mockReturnValue(true);
+    });
+
+    it("shows only from date when temporal coverage has no to date", () => {
+      renderComponent(withTemporalCoverage("2000-01-01/.."));
+      expect(screen.getByText("01.01.2000")).toBeInTheDocument();
+      // Does not add a dash if no validity end date exists
+      expect(screen.queryByText("01.01.2000 -")).not.toBeInTheDocument();
+    });
+
+    it("shows from and to date when temporal coverage has both", () => {
+      renderComponent(withTemporalCoverage("2000-01-01/2024-12-31"));
+      expect(screen.getByText("01.01.2000 - 31.12.2024")).toBeInTheDocument();
+    });
+  });
+
   it("renders ausfertigungs datum when in prototype environment", () => {
     renderComponent();
     expect(screen.getByText("14.12.1999")).toBeInTheDocument();

--- a/frontend/src/components/search/NormSearchResult.vue
+++ b/frontend/src/components/search/NormSearchResult.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { Dayjs } from "dayjs";
 import IcBaselineBalance from "~icons/ic/baseline-balance";
 import type { RouteLocationRaw, RouteLocationAsPath } from "#vue-router";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
@@ -31,20 +30,23 @@ const secondaryTitle = computed<SearchResultHeaderItem | undefined>(() =>
 const resultTypeId = useId();
 
 const headerItems = computed<SearchResultHeaderItem[]>(() => {
-  let date: string | Dayjs | undefined =
-    searchResult.item.exampleOfWork.legislationDate;
+  let dateValue: string | undefined = dateFormattedDDMMYYYY(
+    searchResult.item.exampleOfWork.legislationDate,
+  );
 
   if (privateFeaturesEnabled) {
     const coverage = temporalCoverageToValidityInterval(
       searchResult.item.temporalCoverage,
     );
-    date = coverage?.from;
+    const from = dateFormattedDDMMYYYY(coverage?.from);
+    const to = dateFormattedDDMMYYYY(coverage?.to);
+    dateValue = from && to ? `${from} - ${to}` : from;
   }
 
   return [
     { value: "Norm", id: resultTypeId },
     { value: searchResult.item.abbreviation },
-    { value: dateFormattedDDMMYYYY(date) },
+    { value: dateValue },
   ].filter((i): i is SearchResultHeaderItem => i.value !== undefined);
 });
 


### PR DESCRIPTION
- in none prototype environment: show validity  from - to date in search result header if a "to" date exists

RISDEV-11065