### PR TITLE
RISDEV-0000 cleanup show error

### DIFF
--- a/frontend/src/composables/useNormVersions.spec.ts
+++ b/frontend/src/composables/useNormVersions.spec.ts
@@ -49,13 +49,12 @@ describe("useNormVersions", () => {
     );
   });
 
-  it("returns an empty list when an error occurs", () => {
+  it("throws when an error occurs", () => {
     vi.mocked(useRisBackendMock).mockReturnValue({
       status: ref("error"),
       data: computed(() => undefined),
       error: ref("Error occurred"),
     } as unknown as ReturnType<typeof useRisBackendMock>);
-    const { sortedVersions } = useNormVersions("dummy-eli");
-    expect(sortedVersions.value).toEqual([]);
+    expect(() => useNormVersions("dummy-eli")).toThrow();
   });
 });

--- a/frontend/src/composables/useNormVersions.spec.ts
+++ b/frontend/src/composables/useNormVersions.spec.ts
@@ -49,12 +49,14 @@ describe("useNormVersions", () => {
     );
   });
 
-  it("throws when an error occurs", () => {
+  it("exposes the error without throwing when an error occurs", () => {
     vi.mocked(useRisBackendMock).mockReturnValue({
       status: ref("error"),
       data: computed(() => undefined),
       error: ref("Error occurred"),
     } as unknown as ReturnType<typeof useRisBackendMock>);
-    expect(() => useNormVersions("dummy-eli")).toThrow();
+    const { error, sortedVersions } = useNormVersions("dummy-eli");
+    expect(error.value).toBe("Error occurred");
+    expect(sortedVersions.value).toEqual([]);
   });
 });

--- a/frontend/src/composables/useNormVersions.ts
+++ b/frontend/src/composables/useNormVersions.ts
@@ -1,5 +1,4 @@
-import { computed, type ComputedRef } from "vue";
-import type { AsyncDataRequestStatus } from "#app";
+import { computed } from "vue";
 import type {
   JSONLDList,
   LegislationExpression,
@@ -9,46 +8,12 @@ import type {
 } from "~/types/api";
 import { getCurrentDateInGermanyFormatted } from "~/utils/dateFormatting";
 
-interface UseNormVersions {
-  status: Ref<AsyncDataRequestStatus>;
-  sortedVersions: ComputedRef<LegislationExpression[]>;
-}
-
-export function useNormVersions(eli: string): UseNormVersions {
-  const { data, status } = getNormVersions(eli);
-  const sortedVersions = computed(() => data.value?.member ?? []);
-  return { status, sortedVersions };
-}
-
-function getNormVersions(eli: string) {
-  const immediate = true;
-  const { status, data, error } = useRisBackend<
+export function useNormVersions(eli: string) {
+  const { data, status, error } = useRisBackend<
     JSONLDList<LegislationExpression>
-  >(`/v1/legislation/work-example/${eli}`, {
-    immediate: immediate,
-  });
-
-  if (error?.value) {
-    throw createError(error.value);
-  }
-
-  return { status, data };
-}
-
-function getNorms(params: LegislationSearchParams) {
-  const immediate = params.eli !== undefined;
-  const { status, data, error } = useRisBackend<
-    JSONLDList<SearchResult<LegislationWork>>
-  >(`/v1/legislation`, {
-    params,
-    immediate: immediate,
-  });
-
-  if (error?.value) {
-    throw createError(error.value);
-  }
-
-  return { status, data };
+  >(`/v1/legislation/work-example/${eli}`, { immediate: true });
+  const sortedVersions = computed(() => data.value?.member ?? []);
+  return { data, status, error, sortedVersions };
 }
 
 export function useValidNormVersions(eli: string) {
@@ -59,4 +24,15 @@ export function useValidNormVersions(eli: string) {
     temporalCoverageTo: today,
     size: 300,
   });
+}
+
+function getNorms(params: LegislationSearchParams) {
+  const immediate = params.eli !== undefined;
+  return useRisBackend<JSONLDList<SearchResult<LegislationWork>>>(
+    `/v1/legislation`,
+    {
+      params,
+      immediate: immediate,
+    },
+  );
 }

--- a/frontend/src/composables/useNormVersions.ts
+++ b/frontend/src/composables/useNormVersions.ts
@@ -29,7 +29,7 @@ function getNormVersions(eli: string) {
   });
 
   if (error?.value) {
-    showError(error.value);
+    throw createError(error.value);
   }
 
   return { status, data };
@@ -45,7 +45,7 @@ function getNorms(params: LegislationSearchParams) {
   });
 
   if (error?.value) {
-    showError(error.value);
+    throw createError(error.value);
   }
 
   return { status, data };

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -196,6 +196,10 @@ const validVersions =
     ? undefined
     : useValidNormVersions(norm.value?.exampleOfWork.legislationIdentifier);
 
+if (validVersions?.error.value) {
+  throw createError(validVersions.error.value);
+}
+
 const inForceNormLink = computed(() => {
   if (
     !validVersions ||

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -110,8 +110,15 @@ const normBreadcrumbTitle = computed(() =>
   getNormBreadcrumbTitle(metadata.value),
 );
 
-const { status: normVersionsStatus, sortedVersions: normVersions } =
-  useNormVersions(metadata.value.exampleOfWork?.legislationIdentifier ?? "");
+const {
+  status: normVersionsStatus,
+  sortedVersions: normVersions,
+  error: normVersionsError,
+} = useNormVersions(metadata.value.exampleOfWork?.legislationIdentifier ?? "");
+
+if (normVersionsError.value) {
+  throw createError(normVersionsError.value);
+}
 
 const searchBackLink = useSearchBackLink(DocumentKind.Norm);
 

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/index.vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/index.vue
@@ -22,11 +22,11 @@ if (matchedExpressionEli.value) {
 }
 
 if (loadError?.value) {
-  showError(loadError.value);
+  throw createError(loadError.value);
 }
 
 if (data.value?.member?.length === 0) {
-  showError({
+  throw createError({
     statusCode: 404,
     statusMessage: "no norms found matching work ELI",
   });

--- a/frontend/src/pages/translations/[id].vue
+++ b/frontend/src/pages/translations/[id].vue
@@ -31,7 +31,7 @@ const id = route.params.id as string;
 
 const { data, error } = await fetchTranslationAndHTML(id);
 if (error.value || !data.value) {
-  showError({ status: error.value?.status ?? 500 });
+  throw createError({ statusCode: error.value?.status ?? 500 });
 }
 
 const { legislation } = await getGermanOriginal(id);


### PR DESCRIPTION
- removes almost all instances of `showError` in favor of `throw createError` for more consistent and predictable error handling
- only exception: kept `showError` inside a watcher, which behave differently due to reactivity
- moved the error handling of the norm versions composable to the view instead of handling it internally