### PR TITLE
RISDEV-11440 stop text content from inheriting sidebar height

### DIFF
--- a/frontend/src/components/SidebarLayout.vue
+++ b/frontend/src/components/SidebarLayout.vue
@@ -6,11 +6,9 @@
 
     <div
       v-if="$slots.sidebar"
-      class="col-span-12 row-start-1 md:col-span-4 md:col-start-9 md:row-start-auto md:h-full md:border-l md:border-gray-400 print:hidden"
+      class="col-span-12 row-start-1 md:col-span-4 md:col-start-9 md:row-start-auto md:h-full md:min-h-0 md:border-l md:border-gray-400 print:hidden"
     >
-      <div
-        class="overflow-auto md:sticky md:top-0 md:max-h-[calc(min(100%,100dvh))]"
-      >
+      <div class="overflow-auto md:sticky md:top-0 md:max-h-[100dvh]">
         <slot name="sidebar" />
       </div>
     </div>


### PR DESCRIPTION
The way the sidebar layout height was calculated meant that the tallest column would define the height for all columns. Combined with the overflow, this would lead to large amounts of whitespace and unnecessary scrolling when either the sidebar or the main content is significantly taller than the other element. This PR fixes this by:

- setting a `0` min height to allow shrinking
- removing the minimum 100% height to prevent unnecessary growing