### PR TITLE
RISDEV-9129 hide tablist for empty caselaw documents

### DIFF
--- a/backend/e2e-data/caselaw/KORE000001234/KORE000001234.xml
+++ b/backend/e2e-data/caselaw/KORE000001234/KORE000001234.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akn:akomaNtoso xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:ris="http://rechtsinformationen.bund.de/schema/ris/0.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://docs.oasis-open.org/legaldocml/ns/akn/3.0 https://docs.oasis-open.org/legaldocml/akn-core/v2.0/cs01/part2-specs/schemas/akomantoso30.xsd">
+    <akn:judgment name="/akn/ontology/de/concept/documenttype/bund/rechtsprechung/entscheidung">
+        <akn:meta>
+            <akn:identification source="#ris">
+                <akn:FRBRWork>
+                    <akn:FRBRthis value="KORE000001234"/>
+                    <akn:FRBRuri value="KORE000001234"/>
+                    <akn:FRBRalias name="uebergreifendeId" value="f577e1e4-c3e6-4669-b4bd-230db8f6dc97" showAs="Übergreifende ID"/>
+                    <akn:FRBRalias name="dokumentnummer" value="KORE000001234" showAs="Dokumentnummer"/>
+                    <akn:FRBRalias name="ecli" value="ECLI:DE:LGMUSTER:2000:0101.1O1234.00.0A" showAs="ECLI"/>
+                    <akn:FRBRalias eId="aktenzeichen" name="aktenzeichen" value="1 O 1234/00" showAs="Aktenzeichen"/>
+                    <akn:FRBRdate eId="entscheidungsdatum" date="2000-01-01" name="entscheidungsdatum" showAs="Entscheidungsdatum"/>
+                    <akn:FRBRauthor href="#organisation-gericht-lg-nuernberg-fuerth"/>
+                    <akn:FRBRcountry value="deu"/>
+                </akn:FRBRWork>
+                <akn:FRBRExpression>
+                    <akn:FRBRthis value="KORE000001234"/>
+                    <akn:FRBRuri value="KORE000001234"/>
+                    <akn:FRBRdate date="2000-01-01" name="entscheidungsdatum" showAs="Entscheidungsdatum"/>
+                    <akn:FRBRauthor href="#organisation-gericht-lg-nuernberg-fuerth"/>
+                    <akn:FRBRlanguage language="deu"/>
+                </akn:FRBRExpression>
+                <akn:FRBRManifestation>
+                    <akn:FRBRthis value="KORE000001234.xml"/>
+                    <akn:FRBRuri value="KORE000001234.xml"/>
+                    <akn:FRBRdate date="2001-01-01" name="erstveroeffentlichung" showAs="Erstveröffentlichung"/>
+                    <akn:FRBRdate date="2001-01-15" name="letzteVeroeffentlichung" showAs="Letzte Veröffentlichung"/>
+                    <akn:FRBRauthor href="#organisation-dokumentationsstelle-bgh"/>
+                </akn:FRBRManifestation>
+            </akn:identification>
+            <akn:analysis source="#ris">
+                <akn:otherReferences source="#ris">
+                    <akn:implicitReference ris:domainTerm="Fundstelle">
+                        <ris:fundstelle domainTerm="Fundstelle">
+                            <ris:periodikum domainTerm="Periodikum">
+                                <ris:abkuerzung domainTerm="Abkürzung">MustZ</ris:abkuerzung>
+                                <ris:periodikumTyp domainTerm="Art des Periodikums">nichtamtlich</ris:periodikumTyp>
+                                <ris:titel domainTerm="Titel">MustZ. Musterzeitschrift für Recht</ris:titel>
+                            </ris:periodikum>
+                            <ris:zitatstelle domainTerm="Zitatstelle">2000, 1-2</ris:zitatstelle>
+                            <ris:fundstellenTyp domainTerm="Art der Fundstelle">nichtamtlich</ris:fundstellenTyp>
+                        </ris:fundstelle>
+                    </akn:implicitReference>
+                </akn:otherReferences>
+            </akn:analysis>
+            <akn:references source="#ris">
+                <akn:TLCOrganization eId="ris" href="/akn/ontology/organizations/de/ris/rechtsinformationssystem-des-bundes" showAs="Rechtsinformationssystem des Bundes"/>
+                <akn:TLCOrganization eId="organisation-dokumentationsstelle-bgh" href="/akn/ontology/organizations/de/ris/dokumentationsstelle/bgh" showAs="BGH"/>
+                <akn:TLCOrganization eId="organisation-gericht-lg-nuernberg-fuerth" href="/akn/ontology/organizations/de/ris/gericht/lg-nuernberg-fuerth" showAs="LG Nürnberg-Fürth"/>
+            </akn:references>
+            <akn:proprietary source="#ris">
+                <ris:meta>
+                    <ris:dokumenttyp domainTerm="Dokumenttyp">Beschluss</ris:dokumenttyp>
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-lg-nuernberg-fuerth" showAs="LG Nürnberg-Fürth">
+                        <ris:gerichtstyp domainTerm="Gerichtstyp">LG</ris:gerichtstyp>
+                        <ris:gerichtsort domainTerm="Gerichtsort">Nürnberg-Fürth</ris:gerichtsort>
+                        <ris:gerichtsbarkeit domainTerm="Gerichtsbarkeit">Ordentliche Gerichtsbarkeit</ris:gerichtsbarkeit>
+                        <ris:spruchkoerper domainTerm="Spruchkörper">1. Zivilkammer</ris:spruchkoerper>
+                    </ris:gericht>
+                    <ris:regionen domainTerm="Regionen">
+                        <ris:region domainTerm="Region">BE</ris:region>
+                    </ris:regionen>
+                    <ris:aktenzeichenListe domainTerm="Liste der Aktenzeichen">
+                        <ris:aktenzeichen domainTerm="Aktenzeichen" refersTo="#aktenzeichen">1 O 1234/00</ris:aktenzeichen>
+                    </ris:aktenzeichenListe>
+                    <ris:rechtskraft domainTerm="Rechtskraft">Keine Angabe</ris:rechtskraft>
+                    <ris:gesetzgebungsauftrag domainTerm="Gesetzgebungsauftrag">Keine Angabe</ris:gesetzgebungsauftrag>
+                    <ris:vorabdokument domainTerm="Vorab-Dokument">Ja</ris:vorabdokument>
+                </ris:meta>
+            </akn:proprietary>
+        </akn:meta>
+        <akn:header>
+            <akn:p>Aktenzeichen: <akn:docNumber refersTo="#aktenzeichen">1 O 1234/00</akn:docNumber>
+            </akn:p>
+            <akn:p>Entscheidungsdatum: <akn:docDate date="2000-01-01" refersTo="#entscheidungsdatum">01.01.2000</akn:docDate>
+            </akn:p>
+            <akn:p>Gericht: <akn:courtType refersTo="#organisation-gericht-lg-nuernberg-fuerth">LG Nürnberg-Fürth</akn:courtType>
+            </akn:p>
+            <akn:p>Dokumenttyp: <akn:docType>Beschluss</akn:docType>
+            </akn:p>
+            <akn:p>Kurztitel: <akn:shortTitle>
+                <akn:embeddedStructure>
+                    <akn:p alternativeTo="textWrapper">LG Nürnberg-Fürth, Leerer Vorab-Beschluss vom 1. Januar 2000 - 1 O 1234/00</akn:p>
+                </akn:embeddedStructure>
+            </akn:shortTitle>
+            </akn:p>
+        </akn:header>
+        <akn:judgmentBody status="incomplete">
+            <akn:introduction>
+                <akn:p>
+                    <akn:placeholder>Vorabveröffentlichung: Der Entscheidungstext wird zu einem späteren Zeitpunkt nachgereicht.</akn:placeholder>
+                </akn:p>
+            </akn:introduction>
+        </akn:judgmentBody>
+    </akn:judgment>
+</akn:akomaNtoso>

