### PR TITLE
RISDEV-10909 make data table internal cell spacing less dependent on content height

### DIFF
--- a/frontend/src/components/ui/DataTable.vue
+++ b/frontend/src/components/ui/DataTable.vue
@@ -86,7 +86,7 @@ const gridTemplateColumns = computed(() =>
       <span
         v-for="column in columns"
         :key="column.key"
-        class="typo-label1-bold p-16"
+        class="typo-label1-bold flex min-h-48 items-center px-16 py-10"
       >
         {{ column.label }}
       </span>
@@ -102,13 +102,17 @@ const gridTemplateColumns = computed(() =>
         <component
           :is="rowAs"
           :aria-current="row.current ? 'page' : undefined"
-          class="grid grid-cols-[max-content_minmax(0,1fr)] items-center gap-16 p-16 focus-visible:outline-4 focus-visible:-outline-offset-4 focus-visible:outline-blue-800 md:col-span-full md:grid-cols-subgrid md:gap-0 md:p-0"
+          class="grid grid-cols-[max-content_minmax(0,1fr)] items-center gap-x-16 gap-y-8 p-16 focus-visible:outline-4 focus-visible:-outline-offset-4 focus-visible:outline-blue-800 md:col-span-full md:grid-cols-subgrid md:gap-0 md:p-0"
           v-bind="row.attrs"
         >
           <template v-for="column in columns" :key="column.key">
-            <span class="typo-label1-bold md:sr-only">{{ column.label }}:</span>
+            <span class="typo-label1-bold flex min-h-32 items-center md:sr-only"
+              >{{ column.label }}:</span
+            >
             {{ " " }}
-            <span class="typo-label1-regular md:p-16">
+            <span
+              class="typo-label1-regular flex min-h-32 items-center md:min-h-48 md:px-16"
+            >
               <slot :name="`cell-${column.key}`" :row="row" :column="column">
                 {{ row[column.key] }}
               </slot>

--- a/frontend/src/components/ui/DataTable.vue
+++ b/frontend/src/components/ui/DataTable.vue
@@ -73,7 +73,7 @@ const gridTemplateColumns = computed(() =>
 
 <template>
   <ul
-    class="border-t border-gray-400 md:grid md:[grid-template-columns:var(--data-table-columns)] md:border-t-0"
+    class="border-t border-gray-400 md:grid md:grid-cols-(--data-table-columns) md:border-t-0"
     :style="{ '--data-table-columns': gridTemplateColumns }"
   >
     <!-- Decorative: every row repeats the column labels for assistive


### PR DESCRIPTION
Instead of deriving the line height from content height + padding, set a minimum line height that matches the designs visually, reduce vertical padding, and center the items. Looks the same, but gives cell content a bit more flexibility before it pushes the size of the row.