### PR TITLE
RISDEV-11432 Infra and Backend Maintenance tasks

### DIFF
--- a/backend/src/main/resources/application-production.yaml
+++ b/backend/src/main/resources/application-production.yaml
@@ -1,8 +1,12 @@
 server:
+  #This url will change before go live
+  front-end-url: "https://ris-portal.prod.tech.digitalservice.dev/"
+  docs-url: "https://docs.rechtsinformationen.bund.de/"
   cms-url: "https://content-management.ris.bund.de/"
 
 swagger:
   server:
+    #This url will change before go live
     url: "https://ris-portal.prod.tech.digitalservice.dev/"
 
 spring:
@@ -10,18 +14,6 @@ spring:
     import:
       - "kubernetes:"
       - "optional:configtree:/etc/secrets/*/"
-  cloud:
-    kubernetes:
-      config:
-        fail-fast: true
-        sources:
-          - name: ris-search-opensearch-config
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health,info,prometheus
 
 s3:
   file-storage:

--- a/backend/src/main/resources/application-prototype.yaml
+++ b/backend/src/main/resources/application-prototype.yaml
@@ -1,6 +1,7 @@
 server:
   front-end-url: "https://testphase.rechtsinformationen.bund.de/"
   docs-url: "https://docs.rechtsinformationen.bund.de/"
+  cms-url: "https://content-management.ris.bund.de/"
 
 swagger:
   server:
@@ -11,25 +12,6 @@ spring:
     import:
       - "kubernetes:"
       - "optional:configtree:/etc/secrets/*/"
-  cloud:
-    kubernetes:
-      config:
-        fail-fast: true
-        sources:
-          - name: ris-search-opensearch-prototype-config
-          - name: posthog-config
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health,info,prometheus
-
-# Used for sending feedback to posthog
-posthog:
-  api-key:
-  host:
-  feedback-survey-id:
 
 s3:
   file-storage:

--- a/backend/src/main/resources/application-staging.yaml
+++ b/backend/src/main/resources/application-staging.yaml
@@ -12,12 +12,6 @@ spring:
       - "kubernetes:"
       - "optional:configtree:/etc/secrets/*/"
 
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health,info,prometheus
-
 s3:
   file-storage:
     case-law:

--- a/backend/src/main/resources/application-uat.yaml
+++ b/backend/src/main/resources/application-uat.yaml
@@ -11,18 +11,6 @@ spring:
     import:
       - "kubernetes:"
       - "optional:configtree:/etc/secrets/*/"
-  cloud:
-    kubernetes:
-      config:
-        fail-fast: true
-        sources:
-          - name: ris-search-opensearch-config
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health,info,prometheus
 
 s3:
   file-storage:

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -14,6 +14,12 @@ server:
   cms-url: ""
   api-keys: []
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+
 rate-limit:
   default:
     requests: 600
@@ -89,6 +95,11 @@ sentry:
   traces-sample-rate: 0.01
   minimum-event-level: "error"
 
+posthog:
+  api-key: ""
+  host: ""
+  feedback-survey-id: ""
+
 app:
   security:
     # Since the api also hosts the swagger files, this header is used for both the api AND some of the docs pages
@@ -97,16 +108,6 @@ app:
 
 logging:
   level:
-    de:
-      bund:
-        digitalservice:
-          ris:
-            search:
-              config:
-                httplogs: TRACE
-      springframework:
-        ws:
-          server:
-            MessageTracing:
-              sent: DEBUG
-              received: TRACE
+    de.bund.digitalservice.ris.search.config.httplogs: TRACE
+    springframework.ws.server.MessageTracing.sent: DEBUG
+    springframework.ws.server.MessageTracing.received: TRACE


### PR DESCRIPTION
* Move management endpoints to application.yaml so they are also available locally
* Move posthog properties to application.yaml with empty string as agreed by team convention
* Fixed bug in logging configuration related to soap webserver and flattened the config values
* Added placeholder urls for unfinished production and comments for clarity
* Removed kubernetes cloud config no longer needed from OTC after proof that staging works without it.