### PR TITLE
RISDEV-9129 hide text tab for empty norms

### DIFF
--- a/backend/e2e-data/norm/eli/bund/bgbl-1/2025/999/2025-01-01/1/deu/2025-01-01/regelungstext-1.xml
+++ b/backend/e2e-data/norm/eli/bund/bgbl-1/2025/999/2025-01-01/1/deu/2025-01-01/regelungstext-1.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="Grammatiken/Norms/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.8.2/"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://MetadatenRIS.LegalDocML.de/1.8.2/ Grammatiken/Norms/legalDocML.de-metadaten-ris.xsd http://MetadatenRegelungstext.LegalDocML.de/1.8.2/ Grammatiken/legalDocML.de-metadaten-regelungstext.xsd http://MetadatenRechtsetzungsdokument.LegalDocML.de/1.8.2/ Grammatiken/legalDocML.de-metadaten-rechtsetzungsdokument.xsd http://Inhaltsdaten.LegalDocML.de/1.8.2/ Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+    <akn:act name="/akn/ontology/de/concept/documenttype/bund/regelungstext-verkuendung">
+        <akn:meta GUID="a1000000-0000-0000-0000-000000000001" eId="meta-n1">
+            <akn:identification GUID="a1000000-0000-0000-0000-000000000002" eId="meta-n1_ident-n1" source="attributsemantik-noch-undefiniert">
+                <akn:FRBRWork GUID="a1000000-0000-0000-0000-000000000003" eId="meta-n1_ident-n1_frbrwork-n1">
+                    <akn:FRBRthis GUID="a1000000-0000-0000-0000-000000000004" eId="meta-n1_ident-n1_frbrwork-n1_frbrthis-n1" value="eli/bund/bgbl-1/2025/999/regelungstext-1"/>
+                    <akn:FRBRuri GUID="a1000000-0000-0000-0000-000000000005" eId="meta-n1_ident-n1_frbrwork-n1_frbruri-n1" value="eli/bund/bgbl-1/2025/999"/>
+                    <akn:FRBRalias GUID="a1000000-0000-0000-0000-000000000006" eId="meta-n1_ident-n1_frbrwork-n1_frbralias-n1" name="übergreifende-id" value="a1000000-0000-0000-0000-000000000099"/>
+                    <akn:FRBRdate GUID="a1000000-0000-0000-0000-000000000007" date="2025-01-01" eId="meta-n1_ident-n1_frbrwork-n1_frbrdate-n1" name="verkuendungsfassung-verkuendungsdatum"/>
+                    <akn:FRBRauthor GUID="a1000000-0000-0000-0000-000000000008" eId="meta-n1_ident-n1_frbrwork-n1_frbrauthor-n1" href="recht.bund.de/institution/bundesregierung"/>
+                    <akn:FRBRcountry GUID="a1000000-0000-0000-0000-000000000009" eId="meta-n1_ident-n1_frbrwork-n1_frbrcountry-n1" value="de"/>
+                    <akn:FRBRnumber GUID="a1000000-0000-0000-0000-000000000010" eId="meta-n1_ident-n1_frbrwork-n1_frbrnumber-n1" value="999"/>
+                    <akn:FRBRname GUID="a1000000-0000-0000-0000-000000000011" eId="meta-n1_ident-n1_frbrwork-n1_frbrname-n1" value="bgbl-1"/>
+                    <akn:FRBRsubtype GUID="a1000000-0000-0000-0000-000000000012" eId="meta-n1_ident-n1_frbrwork-n1_frbrsubtype-n1" value="regelungstext-1"/>
+                </akn:FRBRWork>
+                <akn:FRBRExpression GUID="a1000000-0000-0000-0000-000000000013" eId="meta-n1_ident-n1_frbrexpression-n1">
+                    <akn:FRBRthis GUID="a1000000-0000-0000-0000-000000000014" eId="meta-n1_ident-n1_frbrexpression-n1_frbrthis-n1" value="eli/bund/bgbl-1/2025/999/2025-01-01/1/deu/regelungstext-1"/>
+                    <akn:FRBRuri GUID="a1000000-0000-0000-0000-000000000015" eId="meta-n1_ident-n1_frbrexpression-n1_frbruri-n1" value="eli/bund/bgbl-1/2025/999/2025-01-01/1/deu"/>
+                    <akn:FRBRalias GUID="a1000000-0000-0000-0000-000000000016" eId="meta-n1_ident-n1_frbrexpression-n1_frbralias-n1" name="aktuelle-version-id" value="a1000000-0000-0000-0000-000000000098"/>
+                    <akn:FRBRauthor GUID="a1000000-0000-0000-0000-000000000017" eId="meta-n1_ident-n1_frbrexpression-n1_frbrauthor-n1" href="recht.bund.de/institution/bundesregierung"/>
+                    <akn:FRBRdate GUID="a1000000-0000-0000-0000-000000000018" date="2025-01-01" eId="meta-n1_ident-n1_frbrexpression-n1_frbrdate-n1" name="verkuendung"/>
+                    <akn:FRBRlanguage GUID="a1000000-0000-0000-0000-000000000019" eId="meta-n1_ident-n1_frbrexpression-n1_frbrlanguage-n1" language="deu"/>
+                    <akn:FRBRversionNumber GUID="a1000000-0000-0000-0000-000000000020" eId="meta-n1_ident-n1_frbrexpression-n1_frbrversionnumber-n1" value="1"/>
+                </akn:FRBRExpression>
+                <akn:FRBRManifestation GUID="a1000000-0000-0000-0000-000000000021" eId="meta-n1_ident-n1_frbrmanifestation-n1">
+                    <akn:FRBRthis GUID="a1000000-0000-0000-0000-000000000022" eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrthis-n1" value="eli/bund/bgbl-1/2025/999/2025-01-01/1/deu/2025-01-01/regelungstext-1.xml"/>
+                    <akn:FRBRuri GUID="a1000000-0000-0000-0000-000000000023" eId="meta-n1_ident-n1_frbrmanifestation-n1_frbruri-n1" value="eli/bund/bgbl-1/2025/999/2025-01-01/1/deu/2025-01-01/regelungstext-1.xml"/>
+                    <akn:FRBRdate GUID="a1000000-0000-0000-0000-000000000024" date="2025-01-01" eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrdate-n1" name="generierung"/>
+                    <akn:FRBRauthor GUID="a1000000-0000-0000-0000-000000000025" eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrauthor-n1" href="recht.bund.de"/>
+                    <akn:FRBRformat GUID="a1000000-0000-0000-0000-000000000026" eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrformat-n1" value="xml"/>
+                </akn:FRBRManifestation>
+            </akn:identification>
+            <akn:lifecycle GUID="a1000000-0000-0000-0000-000000000027" eId="meta-n1_lebzykl-n1" source="attributsemantik-noch-undefiniert">
+                <akn:eventRef GUID="a1000000-0000-0000-0000-000000000028" date="2025-01-01" eId="meta-n1_lebzykl-n1_ereignis-n1" refersTo="ausfertigung" source="attributsemantik-noch-undefiniert" type="generation"/>
+            </akn:lifecycle>
+            <akn:temporalData GUID="a1000000-0000-0000-0000-000000000029" eId="meta-n1_geltzeiten-n1" source="attributsemantik-noch-undefiniert">
+                <akn:temporalGroup GUID="a1000000-0000-0000-0000-000000000030" eId="meta-n1_geltzeiten-n1_geltungszeitgr-n1">
+                    <akn:timeInterval GUID="a1000000-0000-0000-0000-000000000031" eId="meta-n1_geltzeiten-n1_geltungszeitgr-n1_gelzeitintervall-n1" refersTo="geltungszeit" start="#meta-n1_lebzykl-n1_ereignis-n1"/>
+                </akn:temporalGroup>
+            </akn:temporalData>
+            <akn:proprietary GUID="a1000000-0000-0000-0000-000000000032" eId="meta-n1_proprietary-n1" source="attributsemantik-noch-undefiniert">
+                <ris:legalDocML.de_metadaten xmlns:ris="http://MetadatenRIS.LegalDocML.de/1.8.2/" xsi:schemaLocation="http://MetadatenRIS.LegalDocML.de/1.8.2/ ../schema/legalDocML.de-metadaten-ris.xsd">
+                    <ris:abkuerzung refersTo="interne-abkuerzung">EmptyBodyTestG</ris:abkuerzung>
+                    <ris:inkraft date="2025-01-01"/>
+                </ris:legalDocML.de_metadaten>
+            </akn:proprietary>
+        </akn:meta>
+        <akn:preface GUID="a1000000-0000-0000-0000-000000000033" eId="einleitung-n1">
+            <akn:longTitle GUID="a1000000-0000-0000-0000-000000000034" eId="einleitung-n1_doktitel-n1">
+                <akn:p GUID="a1000000-0000-0000-0000-000000000035" eId="einleitung-n1_doktitel-n1_text-n1">
+                    <akn:docTitle GUID="a1000000-0000-0000-0000-000000000036" eId="einleitung-n1_doktitel-n1_text-n1_doctitel-n1">Gesetz mit leerem Gesetzestext</akn:docTitle>
+                    <akn:shortTitle GUID="a1000000-0000-0000-0000-000000000037" eId="einleitung-n1_doktitel-n1_text-n1_kurztitel-n1">(EmptyBodyTestG)</akn:shortTitle>
+                </akn:p>
+            </akn:longTitle>
+        </akn:preface>
+        <akn:body GUID="a1000000-0000-0000-0000-000000000038" eId="hauptteil-n1">
+        </akn:body>
+    </akn:act>
+</akn:akomaNtoso>