--- a/backend/e2e-data/caselaw/KORE000005678/KORE000005678.xml
+++ b/backend/e2e-data/caselaw/KORE000005678/KORE000005678.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akn:akomaNtoso xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:ris="http://rechtsinformationen.bund.de/schema/ris/0.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://docs.oasis-open.org/legaldocml/ns/akn/3.0 https://docs.oasis-open.org/legaldocml/akn-core/v2.0/cs01/part2-specs/schemas/akomantoso30.xsd">
+    <akn:judgment name="/akn/ontology/de/concept/documenttype/bund/rechtsprechung/entscheidung">
+        <akn:meta>
+            <akn:identification source="#ris">
+                <akn:FRBRWork>
+                    <akn:FRBRthis value="KORE000005678"/>
+                    <akn:FRBRuri value="KORE000005678"/>
+                    <akn:FRBRalias name="uebergreifendeId" value="b9c8d7e6-f5a4-3210-fedc-ba9876543210" showAs="Übergreifende ID"/>
+                    <akn:FRBRalias name="dokumentnummer" value="KORE000005678" showAs="Dokumentnummer"/>
+                    <akn:FRBRalias name="ecli" value="ECLI:DE:LGBERL:2003:0315.2O9876.03.0B" showAs="ECLI"/>
+                    <akn:FRBRalias eId="aktenzeichen" name="aktenzeichen" value="2 O 9876/03" showAs="Aktenzeichen"/>
+                    <akn:FRBRdate eId="entscheidungsdatum" date="2003-03-15" name="entscheidungsdatum" showAs="Entscheidungsdatum"/>
+                    <akn:FRBRauthor href="#organisation-gericht-lg-berlin"/>
+                    <akn:FRBRcountry value="deu"/>
+                </akn:FRBRWork>
+                <akn:FRBRExpression>
+                    <akn:FRBRthis value="KORE000005678"/>
+                    <akn:FRBRuri value="KORE000005678"/>
+                    <akn:FRBRdate date="2003-03-15" name="entscheidungsdatum" showAs="Entscheidungsdatum"/>
+                    <akn:FRBRauthor href="#organisation-gericht-lg-berlin"/>
+                    <akn:FRBRlanguage language="deu"/>
+                </akn:FRBRExpression>
+                <akn:FRBRManifestation>
+                    <akn:FRBRthis value="KORE000005678.xml"/>
+                    <akn:FRBRuri value="KORE000005678.xml"/>
+                    <akn:FRBRdate date="2003-05-10" name="erstveroeffentlichung" showAs="Erstveröffentlichung"/>
+                    <akn:FRBRdate date="2003-06-01" name="letzteVeroeffentlichung" showAs="Letzte Veröffentlichung"/>
+                    <akn:FRBRauthor href="#organisation-dokumentationsstelle-bgh"/>
+                </akn:FRBRManifestation>
+            </akn:identification>
+            <akn:analysis source="#ris">
+                <akn:otherReferences source="#ris">
+                    <akn:implicitReference ris:domainTerm="Fundstelle">
+                        <ris:fundstelle domainTerm="Fundstelle">
+                            <ris:periodikum domainTerm="Periodikum">
+                                <ris:abkuerzung domainTerm="Abkürzung">TestZ</ris:abkuerzung>
+                                <ris:periodikumTyp domainTerm="Art des Periodikums">nichtamtlich</ris:periodikumTyp>
+                                <ris:titel domainTerm="Titel">TestZ. Testzeitschrift für Verfahrensrecht</ris:titel>
+                            </ris:periodikum>
+                            <ris:zitatstelle domainTerm="Zitatstelle">2003, 55-57</ris:zitatstelle>
+                            <ris:fundstellenTyp domainTerm="Art der Fundstelle">nichtamtlich</ris:fundstellenTyp>
+                        </ris:fundstelle>
+                    </akn:implicitReference>
+                </akn:otherReferences>
+            </akn:analysis>
+            <akn:references source="#ris">
+                <akn:TLCOrganization eId="ris" href="/akn/ontology/organizations/de/ris/rechtsinformationssystem-des-bundes" showAs="Rechtsinformationssystem des Bundes"/>
+                <akn:TLCOrganization eId="organisation-dokumentationsstelle-bgh" href="/akn/ontology/organizations/de/ris/dokumentationsstelle/bgh" showAs="BGH"/>
+                <akn:TLCOrganization eId="organisation-gericht-lg-berlin" href="/akn/ontology/organizations/de/ris/gericht/lg-berlin" showAs="LG Berlin"/>
+            </akn:references>
+            <akn:proprietary source="#ris">
+                <ris:meta>
+                    <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
+                    <ris:gericht domainTerm="Gericht" refersTo="#organisation-gericht-lg-berlin" showAs="LG Berlin">
+                        <ris:gerichtstyp domainTerm="Gerichtstyp">LG</ris:gerichtstyp>
+                        <ris:gerichtsort domainTerm="Gerichtsort">Berlin</ris:gerichtsort>
+                        <ris:gerichtsbarkeit domainTerm="Gerichtsbarkeit">Ordentliche Gerichtsbarkeit</ris:gerichtsbarkeit>
+                        <ris:spruchkoerper domainTerm="Spruchkörper">2. Zivilkammer</ris:spruchkoerper>
+                    </ris:gericht>
+                    <ris:regionen domainTerm="Regionen">
+                        <ris:region domainTerm="Region">BE</ris:region>
+                    </ris:regionen>
+                    <ris:aktenzeichenListe domainTerm="Liste der Aktenzeichen">
+                        <ris:aktenzeichen domainTerm="Aktenzeichen" refersTo="#aktenzeichen">2 O 9876/03</ris:aktenzeichen>
+                    </ris:aktenzeichenListe>
+                    <ris:rechtskraft domainTerm="Rechtskraft">Keine Angabe</ris:rechtskraft>
+                    <ris:gesetzgebungsauftrag domainTerm="Gesetzgebungsauftrag">Keine Angabe</ris:gesetzgebungsauftrag>
+                </ris:meta>
+            </akn:proprietary>
+        </akn:meta>
+        <akn:header>
+            <akn:p>Aktenzeichen: <akn:docNumber refersTo="#aktenzeichen">2 O 9876/03</akn:docNumber>
+            </akn:p>
+            <akn:p>Entscheidungsdatum: <akn:docDate date="2003-03-15" refersTo="#entscheidungsdatum">15.03.2003</akn:docDate>
+            </akn:p>
+            <akn:p>Gericht: <akn:courtType refersTo="#organisation-gericht-lg-berlin">LG Berlin</akn:courtType>
+            </akn:p>
+            <akn:p>Dokumenttyp: <akn:docType>Urteil</akn:docType>
+            </akn:p>
+            <akn:p>Kurztitel: <akn:shortTitle>
+                <akn:embeddedStructure>
+                    <akn:p alternativeTo="textWrapper">LG Berlin, Leeres Urteil vom 15. März 2003 - 2 O 9876/03</akn:p>
+                </akn:embeddedStructure>
+            </akn:shortTitle>
+            </akn:p>
+        </akn:header>
+        <akn:judgmentBody>
+            <akn:introduction>
+                <akn:p>
+                    <akn:placeholder>Kein Entscheidungstext verfügbar.</akn:placeholder>
+                </akn:p>
+            </akn:introduction>
+        </akn:judgmentBody>
+    </akn:judgment>
+</akn:akomaNtoso>

