### PR TITLE
RISDEV-11721 apply Sentry default error reporting to more error sources

### DIFF
--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -7,5 +7,12 @@ if (config.public.sentryDSN) {
     dsn: config.public.sentryDSN,
     environment: config.public.sentryEnvironment,
     tracesSampleRate: 1,
+
+    beforeSend(event, hint) {
+      const error = hint.originalException;
+      const shouldSuppress = isNuxtError(error) && error.status === 404;
+
+      return shouldSuppress ? null : event;
+    },
   });
 }

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -8,9 +8,16 @@ if (config.public.sentryDSN) {
     environment: config.public.sentryEnvironment,
     tracesSampleRate: 1,
 
+    // Errors thrown via `createError` (e.g. 404s) surface through Nuxt's
+    // `vue:error` hook, which the Sentry SDK reports without filtering by status
+    // code (unlike its `app:error` hook). Drop client errors here so they don't
+    // reach Sentry. Client-only: the server side already filters these via the
+    // Nitro error handler.
     beforeSend(event, hint) {
       const error = hint.originalException;
-      const shouldSuppress = isNuxtError(error) && error.status === 404;
+      const status = isNuxtError(error) ? error.status : undefined;
+      const shouldSuppress =
+        status !== undefined && status >= 300 && status < 500;
 
       return shouldSuppress ? null : event;
     },

--- a/frontend/src/composables/useFetchNormContent.ts
+++ b/frontend/src/composables/useFetchNormContent.ts
@@ -220,12 +220,13 @@ function getContentUrl(metadata: LegislationExpression) {
   const encoding = metadata?.encoding?.find(
     (e) => e.encodingFormat === "text/html",
   );
+
   const contentUrl = encoding?.contentUrl;
-  if (contentUrl) {
-    console.info("using manifestation", encoding?.["@id"]);
-  } else {
-    console.error("contentUrl is missing", metadata?.encoding);
-    throw new Error("contentUrl is missing");
+
+  if (!contentUrl) {
+    throw new Error("contentUrl is missing", {
+      cause: { encoding: metadata?.encoding },
+    });
   }
 
   return contentUrl;


### PR DESCRIPTION
This PR adds manual error filtering for 3xx-4xx error codes thrown via `showError` and `createError`. This matches the default behavior of the Sentry SDK on the server and client side for errors thrown via other channels.

See Sentry SDK for [client](https://github.com/getsentry/sentry-javascript/blob/61b7d52d721e181f86f30620928ef0fb39cdf42f/packages/nuxt/src/runtime/plugins/sentry.client.ts#L71) and [server](https://github.com/getsentry/sentry-javascript/blob/61b7d52d721e181f86f30620928ef0fb39cdf42f/packages/nuxt/src/runtime/hooks/captureErrorHook.ts#L24)