### PR TITLE
RISDEV-9129 define index field for vorabdokument

### DIFF
--- a/backend/src/main/resources/openSearch/case_law_index_template.json
+++ b/backend/src/main/resources/openSearch/case_law_index_template.json
@@ -400,6 +400,9 @@
         },
         "indexed_at": {
           "type": "date"
+        },
+        "vorabdokument": {
+          "type": "boolean"
         }
       }
     }


### PR DESCRIPTION
- define a new caselaw field which stores a flag telling whether the document is a "vorabdokument" or not

RISDEV-9129