### PR TITLE
RISDEV-10909, RISDEV-12189 rewrite Norm versions list

### DIFF
--- a/frontend/e2e/normVersions.spec.ts
+++ b/frontend/e2e/normVersions.spec.ts
@@ -8,7 +8,7 @@ test.beforeAll(async ({ privateFeaturesEnabled }) => {
 });
 
 test.describe("fassungen tab", async () => {
-  test("displays Fassungen table in the Fassungen tab", async ({ page }) => {
+  test("displays Fassungen in the Fassungen tab", async ({ page }) => {
     await navigate(
       page,
       "/gesetze/eli/bund/bgbl-1/2020/s1126/2020-08-04/1/deu",
@@ -16,20 +16,29 @@ test.describe("fassungen tab", async () => {
 
     await page.getByRole("tab", { name: "Fassungen" }).click();
 
-    await expect(page.getByRole("table").getByRole("row")).toHaveText(
-      [
-        "Gültig ab Gültig bis Status",
-        "04.08.2919 - Zukünftig in Kraft",
-        "04.08.2022 01.01.2030 Aktuell gültig",
-        "04.08.2020 03.08.2022 Außer Kraft",
-      ],
-      { useInnerText: true },
-    );
+    await expect(
+      page.getByRole("list", { name: "Fassungen" }).getByRole("listitem"),
+    ).toHaveText([
+      "Gültig ab: 04.08.2919 Gültig bis: – Status: Zukünftig in Kraft",
+      "Gültig ab: 04.08.2022 Gültig bis: 01.01.2030 Status: Aktuell gültig",
+      "Gültig ab: 04.08.2020 Gültig bis: 03.08.2022 Status: Außer Kraft",
+    ]);
   });
 
-  test("can navigate to a Fassung by clicking the table row", async ({
+  test("marks the Fassung currently displayed as the current page", async ({
     page,
   }) => {
+    await navigate(
+      page,
+      "/gesetze/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu?view=versions",
+    );
+
+    await expect(
+      page.getByRole("link", { name: /04\.08\.2022/ }),
+    ).toHaveAttribute("aria-current", "page");
+  });
+
+  test("can navigate to a Fassung by clicking its link", async ({ page }) => {
     await navigate(
       page,
       "/gesetze/eli/bund/bgbl-1/2020/s1126/2022-08-04/1/deu?view=versions",
@@ -41,9 +50,7 @@ test.describe("fassungen tab", async () => {
       }),
     ).toBeVisible();
 
-    await page
-      .getByRole("row", { name: "04.08.2919 - Zukünftig in Kraft" })
-      .click();
+    await page.getByRole("link", { name: /04\.08\.2919/ }).click();
 
     await expect(
       page.getByRole("heading", {
@@ -58,17 +65,17 @@ test.describe("fassungen tab", async () => {
       "/gesetze/eli/bund/bgbl-1/2020/s1126/2020-08-04/1/deu?view=versions",
     );
 
-    const tableBody = page.getByRole("table").getByRole("rowgroup").nth(1);
+    const versions = page
+      .getByRole("list", { name: "Fassungen" })
+      .getByRole("listitem");
 
-    await expect(tableBody.getByRole("row")).toHaveCount(3);
+    await expect(versions).toHaveCount(3);
 
     await page.getByRole("textbox", { name: "Gültig am" }).fill("04.08.2020");
 
-    await expect(tableBody.getByRole("row")).toHaveCount(1);
-    await expect(tableBody.getByRole("row")).toHaveText(
-      "04.08.2020 03.08.2022 Außer Kraft",
-      { useInnerText: true },
-    );
+    await expect(versions).toHaveText([
+      "Gültig ab: 04.08.2020 Gültig bis: 03.08.2022 Status: Außer Kraft",
+    ]);
   });
 
   test("shows no results placeholder when no Fassung found", async ({
@@ -79,16 +86,39 @@ test.describe("fassungen tab", async () => {
       "/gesetze/eli/bund/bgbl-1/2020/s1126/2020-08-04/1/deu?view=versions",
     );
 
-    const tableBody = page.getByRole("table").getByRole("rowgroup").nth(1);
+    const versions = page
+      .getByRole("list", { name: "Fassungen" })
+      .getByRole("listitem");
 
-    await expect(tableBody.getByRole("row")).toHaveCount(3);
+    await expect(versions).toHaveCount(3);
 
     await page.getByRole("textbox", { name: "Gültig am" }).fill("04.08.1536");
 
-    await expect(tableBody.getByRole("row")).toHaveCount(1);
-    await expect(tableBody.getByRole("row")).toHaveText(
-      "Keine Ergebnisse gefunden",
+    await expect(versions).toHaveText(["Keine Ergebnisse gefunden"]);
+  });
+});
+
+test.describe("fassungen tab on a small screen", () => {
+  test.beforeEach(({ isMobileTest }) => {
+    test.skip(!isMobileTest);
+  });
+
+  test("shows a label in front of every value instead of a header row", async ({
+    page,
+  }) => {
+    await navigate(
+      page,
+      "/gesetze/eli/bund/bgbl-1/2020/s1126/2020-08-04/1/deu?view=versions",
     );
+
+    const firstVersion = page
+      .getByRole("list", { name: "Fassungen" })
+      .getByRole("listitem")
+      .first();
+
+    await expect(firstVersion.getByText("Gültig ab:")).toBeVisible();
+    await expect(firstVersion.getByText("Gültig bis:")).toBeVisible();
+    await expect(firstVersion.getByText("Status:")).toBeVisible();
   });
 });
 

--- a/frontend/src/components/documents/norms/VersionList.spec.ts
+++ b/frontend/src/components/documents/norms/VersionList.spec.ts
@@ -1,8 +1,9 @@
 import {
-  mountSuspended,
+  renderSuspended,
   registerEndpoint,
   mockNuxtImport,
 } from "@nuxt/test-utils/runtime";
+import { screen } from "@testing-library/vue";
 import { vi } from "vitest";
 import type { JSONLDList, LegislationExpression } from "~/types/api";
 import VersionList from "./VersionList.vue";
@@ -69,19 +70,28 @@ registerEndpoint(`/v1/legislation`, () => {
   return data;
 });
 
-const { mockNavigateTo, useRouteMock } = vi.hoisted(() => ({
-  mockNavigateTo: vi.fn(),
+const { useRouteMock } = vi.hoisted(() => ({
   useRouteMock: vi.fn(() => ({ query: {} })),
 }));
-mockNuxtImport("navigateTo", () => mockNavigateTo);
 mockNuxtImport("useRoute", () => useRouteMock);
+
+/** Props for the list, with the second version being the displayed one. */
+function props(versions = data.member!) {
+  return {
+    currentLegislationIdentifier: data.member![1]?.legislationIdentifier ?? "",
+    versions,
+  };
+}
+
+function hrefs() {
+  return screen.getAllByRole("link").map((link) => link.getAttribute("href"));
+}
 
 describe("VersionList", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2025-01-01T12:00:00"));
 
-    mockNavigateTo.mockClear();
     useRouteMock.mockReturnValue({ query: {} });
   });
 
@@ -90,122 +100,81 @@ describe("VersionList", () => {
   });
 
   it("lists versions, sorted by date", async () => {
-    const wrapper = await mountSuspended(VersionList, {
-      props: {
-        status: "success",
-        currentLegislationIdentifier:
-          data.member![1]?.legislationIdentifier ?? "",
-        versions: data.member!,
-      },
-    });
+    await renderSuspended(VersionList, { props: props() });
 
-    const headerRowCells = wrapper.find("thead").findAll("th");
-    expect(headerRowCells.map((cell) => cell.text())).toEqual([
-      "Gültig ab",
-      "Gültig bis",
-      "Status",
-    ]);
+    const versions = screen.getAllByRole("listitem");
+    expect(versions).toHaveLength(3);
 
-    const tableBodyRows = wrapper.find("tbody").findAll("tr");
-    expect(tableBodyRows).toHaveLength(3);
+    expect(versions[0]).toHaveTextContent(
+      "Gültig ab: 01.01.2031 Gültig bis: – Status: Zukünftig in Kraft",
+    );
+    expect(versions[1]).toHaveTextContent(
+      "Gültig ab: 01.01.2020 Gültig bis: – Status: Aktuell gültig",
+    );
+    expect(versions[2]).toHaveTextContent(
+      "Gültig ab: 05.01.2000 Gültig bis: 31.12.2019 Status: Außer Kraft",
+    );
+  });
 
-    const futureVersionRowCells = tableBodyRows[0]?.findAll("td");
-    expect(futureVersionRowCells?.map((cell) => cell.text())).toEqual([
-      "01.01.2031",
-      "-",
-      "Zukünftig in Kraft",
-    ]);
+  it("renders the column labels as a header", async () => {
+    await renderSuspended(VersionList, { props: props() });
 
-    const currentVersionRowCells = tableBodyRows[1]?.findAll("td");
-    expect(currentVersionRowCells?.map((cell) => cell.text())).toEqual([
-      "01.01.2020",
-      "-",
-      "Aktuell gültig",
-    ]);
+    for (const label of ["Gültig ab", "Gültig bis", "Status"]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
 
-    const pastVersionRowCells = tableBodyRows[2]?.findAll("td");
-    expect(pastVersionRowCells?.map((cell) => cell.text())).toEqual([
-      "05.01.2000",
-      "31.12.2019",
-      "Außer Kraft",
+  it("links every version, so it can be opened in a new tab", async () => {
+    await renderSuspended(VersionList, { props: props() });
+
+    expect(hrefs()).toEqual([
+      "/gesetze/eli/bund/bgbl-1/2000/s001/2030-01-01/1/deu/regelungstext-1",
+      "/gesetze/eli/bund/bgbl-1/2000/s001/2020-01-01/1/deu/regelungstext-1",
+      "/gesetze/eli/bund/bgbl-1/2000/s001/2000-01-01/1/deu/regelungstext-1",
     ]);
   });
 
-  it("navigates on row click if fassung is not currently displayed", async () => {
-    const wrapper = await mountSuspended(VersionList, {
-      props: {
-        status: "success",
-        currentLegislationIdentifier:
-          data.member![1]?.legislationIdentifier ?? "",
-        versions: data.member!,
-      },
-    });
+  it("marks the version currently displayed as the current page", async () => {
+    await renderSuspended(VersionList, { props: props() });
 
-    const futureVersionRow = wrapper.find("tbody").findAll("tr")[0];
-    await futureVersionRow?.trigger("click");
-
-    expect(mockNavigateTo).toHaveBeenCalledTimes(1);
-    expect(mockNavigateTo).toHaveBeenCalledWith({
-      path: "/gesetze/eli/bund/bgbl-1/2000/s001/2030-01-01/1/deu/regelungstext-1",
-      query: { from: undefined },
-    });
+    const links = screen.getAllByRole("link");
+    expect(links[0]).not.toHaveAttribute("aria-current");
+    expect(links[1]).toHaveAttribute("aria-current", "page");
+    expect(links[2]).not.toHaveAttribute("aria-current");
   });
 
-  it("does not nvigate to fassung currently displayed", async () => {
-    const wrapper = await mountSuspended(VersionList, {
-      props: {
-        status: "success",
-        currentLegislationIdentifier:
-          data.member![1]?.legislationIdentifier ?? "",
-        versions: data.member!,
-      },
-    });
-
-    const futureVersionRow = wrapper.find("tbody").findAll("tr")[1];
-    await futureVersionRow?.trigger("click");
-
-    expect(mockNavigateTo).toHaveBeenCalledTimes(0);
-  });
-
-  it("keeps the from query parameter when navigating to a version", async () => {
+  it("keeps the from query parameter in the version links", async () => {
     useRouteMock.mockReturnValue({ query: { from: "/suche?q=test" } });
 
-    const wrapper = await mountSuspended(VersionList, {
-      props: {
-        status: "success",
-        currentLegislationIdentifier:
-          data.member![1]?.legislationIdentifier ?? "",
-        versions: data.member!,
-      },
-    });
+    await renderSuspended(VersionList, { props: props() });
 
-    const futureVersionRow = wrapper.find("tbody").findAll("tr")[0];
-    await futureVersionRow?.trigger("click");
-
-    expect(mockNavigateTo).toHaveBeenCalledWith({
-      path: "/gesetze/eli/bund/bgbl-1/2000/s001/2030-01-01/1/deu/regelungstext-1",
-      query: { from: "/suche?q=test" },
-    });
+    for (const href of hrefs()) {
+      const url = new URL(href!, "http://localhost");
+      expect(url.pathname).toMatch(/^\/gesetze\/eli\/bund\/bgbl-1\/2000\//);
+      expect(url.searchParams.get("from")).toBe("/suche?q=test");
+    }
   });
 
-  it("keeps the from query parameter when navigating to a past version", async () => {
-    useRouteMock.mockReturnValue({ query: { from: "/suche?q=test" } });
+  it("labels the status as unknown when it can't be determined", async () => {
+    const withoutCoverage = createLegislationExpression(
+      "eli/bund/bgbl-1/2000/s001/2040-01-01/1/deu/regelungstext-1",
+      "",
+      "NotInForce",
+    );
 
-    const wrapper = await mountSuspended(VersionList, {
-      props: {
-        status: "success",
-        currentLegislationIdentifier:
-          data.member![1]?.legislationIdentifier ?? "",
-        versions: data.member!,
-      },
+    await renderSuspended(VersionList, {
+      props: props([withoutCoverage]),
     });
 
-    const pastVersionRow = wrapper.find("tbody").findAll("tr")[2];
-    await pastVersionRow?.trigger("click");
+    expect(screen.getByRole("listitem")).toHaveTextContent(
+      "Gültig ab: – Gültig bis: – Status: Unbekannt",
+    );
+  });
 
-    expect(mockNavigateTo).toHaveBeenCalledWith({
-      path: "/gesetze/eli/bund/bgbl-1/2000/s001/2000-01-01/1/deu/regelungstext-1",
-      query: { from: "/suche?q=test" },
-    });
+  it("shows a placeholder when there are no versions", async () => {
+    await renderSuspended(VersionList, { props: props([]) });
+
+    expect(screen.getByText("Keine Ergebnisse gefunden")).toBeInTheDocument();
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
   });
 });

--- a/frontend/src/components/documents/norms/VersionList.vue
+++ b/frontend/src/components/documents/norms/VersionList.vue
@@ -1,111 +1,79 @@
 <script setup lang="ts">
-import { orderBy } from "lodash-es";
-import { Column, DataTable } from "primevue";
-import type { RouteLocationRaw } from "#vue-router";
+import { NuxtLink } from "#components";
+import { BadgeColor } from "~/components/ui/Badge.vue";
+import type {
+  DataTableColumn,
+  DataTableRow,
+} from "~/components/ui/DataTable.vue";
 import type { LegislationExpression } from "~/types/api";
 
 const props = defineProps<{
-  status: string;
   currentLegislationIdentifier: string;
   versions: LegislationExpression[];
 }>();
 
-type TableRowData = {
-  id: number;
+type VersionRow = DataTableRow & {
   fromDate: string;
   toDate: string;
-  status?: ReturnType<typeof formatNormValidity>;
-  link: RouteLocationRaw;
-  selectable: boolean;
+  status: { label: string; color: BadgeColor };
 };
 
 const route = useRoute();
 
-const selectedVersion = ref<TableRowData>();
+const columns: DataTableColumn<VersionRow>[] = [
+  { key: "fromDate", label: "Gültig ab" },
+  { key: "toDate", label: "Gültig bis" },
+  { key: "status", label: "Status" },
+];
 
-const tableRowData = computed<TableRowData[]>(() => {
-  const versionsSorted = orderBy(
-    props.versions,
-    [(version) => version.temporalCoverage],
-    ["desc"],
+const rows = computed<VersionRow[]>(() => {
+  // Newest Fassung first
+  const versionsSorted = props.versions.toSorted((a, b) =>
+    b.temporalCoverage.localeCompare(a.temporalCoverage),
   );
 
-  return versionsSorted.map((version, index) => {
+  return versionsSorted.map((version) => {
     const validityInterval = temporalCoverageToValidityInterval(
       version.temporalCoverage,
     );
 
-    const status = formatNormValidity(version.temporalCoverage);
+    const current =
+      version.legislationIdentifier === props.currentLegislationIdentifier;
 
-    const id = index;
-
-    const link: RouteLocationRaw = {
+    const to = {
       path: `/gesetze/${version.legislationIdentifier}`,
       query: { from: route.query.from },
     };
 
-    const selectable =
-      version.legislationIdentifier !== props.currentLegislationIdentifier;
-
-    const rowData: TableRowData = {
-      id: id,
-      fromDate: dateFormattedDDMMYYYY(validityInterval?.from) ?? "-",
-      toDate: dateFormattedDDMMYYYY(validityInterval?.to) ?? "-",
-      status: status,
-      link: link,
-      selectable: selectable,
+    const status = formatNormValidity(version.temporalCoverage) ?? {
+      label: "Unbekannt",
+      color: BadgeColor.BLUE,
     };
 
-    return rowData;
+    return {
+      key: version.legislationIdentifier ?? "",
+      attrs: { to },
+      current,
+      fromDate: dateFormattedDDMMYYYY(validityInterval?.from) ?? "–",
+      toDate: dateFormattedDDMMYYYY(validityInterval?.to) ?? "–",
+      status,
+    };
   });
 });
-
-const rowClass = (row: TableRowData) => {
-  return row.selectable
-    ? "group cursor-pointer"
-    : "cursor-not-allowed pointer-event-none bg-blue-100 text-gray-1000";
-};
-
-async function onRowSelect() {
-  if (selectedVersion.value) await navigateTo(selectedVersion.value.link);
-}
-
-async function handleSelectionUpdate(newSelection: TableRowData) {
-  // Necessary so the unselectable row is never highlighted as selected
-  if (newSelection.selectable) selectedVersion.value = newSelection;
-  else selectedVersion.value = undefined;
-}
 </script>
 
 <template>
-  <DataTable
-    v-model:selection="selectedVersion"
-    selection-mode="single"
-    data-key="id"
-    :value="tableRowData"
-    :loading="status === 'pending'"
-    :row-class="rowClass"
-    @row-select="onRowSelect"
-    @update:selection="handleSelectionUpdate"
-    :pt="{ emptyMessageCell: { class: 'ps-16 py-12 text-left text-gray-900' } }"
+  <UiDataTable
+    :columns="columns"
+    :row-as="NuxtLink"
+    :rows="rows"
+    aria-label="Fassungen"
+    class="-mx-16 md:mx-0"
   >
+    <template #cell-status="{ row }">
+      <UiBadge :label="row.status.label" :color="row.status.color" />
+    </template>
+
     <template #empty>Keine Ergebnisse gefunden</template>
-    <Column
-      field="fromDate"
-      header="Gültig ab"
-      header-class="whitespace-nowrap w-1"
-    />
-    <Column
-      field="toDate"
-      header="Gültig bis"
-      header-class="whitespace-nowrap w-1"
-    />
-    <Column header="Status">
-      <template #body="{ data: { status } }">
-        <div class="flex justify-between">
-          <UiBadge v-if="status" :label="status.label" :color="status.color" />
-        </div>
-      </template>
-    </Column>
-  </DataTable>
+  </UiDataTable>
 </template>

--- a/frontend/src/components/ui/Badge.stories.ts
+++ b/frontend/src/components/ui/Badge.stories.ts
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
 import { html } from "../../utils/tags";
-import Badge, { BadgeColor } from "./Badge.vue";
+import UiBadge, { BadgeColor } from "./Badge.vue";
 
-const meta: Meta<typeof Badge> = {
-  component: Badge,
+const meta: Meta<typeof UiBadge> = {
+  component: UiBadge,
   tags: ["autodocs"],
   args: {
     label: "Badge",
@@ -28,10 +28,10 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: (args) => ({
-    components: { Badge },
+    components: { UiBadge },
     setup() {
       return { args };
     },
-    template: html`<Badge v-bind="args" />`,
+    template: html`<UiBadge v-bind="args" />`,
   }),
 };

--- a/frontend/src/components/ui/DataTable.spec.ts
+++ b/frontend/src/components/ui/DataTable.spec.ts
@@ -1,0 +1,150 @@
+import { render, screen } from "@testing-library/vue";
+import { describe, it, expect } from "vitest";
+import { h } from "vue";
+import DataTable, { type DataTableColumn } from "./DataTable.vue";
+
+type Row = {
+  key: string;
+  attrs?: Record<string, unknown>;
+  current?: boolean;
+  fromDate: string;
+  status: string;
+};
+
+const columns: DataTableColumn<Row>[] = [
+  { key: "fromDate", label: "Gültig ab" },
+  { key: "status", label: "Status" },
+];
+
+const rows: Row[] = [
+  { key: "a", fromDate: "27.10.2026", status: "Zukünftig in Kraft" },
+  { key: "b", fromDate: "15.08.2025", status: "Aktuell gültig" },
+];
+
+type Props = {
+  columns: DataTableColumn<Row>[];
+  rowAs?: string;
+  rows: Row[];
+};
+
+/**
+ * `render` can't infer the component's type parameter and falls back to its
+ * constraint, so the strongly typed props need a cast to get through.
+ */
+function renderTable(
+  props: Props,
+  options: {
+    slots?: Record<string, unknown>;
+    attrs?: Record<string, unknown>;
+  } = {},
+) {
+  return render(DataTable, { props, ...options } as never);
+}
+
+const linkedRows = rows.map((row) => ({
+  ...row,
+  attrs: { href: `/${row.key}` },
+}));
+
+describe("DataTable", () => {
+  it("renders a list with one item per row", () => {
+    renderTable({ columns, rows });
+
+    expect(screen.getByRole("list")).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("renders cell values as plain text by default", () => {
+    renderTable({ columns, rows });
+
+    expect(screen.getByText("27.10.2026")).toBeInTheDocument();
+    expect(screen.getByText("Zukünftig in Kraft")).toBeInTheDocument();
+  });
+
+  it("renders the column labels once as a header and once per row", () => {
+    renderTable({ columns, rows });
+
+    // The visual header row, which is hidden from assistive technology
+    expect(screen.getByText("Gültig ab").closest("li")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+
+    // The per-row labels, which carry the information for screen readers and
+    // are shown next to the value on narrow viewports
+    expect(screen.getAllByText("Gültig ab:")).toHaveLength(2);
+  });
+
+  it("keeps the decorative header row out of the accessibility tree", () => {
+    renderTable({ columns, rows });
+
+    // Would be 3 if the header row were exposed as a list item
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("renders rows as links when rowAs and attrs are given", () => {
+    renderTable({ columns, rowAs: "a", rows: linkedRows });
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute("href", "/a");
+    expect(links[1]).toHaveAttribute("href", "/b");
+  });
+
+  it("gives each row link an accessible name built from labels and values", () => {
+    renderTable({ columns, rowAs: "a", rows: [linkedRows[0]!] });
+
+    expect(
+      screen.getByRole("link", {
+        name: "Gültig ab: 27.10.2026 Status: Zukünftig in Kraft",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("marks the current row as the current page", () => {
+    renderTable({
+      columns,
+      rowAs: "a",
+      rows: linkedRows.map((row) => ({ ...row, current: row.key === "b" })),
+    });
+
+    const links = screen.getAllByRole("link");
+    expect(links[0]).not.toHaveAttribute("aria-current");
+    expect(links[1]).toHaveAttribute("aria-current", "page");
+  });
+
+  it("renders the cell slot and passes row and column as scope", () => {
+    renderTable(
+      { columns, rows },
+      {
+        slots: {
+          "cell-status": (scope: { row: Row; column: DataTableColumn<Row> }) =>
+            h(
+              "span",
+              { "data-testid": "status" },
+              `${scope.column.label}: ${scope.row.status}`,
+            ),
+        },
+      },
+    );
+
+    const cells = screen.getAllByTestId("status");
+    expect(cells).toHaveLength(2);
+    expect(cells[0]).toHaveTextContent("Status: Zukünftig in Kraft");
+  });
+
+  it("renders the empty slot when there are no rows", () => {
+    renderTable(
+      { columns, rows: [] },
+      { slots: { empty: () => "Keine Ergebnisse gefunden" } },
+    );
+
+    expect(screen.getByText("Keine Ergebnisse gefunden")).toBeInTheDocument();
+  });
+
+  it("passes through native attributes", () => {
+    renderTable({ columns, rows }, { attrs: { "aria-label": "Fassungen" } });
+
+    expect(screen.getByRole("list", { name: "Fassungen" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/DataTable.stories.ts
+++ b/frontend/src/components/ui/DataTable.stories.ts
@@ -1,0 +1,184 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import type { ConcreteComponent } from "vue";
+import { html } from "../../utils/tags";
+import UiBadge, { BadgeColor } from "./Badge.vue";
+import UiDataTable, { type DataTableColumn } from "./DataTable.vue";
+
+type VersionRow = {
+  key: string;
+  attrs?: Record<string, unknown>;
+  current?: boolean;
+  fromDate: string;
+  toDate: string;
+  status: string;
+};
+
+const columns: DataTableColumn<VersionRow>[] = [
+  { key: "fromDate", label: "Gültig ab" },
+  { key: "toDate", label: "Gültig bis" },
+  { key: "status", label: "Status" },
+];
+
+const rows: VersionRow[] = [
+  {
+    key: "unknown",
+    fromDate: "–",
+    toDate: "–",
+    status: "Unbekannt",
+  },
+  {
+    key: "future",
+    fromDate: "27.10.2026",
+    toDate: "–",
+    status: "Zukünftig in Kraft",
+  },
+  {
+    key: "current",
+    fromDate: "15.08.2025",
+    toDate: "26.10.2026",
+    status: "Aktuell gültig",
+  },
+  {
+    key: "expired",
+    fromDate: "28.02.2025",
+    toDate: "14.08.2025",
+    status: "Außer Kraft",
+  },
+];
+
+/**
+ * The component is generic over the row type. Spelling the args out explicitly
+ * keeps Storybook from resolving the type parameter to its constraint, which
+ * would reject the column keys below.
+ */
+type DataTableArgs = {
+  columns: DataTableColumn<VersionRow>[];
+  rowAs?: string;
+  rows: VersionRow[];
+};
+
+const meta: Meta<DataTableArgs> = {
+  // The component is generic, so its type doesn't match the concrete component
+  // signature Storybook expects. `DataTableArgs` above describes the props.
+  component: UiDataTable as unknown as ConcreteComponent<DataTableArgs>,
+  tags: ["autodocs"],
+  args: {
+    columns,
+    rowAs: undefined,
+    rows,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { UiDataTable },
+    setup() {
+      return { args };
+    },
+    template: html`<UiDataTable v-bind="args" aria-label="Fassungen" />`,
+  }),
+};
+
+/**
+ * Whole rows become links by passing a link component (or a plain `a`) as
+ * `rowAs`. The per-row target lives in `row.attrs`, so the browser's own
+ * context menu works — unlike a click handler on the row.
+ */
+export const Links: Story = {
+  args: {
+    rowAs: "a",
+    rows: rows.map((row) => ({ ...row, attrs: { href: `#${row.key}` } })),
+  },
+  render: (args) => ({
+    components: { UiDataTable },
+    setup() {
+      return { args };
+    },
+    template: html`<UiDataTable v-bind="args" aria-label="Fassungen" />`,
+  }),
+};
+
+/** The row the user is currently on is highlighted and marked `aria-current`. */
+export const CurrentRow: Story = {
+  args: {
+    rowAs: "a",
+    rows: rows.map((row) => ({
+      ...row,
+      attrs: { href: `#${row.key}` },
+      current: row.key === "current",
+    })),
+  },
+  render: (args) => ({
+    components: { UiDataTable },
+    setup() {
+      return { args };
+    },
+    template: html`<UiDataTable v-bind="args" aria-label="Fassungen" />`,
+  }),
+};
+
+/**
+ * Cells render as plain text by default. A `cell-<key>` slot overrides a single
+ * column, here to render the status as a badge.
+ */
+export const CustomCell: Story = {
+  render: () => ({
+    components: { UiDataTable, UiBadge },
+    setup() {
+      return {
+        columns,
+        rows: [
+          {
+            key: "unknown",
+            fromDate: "–",
+            toDate: "–",
+            status: { label: "Unbekannt", color: BadgeColor.BLUE },
+          },
+          {
+            key: "future",
+            fromDate: "27.10.2026",
+            toDate: "–",
+            status: { label: "Zukünftig in Kraft", color: BadgeColor.YELLOW },
+          },
+          {
+            key: "current",
+            fromDate: "15.08.2025",
+            toDate: "26.10.2026",
+            status: { label: "Aktuell gültig", color: BadgeColor.GREEN },
+          },
+          {
+            key: "expired",
+            fromDate: "28.02.2025",
+            toDate: "14.08.2025",
+            status: { label: "Außer Kraft", color: BadgeColor.RED },
+          },
+        ],
+      };
+    },
+    template: html`
+      <UiDataTable :columns="columns" :rows="rows" aria-label="Fassungen">
+        <template #cell-status="{ row }">
+          <UiBadge :label="row.status.label" :color="row.status.color" />
+        </template>
+      </UiDataTable>
+    `,
+  }),
+};
+
+export const Empty: Story = {
+  args: { rows: [] },
+  render: (args) => ({
+    components: { UiDataTable },
+    setup() {
+      return { args };
+    },
+    template: html`
+      <UiDataTable v-bind="args" aria-label="Fassungen">
+        <template #empty>Keine Ergebnisse gefunden</template>
+      </UiDataTable>
+    `,
+  }),
+};

--- a/frontend/src/components/ui/DataTable.stories.ts
+++ b/frontend/src/components/ui/DataTable.stories.ts
@@ -46,11 +46,6 @@ const rows: VersionRow[] = [
   },
 ];
 
-/**
- * The component is generic over the row type. Spelling the args out explicitly
- * keeps Storybook from resolving the type parameter to its constraint, which
- * would reject the column keys below.
- */
 type DataTableArgs = {
   columns: DataTableColumn<VersionRow>[];
   rowAs?: string;
@@ -58,8 +53,6 @@ type DataTableArgs = {
 };
 
 const meta: Meta<DataTableArgs> = {
-  // The component is generic, so its type doesn't match the concrete component
-  // signature Storybook expects. `DataTableArgs` above describes the props.
   component: UiDataTable as unknown as ConcreteComponent<DataTableArgs>,
   tags: ["autodocs"],
   args: {
@@ -82,11 +75,6 @@ export const Default: Story = {
   }),
 };
 
-/**
- * Whole rows become links by passing a link component (or a plain `a`) as
- * `rowAs`. The per-row target lives in `row.attrs`, so the browser's own
- * context menu works — unlike a click handler on the row.
- */
 export const Links: Story = {
   args: {
     rowAs: "a",
@@ -101,7 +89,6 @@ export const Links: Story = {
   }),
 };
 
-/** The row the user is currently on is highlighted and marked `aria-current`. */
 export const CurrentRow: Story = {
   args: {
     rowAs: "a",
@@ -120,10 +107,6 @@ export const CurrentRow: Story = {
   }),
 };
 
-/**
- * Cells render as plain text by default. A `cell-<key>` slot overrides a single
- * column, here to render the status as a badge.
- */
 export const CustomCell: Story = {
   render: () => ({
     components: { UiDataTable, UiBadge },

--- a/frontend/src/components/ui/DataTable.vue
+++ b/frontend/src/components/ui/DataTable.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts" generic="T extends DataTableRow">
+import { computed, type Component } from "vue";
+
+export type DataTableColumn<T> = {
+  /**
+   * Property of the row rendered in this column. Doubles as the suffix of the
+   * `cell-<key>` slot name.
+   */
+  key: Extract<keyof T, string>;
+  /**
+   * Column header on wide viewports, and the label in front of the value on
+   * narrow ones.
+   */
+  label: string;
+};
+
+export type DataTableRow = {
+  /** Stable identity of the row. */
+  key: string;
+  /**
+   * Attributes applied onto the row element. Use this to turn rows into links,
+   * e.g. `{ to: "/target" }` together with a link component as `rowAs`, or `{
+   * href: "/target" }` together with `rowAs="a"`.
+   */
+  attrs?: Record<string, unknown>;
+  /**
+   * Marks the row as the one currently being displayed. It is highlighted and
+   * announced as the current page.
+   */
+  current?: boolean;
+};
+
+const {
+  columns,
+  rowAs = "div",
+  rows,
+} = defineProps<{
+  /** Columns to render, in order. */
+  columns: DataTableColumn<T>[];
+  /**
+   * Element or component used for each row. Pass a link component to make whole
+   * rows navigable; use `row.attrs` to apply props to the component.
+   */
+  rowAs?: string | Component;
+  /** Rows to render, in order. */
+  rows: T[];
+}>();
+
+defineSlots<
+  {
+    /** Shown in place of the rows when there are none. */
+    empty?: () => unknown;
+  } & {
+    /**
+     * Overrides how the cell of the column with that key is rendered. Without
+     * it, the row's value for that key is rendered as plain text.
+     */
+    [key in `cell-${string}`]?: (props: {
+      row: T;
+      column: DataTableColumn<T>;
+    }) => unknown;
+  }
+>();
+
+const gridTemplateColumns = computed(() =>
+  // Columns are sized to their content, except for the last one which takes up
+  // the remaining space.
+  columns.length > 1
+    ? `repeat(${columns.length - 1}, auto) minmax(0, 1fr)`
+    : "minmax(0, 1fr)",
+);
+</script>
+
+<template>
+  <ul
+    class="border-t border-gray-400 md:grid md:[grid-template-columns:var(--data-table-columns)] md:border-t-0"
+    :style="{ '--data-table-columns': gridTemplateColumns }"
+  >
+    <!-- Decorative: every row repeats the column labels for assistive
+         technology, so exposing them here as well would only add noise. -->
+    <li
+      v-if="columns.length"
+      class="hidden border-b border-gray-400 md:col-span-full md:grid md:grid-cols-subgrid"
+      aria-hidden="true"
+    >
+      <span
+        v-for="column in columns"
+        :key="column.key"
+        class="typo-label1-bold p-16"
+      >
+        {{ column.label }}
+      </span>
+    </li>
+
+    <template v-if="rows.length">
+      <li
+        v-for="row in rows"
+        :key="row.key"
+        :class="{ 'bg-gray-100': row.current }"
+        class="border-b border-gray-400 hover:bg-gray-100 md:col-span-full md:grid md:grid-cols-subgrid"
+      >
+        <component
+          :is="rowAs"
+          :aria-current="row.current ? 'page' : undefined"
+          class="grid grid-cols-[max-content_minmax(0,1fr)] items-center gap-x-24 gap-y-16 p-16 focus-visible:outline-4 focus-visible:-outline-offset-4 focus-visible:outline-blue-800 md:col-span-full md:grid-cols-subgrid md:gap-0 md:p-0"
+          v-bind="row.attrs"
+        >
+          <template v-for="column in columns" :key="column.key">
+            <span class="typo-label1-bold md:sr-only">{{ column.label }}:</span>
+            {{ " " }}
+            <span class="typo-label1-regular md:p-16">
+              <slot :name="`cell-${column.key}`" :row="row" :column="column">
+                {{ row[column.key] }}
+              </slot>
+            </span>
+            {{ " " }}
+          </template>
+        </component>
+      </li>
+    </template>
+
+    <template v-else>
+      <li class="px-16 py-12 text-left text-gray-900 md:col-span-full">
+        <slot name="empty" />
+      </li>
+    </template>
+  </ul>
+</template>

--- a/frontend/src/components/ui/DataTable.vue
+++ b/frontend/src/components/ui/DataTable.vue
@@ -102,7 +102,7 @@ const gridTemplateColumns = computed(() =>
         <component
           :is="rowAs"
           :aria-current="row.current ? 'page' : undefined"
-          class="grid grid-cols-[max-content_minmax(0,1fr)] items-center gap-x-24 gap-y-16 p-16 focus-visible:outline-4 focus-visible:-outline-offset-4 focus-visible:outline-blue-800 md:col-span-full md:grid-cols-subgrid md:gap-0 md:p-0"
+          class="grid grid-cols-[max-content_minmax(0,1fr)] items-center gap-16 p-16 focus-visible:outline-4 focus-visible:-outline-offset-4 focus-visible:outline-blue-800 md:col-span-full md:grid-cols-subgrid md:gap-0 md:p-0"
           v-bind="row.attrs"
         >
           <template v-for="column in columns" :key="column.key">

--- a/frontend/src/components/ui/ProgressSpinner.stories.ts
+++ b/frontend/src/components/ui/ProgressSpinner.stories.ts
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
 import { html } from "../../utils/tags";
-import ProgressSpinner from "./ProgressSpinner.vue";
+import UiProgressSpinner from "./ProgressSpinner.vue";
 
-const meta: Meta<typeof ProgressSpinner> = {
-  component: ProgressSpinner,
+const meta: Meta<typeof UiProgressSpinner> = {
+  component: UiProgressSpinner,
   tags: ["autodocs"],
 };
 
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: () => ({
-    components: { ProgressSpinner },
-    template: html`<ProgressSpinner />`,
+    components: { UiProgressSpinner },
+    template: html`<UiProgressSpinner />`,
   }),
 };

--- a/frontend/src/components/ui/Textarea.stories.ts
+++ b/frontend/src/components/ui/Textarea.stories.ts
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from "@storybook/vue3-vite";
 import { ref } from "vue";
 import IcBaselineErrorOutline from "~icons/ic/baseline-error-outline";
 import { html } from "../../utils/tags";
-// Imported as UiTextarea for consistency with the other ui stories.
 import UiTextarea from "./Textarea.vue";
 
 // placeholder/disabled/readonly are native attributes handled via fallthrough,

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -327,7 +327,6 @@ const fassungenDateFilterInputId = useId();
                 />
               </div>
               <DocumentsNormsVersionList
-                :status="normVersionsStatus"
                 :current-legislation-identifier="
                   metadata.legislationIdentifier ?? ''
                 "


### PR DESCRIPTION
- migrates PrimeVue's data table component to a simplified, list-based custom version
- re-implements the versions list using the new data table with actual links and mobile design