### PR TITLE
RISDEV-11721 improved client error status detection for Sentry

### DIFF
--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -10,16 +10,12 @@ if (config.public.sentryDSN) {
 
     // Errors thrown via `createError` (e.g. 404s) surface through Nuxt's
     // `vue:error` hook, which the Sentry SDK reports without filtering by status
-    // code (unlike its `app:error` hook). Drop client errors here so they don't
-    // reach Sentry. Client-only: the server side already filters these via the
-    // Nitro error handler.
+    // code at all, and through its `app:error` hook, which only filters errors
+    // it recognizes as Nuxt errors. Drop client errors here so they don't reach
+    // Sentry. Client-only: the server side already filters these via the Nitro
+    // error handler.
     beforeSend(event, hint) {
-      const error = hint.originalException;
-      const status = isNuxtError(error) ? error.status : undefined;
-      const shouldSuppress =
-        status !== undefined && status >= 300 && status < 500;
-
-      return shouldSuppress ? null : event;
+      return shouldSuppressSentryEvent(hint.originalException) ? null : event;
     },
 
     ignoreErrors: [

--- a/frontend/src/composables/usePostHog.spec.ts
+++ b/frontend/src/composables/usePostHog.spec.ts
@@ -58,6 +58,7 @@ describe("usePostHog", () => {
     resetPostHogState();
     cookieStoreBackend.clear();
     vi.clearAllMocks();
+    vi.stubGlobal("cookieStore", cookieStoreMock);
   });
 
   it("initializes postHog when userConsent is true", async () => {
@@ -136,6 +137,23 @@ describe("usePostHog", () => {
         sameSite: "lax",
       }),
     );
+    expect(userConsent.value).toBe(true);
+    expect(postHog.value?.opt_in_capturing).toHaveBeenCalled();
+  });
+
+  it("keeps working in browsers without the Cookie Store API", async () => {
+    vi.stubGlobal("cookieStore", undefined);
+    const { initialize, setTracking, isBannerVisible, userConsent, postHog } =
+      usePostHog();
+
+    // Would throw a `ReferenceError` if the API was accessed unconditionally,
+    // which breaks app initialization since the PostHog plugin awaits this.
+    await initialize();
+    expect(userConsent.value).toBeUndefined();
+    expect(isBannerVisible.value).toBe(true);
+
+    // Consent can't be persisted, but it still applies for the session
+    await setTracking(true);
     expect(userConsent.value).toBe(true);
     expect(postHog.value?.opt_in_capturing).toHaveBeenCalled();
   });

--- a/frontend/src/composables/usePostHog.ts
+++ b/frontend/src/composables/usePostHog.ts
@@ -67,6 +67,16 @@ export function resetPostHogState() {
   userConsent.value = undefined;
 }
 
+/**
+ * Returns the Cookie Store API, or `undefined` in browsers that don't support
+ * it (e.g. older versions of Safari). Accessing the global unconditionally
+ * throws a `ReferenceError` there, which breaks app initialization because the
+ * PostHog plugin awaits `initialize()`. Consent can't be persisted without it.
+ */
+function getCookieStore(): typeof cookieStore | undefined {
+  return typeof cookieStore === "undefined" ? undefined : cookieStore;
+}
+
 /** Composable for managing PostHog analytics and user consent. */
 export function usePostHog() {
   const config = useRuntimeConfig();
@@ -89,7 +99,7 @@ export function usePostHog() {
    * application starts.
    */
   async function initialize() {
-    const cookie = await cookieStore.get(CONSENT_COOKIE_NAME);
+    const cookie = await getCookieStore()?.get(CONSENT_COOKIE_NAME);
     userConsent.value = cookie ? stringToBoolean(cookie.value) : undefined;
     if (userConsent.value) activatePostHog();
     else await deactivatePostHog();
@@ -114,19 +124,23 @@ export function usePostHog() {
     postHog.value?.clear_opt_in_out_capturing();
     postHog.value = undefined;
 
-    (await cookieStore.getAll()).forEach(({ name }) => {
-      if (name?.startsWith("ph_")) cookieStore.delete({ name, path: "/" });
+    const store = getCookieStore();
+    if (!store) return;
+
+    (await store.getAll()).forEach(({ name }) => {
+      if (name?.startsWith("ph_")) store.delete({ name, path: "/" });
     });
   }
 
   /** Retrieves the user's PostHog distinct ID from cookies. */
   async function getUserPostHogId() {
-    if (import.meta.server || typeof cookieStore === "undefined" || !key) {
+    const store = getCookieStore();
+    if (import.meta.server || !store || !key) {
       return "anonymous_feedback_user";
     }
 
     try {
-      const cookie = await cookieStore.get(`ph_${key}_posthog`);
+      const cookie = await store.get(`ph_${key}_posthog`);
       if (cookie?.value) {
         const phCookieObject = JSON.parse(cookie.value);
         return phCookieObject.distinct_id ?? "anonymous_feedback_user";
@@ -172,7 +186,7 @@ export function usePostHog() {
     const expiresAt = new Date();
     expiresAt.setFullYear(expiresAt.getFullYear() + 1);
 
-    await cookieStore.set({
+    await getCookieStore()?.set({
       name: CONSENT_COOKIE_NAME,
       value: userHasAccepted.toString(),
       expires: expiresAt.getTime(),

--- a/frontend/src/utils/sentry.spec.ts
+++ b/frontend/src/utils/sentry.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { shouldSuppressSentryEvent } from "~/utils/sentry";
+
+function serializedPayloadError(status: number) {
+  return {
+    data: { path: "/case-law/KVRE460072401" },
+    error: "true",
+    message: `Page not found: /case-law/KVRE460072401`,
+    status,
+    statusCode: status,
+    statusMessage: `Page not found: /case-law/KVRE460072401`,
+    statusText: `Page not found: /case-law/KVRE460072401`,
+    url: "/case-law/KVRE460072401",
+  };
+}
+
+describe("sentry", () => {
+  describe("shouldSuppressSentryEvent", () => {
+    it("suppresses client errors created via createError", () => {
+      expect(shouldSuppressSentryEvent(createError({ status: 404 }))).toBe(
+        true,
+      );
+    });
+
+    it("reports server errors created via createError", () => {
+      expect(shouldSuppressSentryEvent(createError({ status: 500 }))).toBe(
+        false,
+      );
+    });
+
+    it("suppresses client errors that lost their Nuxt error marker", () => {
+      expect(shouldSuppressSentryEvent(serializedPayloadError(404))).toBe(true);
+    });
+
+    it("reports server errors that lost their Nuxt error marker", () => {
+      expect(shouldSuppressSentryEvent(serializedPayloadError(500))).toBe(
+        false,
+      );
+    });
+
+    it("reports errors that are not Nuxt errors, even with a client error status", () => {
+      const fetchError = Object.assign(new Error("Not Found"), {
+        status: 404,
+        statusCode: 404,
+      });
+
+      expect(shouldSuppressSentryEvent(fetchError)).toBe(false);
+    });
+
+    it.each([
+      [299, false],
+      [300, true],
+      [499, true],
+      [500, false],
+    ])("handles the status %i at the range boundaries", (status, expected) => {
+      expect(shouldSuppressSentryEvent({ status })).toBe(expected);
+    });
+
+    it("falls back to statusCode when status is missing", () => {
+      expect(shouldSuppressSentryEvent({ statusCode: 404 })).toBe(true);
+      expect(shouldSuppressSentryEvent({ statusCode: 500 })).toBe(false);
+    });
+
+    it.each([undefined, null, "404", 404, {}, { status: "not a status" }])(
+      "reports %o, which carries no usable status",
+      (error) => {
+        expect(shouldSuppressSentryEvent(error)).toBe(false);
+      },
+    );
+  });
+});

--- a/frontend/src/utils/sentry.ts
+++ b/frontend/src/utils/sentry.ts
@@ -1,0 +1,31 @@
+/**
+ * Whether an error captured by Sentry is a 3xx/4xx error page error, e.g. a 404
+ * created via `createError` or `showError`, which we don't want to report.
+ *
+ * Checking `isNuxtError` is not sufficient here, because that is only true for
+ * errors thrown on the client. An error thrown on the server is serialized to
+ * JSON, losing its Error type and internal markers that `isNuxtError` uses for
+ * detecting its own errors. Instead, we'll check the shape, but cancel if:
+ *
+ * - The error is not an object at all, and therefore guaranteed not to have a
+ *   status property
+ * - The object is an Error but not a Nuxt error - that way we know it has been
+ *   thrown on the client, but has originated somewhere else. Deliberately left
+ *   alone, even if they carry a status, so that any unhandled errors are still
+ *   reported.
+ */
+export function shouldSuppressSentryEvent(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  if (error instanceof Error && !isNuxtError(error)) return false;
+
+  const { status, statusCode } = error as {
+    status?: unknown;
+    statusCode?: unknown;
+  };
+
+  const parsedStatus = Number(status ?? statusCode);
+
+  return (
+    Number.isFinite(parsedStatus) && parsedStatus >= 300 && parsedStatus < 500
+  );
+}


### PR DESCRIPTION
- Updates error status filtering to also work with errors that have been serialized in SSR, and therefore lost their Nuxt error type
- Fixes a crash in the PostHog setup in older browsers that don't support the Cookie Store API, which was the underlying issue that caused the error report