--- a/frontend/e2e/gesetze.spec.ts
+++ b/frontend/e2e/gesetze.spec.ts
@@ -6,6 +6,16 @@ import {
 } from "./utils/actionMenuHelper";
 import { expect, navigate, noJsTest, test } from "./utils/fixtures";
 
+test.describe("empty norm (no text content)", () => {
+  test("does not show the Text tab when the norm body is empty", async ({
+    page,
+  }) => {
+    await navigate(page, "/gesetze/eli/bund/bgbl-1/2025/999/2025-01-01/1/deu");
+
+    await expect(page.getByRole("tab", { name: "Text" })).toHaveCount(0);
+  });
+});
+
 test.describe("view norm page", async () => {
   test.setTimeout(60000);
 

--- a/frontend/e2e/suche.spec.ts
+++ b/frontend/e2e/suche.spec.ts
@@ -773,7 +773,7 @@ test.describe("searching caselaw", () => {
       .getByRole("button", { name: "Alle Dokumentarten" })
       .click();
 
-    await expect(getResultCounter(page)).toHaveText("40 Suchergebnisse");
+    await expect(getResultCounter(page)).toHaveText("41 Suchergebnisse");
 
     // Verify caselaw-specific filters are reset
     await expect(page).not.toHaveURL(/documentKind=R/);

--- a/frontend/src/composables/useFetchNormContent.spec.ts
+++ b/frontend/src/composables/useFetchNormContent.spec.ts
@@ -70,7 +70,7 @@ describe("useFetchNormContent", () => {
           <dd class="ris-standangabe" data-type="hinweis">Stand-Hinweis 2</dd>
       </dl>
    </section>
-   <div>Test HTML content</div>`;
+   <div class="akn-body">Test HTML content</div>`;
 
     mockFetch.mockReturnValueOnce(mockMetadata);
     mockFetch.mockReturnValueOnce(
@@ -92,6 +92,7 @@ describe("useFetchNormContent", () => {
         vollzitat: "Vollzitat",
         body: expectedHtml,
       },
+      hasEmptyBody: false,
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
@@ -229,5 +230,25 @@ describe("useFetchNormContent", () => {
     expect(
       doc.querySelector("#meta-n1_editfnote-n3_text-n1")?.textContent,
     ).toBe("Inhaltsübersicht: präambel Fußnote");
+  });
+
+  it("sets hasEmptyBody to false if akn-body has content", async () => {
+    mockFetch.mockReturnValueOnce(mockMetadata);
+    mockFetch.mockReturnValueOnce(
+      `<html><body><div class="akn-act"><div class="akn-body">Content</div></div></body></html>`,
+    );
+
+    const { data } = await useFetchNormContent(expressionEli);
+    expect(data.value.hasEmptyBody).toBe(false);
+  });
+
+  it("sets hasEmptyBody to true if akn-body div is empty", async () => {
+    mockFetch.mockReturnValueOnce(mockMetadata);
+    mockFetch.mockReturnValueOnce(
+      `<html><body><div class="akn-act"><div class="akn-body"></div></div></body></html>`,
+    );
+
+    const { data } = await useFetchNormContent(expressionEli);
+    expect(data.value.hasEmptyBody).toBe(true);
   });
 });

--- a/frontend/src/composables/useFetchNormContent.ts
+++ b/frontend/src/composables/useFetchNormContent.ts
@@ -16,6 +16,7 @@ export type NormContent = {
     standangabenHinweis?: string[];
     body: string;
   };
+  hasEmptyBody: boolean;
 };
 
 export type UseFetchNormContentOptions = {
@@ -62,6 +63,7 @@ export function useFetchNormContent(
       return {
         legislation: metadata,
         htmlParts,
+        hasEmptyBody: isNormBodyEmpty(document),
       };
     },
     { server: true, lazy: false },

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -143,26 +143,31 @@ const metadataItems = computed(() => {
   ];
 });
 
-const views: OneOrMore<TabView> = [
-  {
+const views = computed<OneOrMore<TabView>>(() => {
+  const baseViews: OneOrMore<TabView> = [
+    {
+      path: "details",
+      label: "Details",
+      icon: IcOutlineInfo,
+      analyticsId: "norm-metadata-tab",
+    },
+    {
+      path: "versions",
+      label: "Fassungen",
+      icon: IcOutlineRestore,
+      analyticsId: "norm-versions-tab",
+    },
+  ] as const;
+
+  const textTab = {
     path: "text",
     label: "Text",
     icon: IcBaselineSubject,
     analyticsId: "norm-text-tab",
-  },
-  {
-    path: "details",
-    label: "Details",
-    icon: IcOutlineInfo,
-    analyticsId: "norm-metadata-tab",
-  },
-  {
-    path: "versions",
-    label: "Fassungen",
-    icon: IcOutlineRestore,
-    analyticsId: "norm-versions-tab",
-  },
-] as const;
+  } as const;
+
+  return data.value.hasEmptyBody ? baseViews : [textTab, ...baseViews];
+});
 
 const { dateFilterValue: fassungenDateFilterValue, filteredNormVersions } =
   useNormVersionFilter(normVersions);

--- a/frontend/src/utils/htmlParser.ts
+++ b/frontend/src/utils/htmlParser.ts
@@ -64,7 +64,7 @@ export function getTextFromElements(elements?: NodeListOf<Element>): string[] {
  * empty if the html `<body>` is empty or contains only a single headline
  * (`<h1>`).
  *
- * @param htmlDocument
+ * @param document
  */
 export function isDocumentEmpty(document?: Document): boolean {
   if (!document) {

--- a/frontend/src/utils/norm.spec.ts
+++ b/frontend/src/utils/norm.spec.ts
@@ -7,6 +7,7 @@ import type { LegislationExpression } from "~/types/api";
 import {
   getMostRelevantExpression,
   getValidityStatus,
+  isNormDocumentEmpty,
   temporalCoverageToValidityInterval,
   type ValidityInterval,
 } from "~/utils/norm";
@@ -253,5 +254,40 @@ describe("getNormMetadataItems", () => {
       "06.05.2025",
       "31.03.2037",
     ]);
+  });
+});
+
+describe("isNormDocumentEmpty", () => {
+  it("returns true if no document is given", () => {
+    expect(isNormDocumentEmpty(undefined)).toBe(true);
+  });
+
+  it("returns true if the document has no akn-body div", () => {
+    const doc = new DOMParser().parseFromString("<div></div>", "text/html");
+    expect(isNormDocumentEmpty(doc)).toBe(true);
+  });
+
+  it("returns true if the akn-body div is empty", () => {
+    const doc = new DOMParser().parseFromString(
+      '<div class="akn-body"></div>',
+      "text/html",
+    );
+    expect(isNormDocumentEmpty(doc)).toBe(true);
+  });
+
+  it("returns true if the akn-body div contains only whitespaces", () => {
+    const doc = new DOMParser().parseFromString(
+      '<div class="akn-body">   </div>',
+      "text/html",
+    );
+    expect(isNormDocumentEmpty(doc)).toBe(true);
+  });
+
+  it("returns false if the akn-body div has content", () => {
+    const doc = new DOMParser().parseFromString(
+      '<div class="akn-body"><p>Content</p></div>',
+      "text/html",
+    );
+    expect(isNormDocumentEmpty(doc)).toBe(false);
   });
 });

--- a/frontend/src/utils/norm.spec.ts
+++ b/frontend/src/utils/norm.spec.ts
@@ -7,7 +7,7 @@ import type { LegislationExpression } from "~/types/api";
 import {
   getMostRelevantExpression,
   getValidityStatus,
-  isNormDocumentEmpty,
+  isNormBodyEmpty,
   temporalCoverageToValidityInterval,
   type ValidityInterval,
 } from "~/utils/norm";
@@ -257,14 +257,14 @@ describe("getNormMetadataItems", () => {
   });
 });
 
-describe("isNormDocumentEmpty", () => {
+describe("isNormBodyEmpty", () => {
   it("returns true if no document is given", () => {
-    expect(isNormDocumentEmpty(undefined)).toBe(true);
+    expect(isNormBodyEmpty(undefined)).toBe(true);
   });
 
   it("returns true if the document has no akn-body div", () => {
     const doc = new DOMParser().parseFromString("<div></div>", "text/html");
-    expect(isNormDocumentEmpty(doc)).toBe(true);
+    expect(isNormBodyEmpty(doc)).toBe(true);
   });
 
   it("returns true if the akn-body div is empty", () => {
@@ -272,7 +272,7 @@ describe("isNormDocumentEmpty", () => {
       '<div class="akn-body"></div>',
       "text/html",
     );
-    expect(isNormDocumentEmpty(doc)).toBe(true);
+    expect(isNormBodyEmpty(doc)).toBe(true);
   });
 
   it("returns true if the akn-body div contains only whitespaces", () => {
@@ -280,7 +280,7 @@ describe("isNormDocumentEmpty", () => {
       '<div class="akn-body">   </div>',
       "text/html",
     );
-    expect(isNormDocumentEmpty(doc)).toBe(true);
+    expect(isNormBodyEmpty(doc)).toBe(true);
   });
 
   it("returns false if the akn-body div has content", () => {
@@ -288,6 +288,6 @@ describe("isNormDocumentEmpty", () => {
       '<div class="akn-body"><p>Content</p></div>',
       "text/html",
     );
-    expect(isNormDocumentEmpty(doc)).toBe(false);
+    expect(isNormBodyEmpty(doc)).toBe(false);
   });
 });

--- a/frontend/src/utils/norm.ts
+++ b/frontend/src/utils/norm.ts
@@ -150,12 +150,12 @@ export function getNormMetadataItems(
 }
 
 /**
- * Determines if the given norm document is empty. A norm is considered empty if
- * the html `<div>` with class `akn-body` is empty.
+ * Checks if the document has a `<div>` with class `akn-body` and checks if it's
+ * empty.
  *
  * @param document
  */
-export function isNormDocumentEmpty(document?: Document): boolean {
+export function isNormBodyEmpty(document?: Document): boolean {
   if (!document) {
     return true;
   }

--- a/frontend/src/utils/norm.ts
+++ b/frontend/src/utils/norm.ts
@@ -148,3 +148,18 @@ export function getNormMetadataItems(
     },
   ];
 }
+
+/**
+ * Determines if the given norm document is empty. A norm is considered empty if
+ * the html `<div>` with class `akn-body` is empty.
+ *
+ * @param document
+ */
+export function isNormDocumentEmpty(document?: Document): boolean {
+  if (!document) {
+    return true;
+  }
+
+  const aknBody = document.querySelector("div.akn-body");
+  return !aknBody || aknBody.innerHTML.trim() === "";
+}


### PR DESCRIPTION
- hide text tab for norms that don't have any body content (specifically no contentn in the `div` with `class="akn-body"`)
- the logic for caselaw will be done in a separate PR

RISDEV-9129