### PR TITLE
RISDEV-9129 add vorabdokument info box

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/CaseLawLdmlToOpenSearchMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/CaseLawLdmlToOpenSearchMapper.java
@@ -106,6 +106,7 @@ public class CaseLawLdmlToOpenSearchMapper {
         // Internal (portal team) fields
         .indexedAt(Instant.now().toString())
         .articles(null)
+        .vorabdokument(isVorabdokument(judgmentBody))
         .build();
   }
 
@@ -224,6 +225,10 @@ public class CaseLawLdmlToOpenSearchMapper {
         .getContentByDomainTerm(term)
         .map(CaseLawLdmlToOpenSearchMapper::sanitize)
         .orElse(null);
+  }
+
+  private boolean isVorabdokument(JudgmentBody judgmentBody) {
+    return Objects.equals(judgmentBody.getStatus(), "incomplete");
   }
 
   private static String sanitize(JaxbHtml html) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/CaseLawLdmlToOpenSearchMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/CaseLawLdmlToOpenSearchMapper.java
@@ -227,7 +227,7 @@ public class CaseLawLdmlToOpenSearchMapper {
         .orElse(null);
   }
 
-  private boolean isVorabdokument(JudgmentBody judgmentBody) {
+  private static boolean isVorabdokument(JudgmentBody judgmentBody) {
     return Objects.equals(judgmentBody.getStatus(), "incomplete");
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/CaseLawSchemaMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/CaseLawSchemaMapper.java
@@ -59,6 +59,7 @@ public class CaseLawSchemaMapper {
         .keywords(doc.keywords())
         .decisionName(doc.decisionName())
         .deviatingDocumentNumber(doc.deviatingDocumentNumber())
+        .vorabdokument(doc.vorabdokument())
         // fields with different name
         .courtName(doc.courtKeyword())
         // end

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/ldml/caselaw/JudgmentBody.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/ldml/caselaw/JudgmentBody.java
@@ -1,5 +1,6 @@
 package de.bund.digitalservice.ris.search.models.ldml.caselaw;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElements;
 import java.util.List;
@@ -21,6 +22,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 public class JudgmentBody {
+  /**
+   * Status of the document.
+   *
+   * <p>Set to "incomplete" in case of a Vorabdokument.
+   */
+  @XmlAttribute private String status;
 
   /**
    * A list of introductory elements such as headnotes (Leitsätze) or outlines (Gliederungen) and

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/CaseLawDocumentationUnit.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/models/opensearch/CaseLawDocumentationUnit.java
@@ -57,7 +57,8 @@ public record CaseLawDocumentationUnit(
         List<String> pendingDecisions,
     @JsonIgnore @Field(name = Fields.HAS_LEGISLATIVE_MANDATE) String hasLegislativeMandate,
     @JsonIgnore @Field(name = Fields.INDEXED_AT) String indexedAt,
-    @Nullable @Field(name = Fields.ARTICLES) List<Article> articles)
+    @Nullable @Field(name = Fields.ARTICLES) List<Article> articles,
+    @Field(name = Fields.VORABDOKUMENT) boolean vorabdokument)
     implements AbstractSearchEntity {
 
   /**
@@ -116,5 +117,6 @@ public record CaseLawDocumentationUnit(
     public static final String HAS_LEGISLATIVE_MANDATE = "has_legislative_mandate";
     public static final String INDEXED_AT = "indexed_at";
     public static final String ARTICLES = "articles";
+    public static final String VORABDOKUMENT = "vorabdokument";
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/CaseLawSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/CaseLawSchema.java
@@ -62,7 +62,11 @@ public record CaseLawSchema(
         @JsonProperty("@id")
         String id,
     @Schema(example = "de", requiredMode = Schema.RequiredMode.REQUIRED) String inLanguage,
-    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<CaseLawEncodingSchema> encoding)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<CaseLawEncodingSchema> encoding,
+    @Schema(
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            description = "Whether or not the dokument is a Vorabdokumet")
+        boolean vorabdokument)
     implements JsonldResource {
 
   @Override

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/CaseLawSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/CaseLawSchema.java
@@ -65,7 +65,7 @@ public record CaseLawSchema(
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<CaseLawEncodingSchema> encoding,
     @Schema(
             requiredMode = Schema.RequiredMode.REQUIRED,
-            description = "Whether or not the dokument is a Vorabdokumet")
+            description = "Whether or not the document is a Vorabdokument")
         boolean vorabdokument)
     implements JsonldResource {
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/CaseLawControllerApiTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/CaseLawControllerApiTest.java
@@ -4,6 +4,8 @@ import static de.bund.digitalservice.ris.ZipTestUtils.readZipStream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWithIgnoringCase;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,6 +20,7 @@ import de.bund.digitalservice.ris.search.config.ApiConfig;
 import de.bund.digitalservice.ris.search.importer.changelog.Changelog;
 import de.bund.digitalservice.ris.search.integration.config.ContainersIntegrationBase;
 import de.bund.digitalservice.ris.search.models.PublicationStatus;
+import de.bund.digitalservice.ris.search.models.opensearch.CaseLawDocumentationUnit;
 import de.bund.digitalservice.ris.search.repository.objectstorage.CaseLawBucket;
 import de.bund.digitalservice.ris.search.service.ChangelogService;
 import de.bund.digitalservice.ris.search.service.IndexCaselawService;
@@ -145,7 +148,26 @@ class CaseLawControllerApiTest extends ContainersIntegrationBase {
                 containsInAnyOrder(
                     "/v1/case-law/" + this.documentNumber + ".html",
                     "/v1/case-law/" + this.documentNumber + ".xml",
-                    "/v1/case-law/" + this.documentNumber + ".zip")));
+                    "/v1/case-law/" + this.documentNumber + ".zip")),
+            jsonPath("$.vorabdokument", is(false)));
+  }
+
+  @Test
+  @DisplayName("Should set vorabdokument to true if vorabdokument")
+  void responseContainsVorabdokumentValue() throws Exception {
+    CaseLawDocumentationUnit docUnit =
+        CaseLawDocumentationUnit.builder()
+            .documentNumber("FOOB000000001")
+            .vorabdokument(true)
+            .build();
+
+    this.caseLawRepository.save(docUnit);
+
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.CASELAW + "/FOOB000000001").contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.vorabdokument", equalTo(true)));
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/CaseLawLdmlToOpenSearchMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/CaseLawLdmlToOpenSearchMapperTest.java
@@ -8,6 +8,7 @@ import de.bund.digitalservice.ris.search.utils.CaseLawLdmlTemplateUtils;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.Month;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -57,5 +58,14 @@ class CaseLawLdmlToOpenSearchMapperTest {
         .containsExactlyInAnyOrder(
             "ensuing decision file number, ensuing decision court type",
             "ensuing decision file number, ensuing decision court type");
+    assertThat(caseLaw.vorabdokument()).isFalse();
+  }
+
+  @Test
+  void setsVorabdokumentToTrueIfDocumentIsMarkedIncomplete() throws IOException {
+    String caselawXml = caseLawLdmlTemplateUtils.getXmlFromTemplate(Map.of("vorabdokument", true));
+
+    CaseLawDocumentationUnit caseLaw = mapper.fromString(caselawXml);
+    assertThat(caseLaw.vorabdokument()).isTrue();
   }
 }

--- a/backend/src/test/resources/templates/case-law/case-law-template.xml
+++ b/backend/src/test/resources/templates/case-law/case-law-template.xml
@@ -28,7 +28,7 @@
             </akn:p>
         </akn:header>
 
-        <akn:judgmentBody>
+        <akn:judgmentBody{% if vorabdokument%} status="incomplete" {% endif %}>
 
             <akn:introduction ris:domainTerm="Leitsatz">
                 <akn:p>{% if leitsatz %}{{ leitsatz }}{% else %}Example Leitsatz/GuidingPrinciple{% endif %}</akn:p>

--- a/frontend/e2e/gerichtsentscheidungen.spec.ts
+++ b/frontend/e2e/gerichtsentscheidungen.spec.ts
@@ -40,8 +40,14 @@ test("can view a single case law documentation unit", async ({ page }) => {
 });
 
 test.describe("hides text tabs for empty documents", () => {
-  test("hides text tab when empty vorabdokument", async ({ page }) => {
+  test("hides text tab when empty vorabdokument and shows info box", async ({
+    page,
+  }) => {
     await navigate(page, "/gerichtsentscheidungen/KORE000001234");
+
+    await expect(page.getByRole("alert")).toHaveText(
+      /Die Metadaten dieser Gerichtsentscheidung/,
+    );
 
     await expect(page.getByRole("tablist")).not.toBeVisible();
 
@@ -54,6 +60,8 @@ test.describe("hides text tabs for empty documents", () => {
 
   test("hides text tab when empty normal document", async ({ page }) => {
     await navigate(page, "/gerichtsentscheidungen/KORE000005678");
+
+    await expect(page.getByRole("alert")).not.toBeVisible();
 
     await expect(page.getByRole("tablist")).not.toBeVisible();
 

--- a/frontend/src/components/Pagination.spec.ts
+++ b/frontend/src/components/Pagination.spec.ts
@@ -17,6 +17,7 @@ const createMockSearchResult = (): SearchResult<CaseLaw> => ({
     deviatingDocumentNumber: [],
     inLanguage: "de",
     encoding: [],
+    vorabdokument: false,
   },
   textMatches: [],
 });

--- a/frontend/src/components/search/CaseLawSearchResult.spec.ts
+++ b/frontend/src/components/search/CaseLawSearchResult.spec.ts
@@ -36,6 +36,7 @@ const searchResult: SearchResult<CaseLaw> = {
     decisionName: ["Decision Name"],
     titleLine: "Title line",
     documentType: "Document Type",
+    vorabdokument: false,
   },
   textMatches: [],
 };

--- a/frontend/src/layouts/document.spec.ts
+++ b/frontend/src/layouts/document.spec.ts
@@ -60,6 +60,19 @@ describe("document", () => {
     );
   });
 
+  it("renders message slot", async () => {
+    await renderSuspended(DocumentLayout, {
+      props: {
+        views: defaultViews,
+      },
+      slots: {
+        message: () => "Some Message",
+      },
+    });
+
+    expect(screen.getByText("Some Message")).toBeVisible();
+  });
+
   it("renders breadcrumbs", async () => {
     await renderSuspended(DocumentLayout, {
       props: {

--- a/frontend/src/layouts/document.vue
+++ b/frontend/src/layouts/document.vue
@@ -38,6 +38,8 @@ const { titlePlaceholder = "Titelzeile nicht vorhanden", views } = defineProps<{
           :placeholder="titlePlaceholder"
         />
 
+        <slot name="message" />
+
         <DocumentsMetadata
           v-if="metadata?.length"
           :items="metadata"

--- a/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
+++ b/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
@@ -136,7 +136,7 @@ const detailsSectionId = useId();
         class="typo-body-regular my-24 bg-white sm:my-32 md:my-40"
       >
         <template #icon>
-          <IcOutlineInfo />
+          <IcOutlineInfo class="text-blue-800" />
         </template>
         <p>
           Die Metadaten dieser Gerichtsentscheidung wurden bereits

--- a/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
+++ b/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { Message } from "primevue";
 import IcBaselineSubject from "~icons/ic/baseline-subject";
 import IcOutlineFileDownload from "~icons/ic/outline-file-download";
 import IcOutlineInfo from "~icons/ic/outline-info";
@@ -126,6 +127,23 @@ const detailsSectionId = useId();
   >
     <template #actionMenu>
       <DocumentsActionMenuCaseLawActionMenu :case-law class="mb-auto" />
+    </template>
+
+    <template #message>
+      <Message
+        v-if="caseLaw?.vorabdokument"
+        severity="info"
+        class="typo-body-regular my-24 bg-white sm:my-32 md:my-40"
+      >
+        <template #icon>
+          <IcOutlineInfo />
+        </template>
+        <p>
+          Die Metadaten dieser Gerichtsentscheidung wurden bereits
+          veröffentlicht. Der Entscheidungstext ist derzeit noch nicht
+          verfügbar, wird aber in Kürze ergänzt.
+        </p>
+      </Message>
     </template>
 
     <template #details>

--- a/frontend/src/public/openapi.json
+++ b/frontend/src/public/openapi.json
@@ -3499,9 +3499,13 @@
             "items" : {
               "$ref" : "#/components/schemas/CaseLawEncodingSchema"
             }
+          },
+          "vorabdokument" : {
+            "type" : "boolean",
+            "description" : "Whether or not the dokument is a Vorabdokumet"
           }
         },
-        "required" : [ "@id", "decisionDate", "decisionName", "deviatingDocumentNumber", "documentNumber", "ecli", "encoding", "fileNumbers", "inLanguage", "keywords" ]
+        "required" : [ "@id", "decisionDate", "decisionName", "deviatingDocumentNumber", "documentNumber", "ecli", "encoding", "fileNumbers", "inLanguage", "keywords", "vorabdokument" ]
       },
       "CourtSearchResult" : {
         "type" : "object",

--- a/frontend/src/public/openapi.json
+++ b/frontend/src/public/openapi.json
@@ -3502,7 +3502,7 @@
           },
           "vorabdokument" : {
             "type" : "boolean",
-            "description" : "Whether or not the dokument is a Vorabdokumet"
+            "description" : "Whether or not the document is a Vorabdokument"
           }
         },
         "required" : [ "@id", "decisionDate", "decisionName", "deviatingDocumentNumber", "documentNumber", "ecli", "encoding", "fileNumbers", "inLanguage", "keywords", "vorabdokument" ]

--- a/frontend/src/types/api-generated.d.ts
+++ b/frontend/src/types/api-generated.d.ts
@@ -1356,7 +1356,7 @@ export interface components {
             /** @example de */
             inLanguage: string;
             encoding: components["schemas"]["CaseLawEncodingSchema"][];
-            /** @description Whether or not the dokument is a Vorabdokumet */
+            /** @description Whether or not the document is a Vorabdokument */
             vorabdokument: boolean;
         };
         CourtSearchResult: {

--- a/frontend/src/types/api-generated.d.ts
+++ b/frontend/src/types/api-generated.d.ts
@@ -1356,6 +1356,8 @@ export interface components {
             /** @example de */
             inLanguage: string;
             encoding: components["schemas"]["CaseLawEncodingSchema"][];
+            /** @description Whether or not the dokument is a Vorabdokumet */
+            vorabdokument: boolean;
         };
         CourtSearchResult: {
             /** @example BGH Karlsruhe */

--- a/frontend/src/utils/anyDocument.spec.ts
+++ b/frontend/src/utils/anyDocument.spec.ts
@@ -29,6 +29,7 @@ describe("anyDocument", () => {
         deviatingDocumentNumber: [],
         inLanguage: "",
         encoding: [],
+        vorabdokument: false,
       };
 
       expect(isCaselaw(doc)).toBe(true);
@@ -99,6 +100,7 @@ describe("anyDocument", () => {
         deviatingDocumentNumber: [],
         inLanguage: "",
         encoding: [],
+        vorabdokument: false,
       };
 
       expect(isLegislation(doc)).toBe(false);
@@ -201,6 +203,7 @@ describe("anyDocument", () => {
         deviatingDocumentNumber: [],
         inLanguage: "",
         encoding: [],
+        vorabdokument: false,
       };
 
       expect(getIdentifier(doc)).toBe("4711");

--- a/frontend/src/utils/caseLaw.spec.ts
+++ b/frontend/src/utils/caseLaw.spec.ts
@@ -32,6 +32,7 @@ describe("caselaw", () => {
           inLanguage: "de",
         },
       ],
+      vorabdokument: false,
     };
 
     it("returns the URL for a matching format", () => {


### PR DESCRIPTION
- add a new field `vorabdokument` to the caselaw api schema which is a flag telling whether or not the document is a _Vorabdokument_
- use the new field to conditionally render an info message on the caselaw document

RISDEV-9129