### PR TITLE
RISDEV-11454 drop chunk loading errors

### DIFF
--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -21,5 +21,18 @@ if (config.public.sentryDSN) {
 
       return shouldSuppress ? null : event;
     },
+
+    ignoreErrors: [
+      // Client-side chunk loading errors (e.g. after a deployment invalidates
+      // old hashed chunk URLs) are already handled by Nuxt's
+      // `nuxt:chunk-reload` plugin, which performs a hard reload. Sentry
+      // reports them as unhandles errors even though the user is not affected.
+      // Drop them as noise. The wording differs per browser.
+      //
+      // See https://nuxt.com/docs/4.x/getting-started/error-handling#errors-with-js-chunks
+      /Failed to fetch dynamically imported module/, // Chrome
+      /error loading dynamically imported module/, // Firefox
+      /Importing a module script failed/, // Safari
+    ],
   });
 }


### PR DESCRIPTION
Client-side chunk loading errors (e.g. after a deployment invalidates old hashed chunk URLs) are already handled by Nuxt's `nuxt:chunk-reload` plugin, which performs a hard reload. Sentry reports them as unhandles errors even though the user is not affected. Drop them as noise.

See https://nuxt.com/docs/4.x/getting-started/error-handling#errors-with-js-chunks