--- a/frontend/e2e/erweiterteSuche.spec.ts
+++ b/frontend/e2e/erweiterteSuche.spec.ts
@@ -505,7 +505,7 @@ test.describe("searching caselaw", () => {
 
     // Ensure all visible entries are of type caselaw
     await expect(searchResults).toHaveText(
-      Array(11).fill(/^(Beschluss|Urteil)/),
+      Array(12).fill(/^(Beschluss|Urteil)/),
     );
   });
 

--- a/frontend/e2e/gerichtsentscheidungen.spec.ts
+++ b/frontend/e2e/gerichtsentscheidungen.spec.ts
@@ -39,6 +39,32 @@ test("can view a single case law documentation unit", async ({ page }) => {
   await firstSectionHeader.scrollIntoViewIfNeeded();
 });
 
+test.describe("hides text tabs for empty documents", () => {
+  test("hides text tab when empty vorabdokument", async ({ page }) => {
+    await navigate(page, "/gerichtsentscheidungen/KORE000001234");
+
+    await expect(page.getByRole("tablist")).not.toBeVisible();
+
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Details" }),
+    ).toBeVisible();
+
+    await expect(page.getByTestId("details-list")).toBeVisible();
+  });
+
+  test("hides text tab when empty normal document", async ({ page }) => {
+    await navigate(page, "/gerichtsentscheidungen/KORE000005678");
+
+    await expect(page.getByRole("tablist")).not.toBeVisible();
+
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Details" }),
+    ).toBeVisible();
+
+    await expect(page.getByTestId("details-list")).toBeVisible();
+  });
+});
+
 test("sidebar TOC renders on desktop and clicking a link scrolls to the section", async ({
   page,
   isMobileTest,

--- a/frontend/e2e/suche.spec.ts
+++ b/frontend/e2e/suche.spec.ts
@@ -558,7 +558,7 @@ test.describe("searching caselaw", () => {
       await expect(page).toHaveURL(/typeGroup=urteil/);
 
       await expect(getSearchResults(page)).toHaveText(
-        Array.from<RegExp>({ length: 11 }).fill(/^Urteil/),
+        Array.from<RegExp>({ length: 12 }).fill(/^Urteil/),
       );
     });
 
@@ -572,7 +572,7 @@ test.describe("searching caselaw", () => {
       await expect(page).toHaveURL(/typeGroup=beschluss/);
 
       await expect(getSearchResults(page)).toHaveText(
-        Array.from<RegExp>({ length: 2 }).fill(/^Beschluss/),
+        Array.from<RegExp>({ length: 3 }).fill(/^Beschluss/),
       );
     });
 
@@ -598,7 +598,7 @@ test.describe("searching caselaw", () => {
       await expect(page).toHaveURL(/typeGroup=($|&)/);
 
       await expect(getSearchResults(page)).toHaveText(
-        Array(13).fill(/^(Beschluss|Urteil)/),
+        Array(15).fill(/^(Beschluss|Urteil)/),
       );
     });
   });
@@ -667,7 +667,7 @@ test.describe("searching caselaw", () => {
     await expect(page).toHaveURL(/dateFilterFrom=&dateFilterTo=2024-12-31/);
 
     const searchResults = getSearchResults(page);
-    await expect(searchResults).toHaveCount(2);
+    await expect(searchResults).toHaveCount(4);
     await expect(searchResults.nth(0)).toHaveText(/15.06.2024|22.11.2023/);
   });
 
@@ -773,7 +773,7 @@ test.describe("searching caselaw", () => {
       .getByRole("button", { name: "Alle Dokumentarten" })
       .click();
 
-    await expect(getResultCounter(page)).toHaveText("41 Suchergebnisse");
+    await expect(getResultCounter(page)).toHaveText("43 Suchergebnisse");
 
     // Verify caselaw-specific filters are reset
     await expect(page).not.toHaveURL(/documentKind=R/);
@@ -1265,7 +1265,7 @@ test.describe("mobile filter and sort drawers", () => {
     await expect(page).toHaveURL(/dateFilterFrom=&dateFilterTo=2024-12-31/);
 
     const searchResults = getSearchResults(page);
-    await expect(searchResults).toHaveCount(2);
+    await expect(searchResults).toHaveCount(4);
     await expect(searchResults.nth(0)).toHaveText(/15.06.2024|22.11.2023/);
   });
 

--- a/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
+++ b/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
@@ -38,6 +38,8 @@ const document = computed(() => {
   }
 });
 
+const isEmptyDocument = computed(() => isDocumentEmpty(document.value));
+
 useCaselawSeo({ caseLaw: caseLaw.value, document: document.value });
 
 // Page contents ------------------------------------------
@@ -116,6 +118,7 @@ const detailsSectionId = useId();
   <NuxtLayout
     name="document"
     :breadcrumbs
+    :is-empty-document="isEmptyDocument"
     :metadata="headerMetadata"
     :secondary-title
     :title

--- a/frontend/src/pages/literaturnachweise/[documentNumber].vue
+++ b/frontend/src/pages/literaturnachweise/[documentNumber].vue
@@ -55,12 +55,14 @@ const textSectionId = useId();
 const detailsSectionId = useId();
 
 const title = computed(() => getTitle(literature.value));
-const document = html.value ? parseDocument(html.value) : undefined;
-const isEmptyDocument = computed(() => isDocumentEmpty(document));
+const document = computed(() =>
+  html.value ? parseDocument(html.value) : undefined,
+);
+const isEmptyDocument = computed(() => isDocumentEmpty(document.value));
 
 const tocEntries = computed<TreeItem[] | null>(() => {
-  return document
-    ? getAllSectionsFromDocument(document, "section").map((entry) => ({
+  return document.value
+    ? getAllSectionsFromDocument(document.value, "section").map((entry) => ({
         key: entry.id,
         subtitle: entry.title, // Subtitle for more subtle appearance
         to: { hash: `#${entry.id}`, query: { from: route.query.from } },

--- a/frontend/src/pages/verwaltungsregelungen/[documentNumber].vue
+++ b/frontend/src/pages/verwaltungsregelungen/[documentNumber].vue
@@ -50,12 +50,14 @@ const detailsSectionId = useId();
 
 const title = computed(() => data.value?.headline);
 
-const document = html.value ? parseDocument(html.value) : undefined;
-const isEmptyDocument = isDocumentEmpty(document);
+const document = computed(() =>
+  html.value ? parseDocument(html.value) : undefined,
+);
+const isEmptyDocument = computed(() => isDocumentEmpty(document.value));
 
 const tocEntries = computed<TreeItem[] | null>(() => {
-  return document
-    ? getAllSectionsFromDocument(document, "section").map((entry) => ({
+  return document.value
+    ? getAllSectionsFromDocument(document.value, "section").map((entry) => ({
         key: entry.id,
         subtitle: entry.title, // Subtitle for more subtle appearance
         to: { hash: `#${entry.id}`, query: { from: route.query.from } },


### PR DESCRIPTION
- hide the tablist and only show the details if the caselaw document is considered empty
- does not yet add the info box for "Vorabdokumente", this will be done separately because a new index field is needed

RISDEV-9129