### PR TITLE
RISDEV-12253 render Eingangsformel footnotes in legislation HTML

### DIFF
--- a/backend/e2e-data/norm/eli/bund/bgbl-1/2000/s1016/2023-04-26/10/deu/2023-04-26/regelungstext-1.xml
+++ b/backend/e2e-data/norm/eli/bund/bgbl-1/2000/s1016/2023-04-26/10/deu/2023-04-26/regelungstext-1.xml
@@ -132,6 +132,7 @@
                 </akn:note>
                 <akn:note GUID="e139d37b-0714-4996-9269-6117aca521e2" eId="meta-n1_editfnote-n4" marker="#" placementBase="#präambel-n1_blockcontainer-n1" refersTo="aenderungsfussnote"><akn:p GUID="d3c6dd33-4847-4529-950f-f8e248c89715" eId="meta-n1_editfnote-n4_text-n1">Inhaltsübersicht: präambel Fußnote</akn:p></akn:note>
                 <akn:note GUID="e7777777-7777-7777-7777-777777777777" eId="meta-n1_editfnote-n5" marker="#" placementBase="#präambel-n1_formel-n1" refersTo="aenderungsfussnote"><akn:p GUID="e8888888-8888-8888-8888-888888888888" eId="meta-n1_editfnote-n5_text-n1">Eingangsformel: Diese Fußnote an der Eingangsformel wurde im End-to-end-Datenbestand ergänzt</akn:p></akn:note>
+                <akn:note GUID="e9999999-9999-9999-9999-999999999999" eId="meta-n1_editfnote-n6" marker="#" placementBase="#schluss-n1_formel-n1" refersTo="aenderungsfussnote"><akn:p GUID="7d8583f6-ae27-5308-9fe7-d1c4d6afa5c5" eId="meta-n1_editfnote-n6_text-n1">Schlussformel: Diese Fußnote an der Schlussformel wurde im End-to-end-Datenbestand ergänzt</akn:p></akn:note>
             </akn:notes>
             <akn:proprietary GUID="bb777777-7777-7777-7777-777777777777" eId="meta-n1_proprietary-n1" source="attributsemantik-noch-undefiniert">
                 <ris:legalDocML.de_metadaten xmlns:ris="http://MetadatenRIS.LegalDocML.de/1.8.2/" xsi:schemaLocation="http://MetadatenRIS.LegalDocML.de/1.8.2/ Grammatiken/legalDocML.de-metadaten-ris.xsd">

--- a/backend/e2e-data/norm/eli/bund/bgbl-1/2000/s1016/2023-04-26/10/deu/2023-04-26/regelungstext-1.xml
+++ b/backend/e2e-data/norm/eli/bund/bgbl-1/2000/s1016/2023-04-26/10/deu/2023-04-26/regelungstext-1.xml
@@ -131,6 +131,7 @@
                     <akn:p GUID="e6666666-6666-6666-6666-666666666666" eId="meta-n1_editfnote-n3_text-n1">Die V wurde von der Bundesregierung erlassen*.</akn:p>
                 </akn:note>
                 <akn:note GUID="e139d37b-0714-4996-9269-6117aca521e2" eId="meta-n1_editfnote-n4" marker="#" placementBase="#präambel-n1_blockcontainer-n1" refersTo="aenderungsfussnote"><akn:p GUID="d3c6dd33-4847-4529-950f-f8e248c89715" eId="meta-n1_editfnote-n4_text-n1">Inhaltsübersicht: präambel Fußnote</akn:p></akn:note>
+                <akn:note GUID="e7777777-7777-7777-7777-777777777777" eId="meta-n1_editfnote-n5" marker="#" placementBase="#präambel-n1_formel-n1" refersTo="aenderungsfussnote"><akn:p GUID="e8888888-8888-8888-8888-888888888888" eId="meta-n1_editfnote-n5_text-n1">Eingangsformel: Diese Fußnote an der Eingangsformel wurde im End-to-end-Datenbestand ergänzt</akn:p></akn:note>
             </akn:notes>
             <akn:proprietary GUID="bb777777-7777-7777-7777-777777777777" eId="meta-n1_proprietary-n1" source="attributsemantik-noch-undefiniert">
                 <ris:legalDocML.de_metadaten xmlns:ris="http://MetadatenRIS.LegalDocML.de/1.8.2/" xsi:schemaLocation="http://MetadatenRIS.LegalDocML.de/1.8.2/ Grammatiken/legalDocML.de-metadaten-ris.xsd">

--- a/backend/src/main/resources/XSLT/html/ldml_de/include/inhalt.xsl
+++ b/backend/src/main/resources/XSLT/html/ldml_de/include/inhalt.xsl
@@ -279,7 +279,7 @@
         <section class="{$eingangsformel}">
             <xsl:apply-templates select="node() | @*"/>
             <xsl:call-template name="notes-collection">
-                <xsl:with-param name="thisId" select="akn:blockContainer/@eId" />
+                <xsl:with-param name="thisId" select="@eId" />
             </xsl:call-template>
         </section>
     </xsl:template>
@@ -439,11 +439,17 @@
         </section>
     </xsl:template>
 
-    <!-- Regelungstext-Schluss :: Signaturblock -->
+    <!-- Regelungstext-Schluss :: Signaturblock
+         Dieses Template verarbeitet auch die Inhaltsübersicht (akn:blockContainer innerhalb von
+         akn:preamble). Eventuelle nichtamtliche Fußnoten folgen jeweils am Ende des Containers,
+         damit die HTML-Verschachtelung dem @placementBase der Fußnote entspricht. -->
     <xsl:template match="akn:blockContainer">
         <xsl:sequence select="akn:gliederungskommentar('Signaturblock (akn:blockContainer innerhalb von akn:conclusions)')"/>
         <div>
             <xsl:apply-templates select="node() | @*"/>
+            <xsl:call-template name="notes-collection">
+                <xsl:with-param name="thisId" select="@eId"/>
+            </xsl:call-template>
         </div>
     </xsl:template>
 

--- a/backend/src/main/resources/XSLT/html/ldml_de/ris-portal.xsl
+++ b/backend/src/main/resources/XSLT/html/ldml_de/ris-portal.xsl
@@ -115,6 +115,11 @@
                 </h2>
             </a>
             <xsl:apply-templates/>
+            <!-- output authorialNote and note contents at the end of the Eingangsformel -->
+            <xsl:call-template name="authorial-notes-collection"/>
+            <xsl:call-template name="notes-collection">
+                <xsl:with-param name="thisId" select="@eId"/>
+            </xsl:call-template>
         </section>
     </xsl:template>
 

--- a/backend/src/main/resources/XSLT/html/ldml_de/ris-portal.xsl
+++ b/backend/src/main/resources/XSLT/html/ldml_de/ris-portal.xsl
@@ -240,6 +240,11 @@
                 </h2>
             </a>
             <xsl:apply-templates/>
+            <!-- output authorialNote and note contents at the end of the Schlussformel -->
+            <xsl:call-template name="authorial-notes-collection"/>
+            <xsl:call-template name="notes-collection">
+                <xsl:with-param name="thisId" select="@eId"/>
+            </xsl:call-template>
         </section>
     </xsl:template>
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/xslt/NormXsltTransformerServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/xslt/NormXsltTransformerServiceTest.java
@@ -69,6 +69,7 @@ class NormXsltTransformerServiceTest {
     "main,         preambleFormulaNotes.xml, preambleFormulaNotes.html,                             Should output notes of a preamble formula",
     "main,         preambleFormulaAndTocNotes.xml, preambleFormulaAndTocNotes.html,                 Should output notes of a preamble formula and of the official toc in their own containers",
     "main,         conclusionsFormula.xml, conclusionsFormula.html,                                 Should transform a conclusions formula",
+    "main,         conclusionsFormulaNotes.xml, conclusionsFormulaNotes.html,                       Should output notes of a conclusions formula",
     "main,         blockList.xml, blockList.html,                                                   Should transform a blockList",
     "main,         preformatted.xml, preformatted.html,                                             Should transform preformatted paragraphs",
     "main,         proprietary.xml, proprietary.html,                                               Should transform proprietary metadata"

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/xslt/NormXsltTransformerServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/xslt/NormXsltTransformerServiceTest.java
@@ -162,7 +162,7 @@ class NormXsltTransformerServiceTest {
 
   @Test
   @DisplayName("Outputs the same Eingangsformel footnotes in the norm and the single article view")
-  void testPreambleFormulaNotesInBothViews() throws IOException, NoSuchKeyException {
+  void testPreambleFormulaNotesInBothViews() throws IOException {
     byte[] bytes = Files.readAllBytes(Path.of(resourcesPath, "preambleFormulaNotes.xml"));
 
     var normView =

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/xslt/NormXsltTransformerServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/xslt/NormXsltTransformerServiceTest.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Function;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -65,6 +66,8 @@ class NormXsltTransformerServiceTest {
     "main,         noPdfLinks.xml, noPdfLinks.html,                                                 Should not apply any special transformation to non-pdf links",
     "main,         container.xml, container.html,                                                   Should transform container elements in the preface",
     "main,         preambleFormula.xml, preambleFormula.html,                                       Should transform a preamble formula",
+    "main,         preambleFormulaNotes.xml, preambleFormulaNotes.html,                             Should output notes of a preamble formula",
+    "main,         preambleFormulaAndTocNotes.xml, preambleFormulaAndTocNotes.html,                 Should output notes of a preamble formula and of the official toc in their own containers",
     "main,         conclusionsFormula.xml, conclusionsFormula.html,                                 Should transform a conclusions formula",
     "main,         blockList.xml, blockList.html,                                                   Should transform a blockList",
     "main,         preformatted.xml, preformatted.html,                                             Should transform preformatted paragraphs",
@@ -154,6 +157,28 @@ class NormXsltTransformerServiceTest {
         .isEqualTo(
             """
             <span class="akn-num" id="c_num-1">§ 1</span> <span class="akn-heading" id="c_heading-1">Article title <a href="#c_heading-1_amtlfnote-1"><sup>1</sup></a></span>""");
+  }
+
+  @Test
+  @DisplayName("Outputs the same Eingangsformel footnotes in the norm and the single article view")
+  void testPreambleFormulaNotesInBothViews() throws IOException, NoSuchKeyException {
+    byte[] bytes = Files.readAllBytes(Path.of(resourcesPath, "preambleFormulaNotes.xml"));
+
+    var normView =
+        Jsoup.parse(service.transformNorm(bytes, "deu", RESOURCES_BASE_PATH, "regelungstext-1"));
+    var articleView =
+        Jsoup.parse(service.transformArticle(bytes, "präambel-n1_formel-n1", RESOURCES_BASE_PATH));
+
+    for (Document view : List.of(normView, articleView)) {
+      assertThat(view.select("ul.nichtamtliche-fussnoten > li.fussnote").text())
+          .isEqualTo("Eingangsformel: Note attached to the Eingangsformel");
+      assertThat(view.select("ol.fussnoten > li.fussnote").text())
+          .startsWith("* Authorial note in the Eingangsformel");
+    }
+
+    // both lists belong to the Eingangsformel, not to the enclosing preamble
+    assertThat(normView.select("#präambel-n1_formel-n1 > ul.nichtamtliche-fussnoten")).hasSize(1);
+    assertThat(normView.select("#präambel-n1_formel-n1 > ol.fussnoten")).hasSize(1);
   }
 
   @Test

--- a/backend/src/test/resources/data/XsltTransformerServiceTest/conclusionsFormulaNotes.html
+++ b/backend/src/test/resources/data/XsltTransformerServiceTest/conclusionsFormulaNotes.html
@@ -1,0 +1,17 @@
+<div class="akn-act">
+    <section class="schlussformel" id="schluss-n1_formel-n1">
+        <a href="regelungstext-1/schluss-n1_formel-n1.html">
+            <h2 class="einzelvorschrift"><span class="akn-heading"> Schlussformel </span></h2></a>
+        <p id="schluss-n1_formel-n1_text-n1">Der Bundesrat hat
+            zugestimmt.<a href="#schluss-n1_formel-n1_amtlfnote-n1"><sup>*</sup></a></p>
+        <ol class="fussnoten">
+            <li id="schluss-n1_formel-n1_amtlfnote-n1" class="fussnote"><span class="marker">*</span>
+                <p>Authorial note in the Schlussformel <a class="rueckverweis" aria-label="Zurück zum Inhalt"
+                                                          href="#schluss-n1_formel-n1_text-n1">↑</a></p></li>
+        </ol>
+        <ul class="nichtamtliche-fussnoten">
+            <li id="meta-n1_editfnote-n1" class="fussnote">
+                <p id="meta-n1_editfnote-n1_text-n1">Schlussformel: Note attached to the Schlussformel</p></li>
+        </ul>
+    </section>
+</div>

--- a/backend/src/test/resources/data/XsltTransformerServiceTest/conclusionsFormulaNotes.xml
+++ b/backend/src/test/resources/data/XsltTransformerServiceTest/conclusionsFormulaNotes.xml
@@ -1,0 +1,20 @@
+<akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.8.2/">
+    <akn:act name="regelungstext">
+        <akn:meta eId="meta-n1">
+            <akn:notes>
+                <akn:note eId="meta-n1_editfnote-n1" marker="#"
+                          placementBase="#schluss-n1_formel-n1" refersTo="kommentierende-fussnote">
+                    <akn:p eId="meta-n1_editfnote-n1_text-n1">Schlussformel: Note attached to the Schlussformel</akn:p>
+                </akn:note>
+            </akn:notes>
+        </akn:meta>
+        <akn:conclusions eId="schluss-n1">
+            <akn:formula eId="schluss-n1_formel-n1" refersTo="schlussformel">
+                <akn:p eId="schluss-n1_formel-n1_text-n1">Der Bundesrat hat zugestimmt.<akn:authorialNote
+                        eId="schluss-n1_formel-n1_amtlfnote-n1" marker="*">
+                    <akn:p eId="schluss-n1_formel-n1_amtlfnote-n1_text-n1">Authorial note in the Schlussformel</akn:p>
+                </akn:authorialNote></akn:p>
+            </akn:formula>
+        </akn:conclusions>
+    </akn:act>
+</akn:akomaNtoso>

--- a/backend/src/test/resources/data/XsltTransformerServiceTest/preambleFormulaAndTocNotes.html
+++ b/backend/src/test/resources/data/XsltTransformerServiceTest/preambleFormulaAndTocNotes.html
@@ -1,0 +1,27 @@
+<div class="akn-act">
+    <section class="eingangsformel" id="präambel-n1">
+        <section class="eingangsformel" id="präambel-n1_formel-n1">
+            <a href="regelungstext-1/pr%C3%A4ambel-n1_formel-n1.html">
+                <h2 class="einzelvorschrift"><span class="akn-heading"> Eingangsformel </span></h2></a>
+            <p id="präambel-n1_formel-n1_text-n1">Der Bundestag hat das folgende Gesetz beschlossen:</p>
+            <ul class="nichtamtliche-fussnoten">
+                <li id="meta-n1_editfnote-n1" class="fussnote">
+                    <p id="meta-n1_editfnote-n1_text-n1">Eingangsformel: Note attached to the Eingangsformel</p></li>
+            </ul>
+        </section>
+        <div id="präambel-n1_blockcontainer-n1" class="inhaltsuebersicht">
+            <span class="akn-heading" id="präambel-n1_blockcontainer-n1_überschrift-n1">Inhaltsübersicht</span>
+            <div class="official-toc">
+                <div class="level-1">
+                    <span class="akn-span"
+                          id="präambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n1_span-n1">Abschnitt 1</span>
+                </div>
+            </div>
+            <ul class="nichtamtliche-fussnoten">
+                <li id="meta-n1_editfnote-n2" class="fussnote">
+                    <p id="meta-n1_editfnote-n2_text-n1">Inhaltsübersicht: Note attached to the official table of
+                        contents</p></li>
+            </ul>
+        </div>
+    </section>
+</div>

--- a/backend/src/test/resources/data/XsltTransformerServiceTest/preambleFormulaAndTocNotes.xml
+++ b/backend/src/test/resources/data/XsltTransformerServiceTest/preambleFormulaAndTocNotes.xml
@@ -1,0 +1,29 @@
+<akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.8.2/">
+    <akn:act name="regelungstext">
+        <akn:meta eId="meta-n1">
+            <akn:notes>
+                <akn:note eId="meta-n1_editfnote-n1" marker="#"
+                          placementBase="#präambel-n1_formel-n1" refersTo="kommentierende-fussnote">
+                    <akn:p eId="meta-n1_editfnote-n1_text-n1">Eingangsformel: Note attached to the Eingangsformel</akn:p>
+                </akn:note>
+                <akn:note eId="meta-n1_editfnote-n2" marker="#"
+                          placementBase="#präambel-n1_blockcontainer-n1" refersTo="aenderungsfussnote">
+                    <akn:p eId="meta-n1_editfnote-n2_text-n1">Inhaltsübersicht: Note attached to the official table of contents</akn:p>
+                </akn:note>
+            </akn:notes>
+        </akn:meta>
+        <akn:preamble eId="präambel-n1">
+            <akn:formula eId="präambel-n1_formel-n1" refersTo="eingangsformel">
+                <akn:p eId="präambel-n1_formel-n1_text-n1">Der Bundestag hat das folgende Gesetz beschlossen:</akn:p>
+            </akn:formula>
+            <akn:blockContainer eId="präambel-n1_blockcontainer-n1" refersTo="inhaltsuebersicht">
+                <akn:heading eId="präambel-n1_blockcontainer-n1_überschrift-n1">Inhaltsübersicht</akn:heading>
+                <akn:toc eId="präambel-n1_blockcontainer-n1_inhuebs-n1">
+                    <akn:tocItem eId="präambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n1" href="" level="1">
+                        <akn:span eId="präambel-n1_blockcontainer-n1_inhuebs-n1_eintrag-n1_span-n1">Abschnitt 1</akn:span>
+                    </akn:tocItem>
+                </akn:toc>
+            </akn:blockContainer>
+        </akn:preamble>
+    </akn:act>
+</akn:akomaNtoso>

--- a/backend/src/test/resources/data/XsltTransformerServiceTest/preambleFormulaNotes.html
+++ b/backend/src/test/resources/data/XsltTransformerServiceTest/preambleFormulaNotes.html
@@ -1,0 +1,19 @@
+<div class="akn-act">
+    <section class="eingangsformel" id="präambel-n1">
+        <section class="eingangsformel" id="präambel-n1_formel-n1">
+            <a href="regelungstext-1/pr%C3%A4ambel-n1_formel-n1.html">
+                <h2 class="einzelvorschrift"><span class="akn-heading"> Eingangsformel </span></h2></a>
+            <p id="präambel-n1_formel-n1_text-n1">Der Bundestag hat das folgende Gesetz
+                beschlossen:<a href="#pr%C3%A4ambel-n1_formel-n1_amtlfnote-n1"><sup>*</sup></a></p>
+            <ol class="fussnoten">
+                <li id="präambel-n1_formel-n1_amtlfnote-n1" class="fussnote"><span class="marker">*</span>
+                    <p>Authorial note in the Eingangsformel <a class="rueckverweis" aria-label="Zurück zum Inhalt"
+                                                              href="#pr%C3%A4ambel-n1_formel-n1_text-n1">↑</a></p></li>
+            </ol>
+            <ul class="nichtamtliche-fussnoten">
+                <li id="meta-n1_editfnote-n1" class="fussnote">
+                    <p id="meta-n1_editfnote-n1_text-n1">Eingangsformel: Note attached to the Eingangsformel</p></li>
+            </ul>
+        </section>
+    </section>
+</div>

--- a/backend/src/test/resources/data/XsltTransformerServiceTest/preambleFormulaNotes.xml
+++ b/backend/src/test/resources/data/XsltTransformerServiceTest/preambleFormulaNotes.xml
@@ -1,0 +1,20 @@
+<akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.8.2/">
+    <akn:act name="regelungstext">
+        <akn:meta eId="meta-n1">
+            <akn:notes>
+                <akn:note eId="meta-n1_editfnote-n1" marker="#"
+                          placementBase="#präambel-n1_formel-n1" refersTo="kommentierende-fussnote">
+                    <akn:p eId="meta-n1_editfnote-n1_text-n1">Eingangsformel: Note attached to the Eingangsformel</akn:p>
+                </akn:note>
+            </akn:notes>
+        </akn:meta>
+        <akn:preamble eId="präambel-n1">
+            <akn:formula eId="präambel-n1_formel-n1" refersTo="eingangsformel">
+                <akn:p eId="präambel-n1_formel-n1_text-n1">Der Bundestag hat das folgende Gesetz beschlossen:<akn:authorialNote
+                        eId="präambel-n1_formel-n1_amtlfnote-n1" marker="*">
+                    <akn:p eId="präambel-n1_formel-n1_amtlfnote-n1_text-n1">Authorial note in the Eingangsformel</akn:p>
+                </akn:authorialNote></akn:p>
+            </akn:formula>
+        </akn:preamble>
+    </akn:act>
+</akn:akomaNtoso>

--- a/frontend/e2e/gesetze.spec.ts
+++ b/frontend/e2e/gesetze.spec.ts
@@ -143,18 +143,17 @@ test.describe("view norm page", async () => {
       "/gesetze/eli/bund/bgbl-1/2000/s1016/2023-04-26/10/deu",
     );
 
-    const content = page.locator(".legislation");
-
     await expect(
-      content.getByText(
+      page.getByText(
         "Eingangsformel: Diese Fußnote an der Eingangsformel wurde im End-to-end-Datenbestand ergänzt",
       ),
     ).toBeVisible();
 
-    // The official table of contents and its footnote are only shown in the accordion
     await expect(
-      content.getByText("Inhaltsübersicht: präambel Fußnote"),
-    ).toBeHidden();
+      page
+        .getByText("Inhaltsübersicht: präambel Fußnote")
+        .filter({ visible: true }),
+    ).toHaveCount(0);
 
     await page
       .getByRole("button", { name: "Amtliches Inhaltsverzeichnis einblenden" })
@@ -175,11 +174,9 @@ test.describe("view norm page", async () => {
     );
 
     await expect(
-      page
-        .locator("section.schlussformel")
-        .getByText(
-          "Schlussformel: Diese Fußnote an der Schlussformel wurde im End-to-end-Datenbestand ergänzt",
-        ),
+      page.getByText(
+        "Schlussformel: Diese Fußnote an der Schlussformel wurde im End-to-end-Datenbestand ergänzt",
+      ),
     ).toBeVisible();
   });
 
@@ -192,11 +189,12 @@ test.describe("view norm page", async () => {
     const marker = await page.getByRole("superscript").innerText();
     expect(marker).toBe("❃");
 
-    const footnotes = page.locator(".dokumentenkopf-fussnoten");
-
-    await expect(footnotes).toContainText(
-      "(Diese Fußnote im Titel wurde im End-to-end-Datenbestand ergänzt",
-    );
+    await expect(
+      page.getByRole("listitem").filter({
+        hasText:
+          "(Diese Fußnote im Titel wurde im End-to-end-Datenbestand ergänzt",
+      }),
+    ).toBeVisible();
   });
 
   test("table of contents renders and clicking a link scrolls to the article", async ({

--- a/frontend/e2e/gesetze.spec.ts
+++ b/frontend/e2e/gesetze.spec.ts
@@ -168,6 +168,21 @@ test.describe("view norm page", async () => {
     ).toBeVisible();
   });
 
+  test("shows the footnote of the Schlussformel", async ({ page }) => {
+    await navigate(
+      page,
+      "/gesetze/eli/bund/bgbl-1/2000/s1016/2023-04-26/10/deu",
+    );
+
+    await expect(
+      page
+        .locator("section.schlussformel")
+        .getByText(
+          "Schlussformel: Diese Fußnote an der Schlussformel wurde im End-to-end-Datenbestand ergänzt",
+        ),
+    ).toBeVisible();
+  });
+
   test("view footnotes in title", async ({ page }) => {
     await navigate(
       page,

--- a/frontend/e2e/gesetze.spec.ts
+++ b/frontend/e2e/gesetze.spec.ts
@@ -135,6 +135,39 @@ test.describe("view norm page", async () => {
     expect(toc.getByRole("listitem")).toBeVisible();
   });
 
+  test("shows the footnote of the Eingangsformel in place, and the one of the official table of contents in its accordion", async ({
+    page,
+  }) => {
+    await navigate(
+      page,
+      "/gesetze/eli/bund/bgbl-1/2000/s1016/2023-04-26/10/deu",
+    );
+
+    const content = page.locator(".legislation");
+
+    await expect(
+      content.getByText(
+        "Eingangsformel: Diese Fußnote an der Eingangsformel wurde im End-to-end-Datenbestand ergänzt",
+      ),
+    ).toBeVisible();
+
+    // The official table of contents and its footnote are only shown in the accordion
+    await expect(
+      content.getByText("Inhaltsübersicht: präambel Fußnote"),
+    ).toBeHidden();
+
+    await page
+      .getByRole("button", { name: "Amtliches Inhaltsverzeichnis einblenden" })
+      .click();
+
+    const toc = page.getByRole("region", {
+      name: "Amtliches Inhaltsverzeichnis ausblenden",
+    });
+    await expect(
+      toc.getByText("Inhaltsübersicht: präambel Fußnote"),
+    ).toBeVisible();
+  });
+
   test("view footnotes in title", async ({ page }) => {
     await navigate(
       page,

--- a/frontend/src/components/documents/norms/LegislationContent.vue
+++ b/frontend/src/components/documents/norms/LegislationContent.vue
@@ -166,11 +166,9 @@ Attributes from the Juris CALS format without a corresponding HTML attribute mig
   @apply hidden;
 }
 
-/* hide default table of contents, since it will be displayed behind an accordion section */
+/* hide default table of contents, since it will be displayed behind an accordion section.
+   This also covers the footnotes attached to it, which are nested inside its container. */
 :deep(.eingangsformel .inhaltsuebersicht) {
-  @apply hidden;
-}
-:deep(section.eingangsformel .nichtamtliche-fussnoten) {
   @apply hidden;
 }
 

--- a/frontend/src/components/ui/Accordion.spec.ts
+++ b/frontend/src/components/ui/Accordion.spec.ts
@@ -79,31 +79,6 @@ describe("Accordion", () => {
     expect(screen.getByRole("button")).toHaveTextContent("Show More");
   });
 
-  it("toggles when used with v-model", async () => {
-    const user = userEvent.setup();
-    render({
-      components: { Accordion },
-      template: `
-        <Accordion
-          v-model="open"
-          header-collapsed="Show More"
-          header-expanded="Show Less"
-        >
-          <div>Slot Content</div>
-        </Accordion>
-      `,
-      data: () => ({ open: false }),
-    });
-
-    expect(screen.getByText("Slot Content")).not.toBeVisible();
-
-    await user.click(screen.getByRole("button"));
-    expect(screen.getByText("Slot Content")).toBeVisible();
-
-    await user.click(screen.getByRole("button"));
-    expect(screen.getByText("Slot Content")).not.toBeVisible();
-  });
-
   it("reflects the open state via aria-expanded", async () => {
     const { rerender } = render(Accordion, {
       props: { ...headers, modelValue: false },

--- a/frontend/src/composables/useFetchNormContent.spec.ts
+++ b/frontend/src/composables/useFetchNormContent.spec.ts
@@ -205,17 +205,32 @@ describe("useFetchNormContent", () => {
     );
   });
 
-  it("adds preamble footnotes to the official toc", async () => {
-    mockFetch.mockReturnValueOnce(mockMetadata);
-    mockFetch.mockReturnValueOnce(
-      `<div class="official-toc">
+  const preambleWithTocHtml = `
+    <section class="eingangsformel" id="präambel-n1">
+      <section class="eingangsformel" id="präambel-n1_formel-n1">
+        <p id="präambel-n1_formel-n1_text-n1">Der Bundestag hat …</p>
         <ul class="nichtamtliche-fussnoten">
           <li class="fussnote">
-           <p id="meta-n1_editfnote-n3_text-n1">Inhaltsübersicht: präambel Fußnote</p>
+            <p id="meta-n1_editfnote-n1_text-n1">Eingangsformel: Eingangsformel Fußnote</p>
           </li>
         </ul>
-      </div>`,
-    );
+      </section>
+      <div class="inhaltsuebersicht" id="präambel-n1_blockcontainer-n1">
+        <span class="akn-heading">Inhaltsübersicht</span>
+        <div class="official-toc">
+          <div class="level-1"><span class="akn-span">Abschnitt 1</span></div>
+        </div>
+        <ul class="nichtamtliche-fussnoten">
+          <li class="fussnote">
+            <p id="meta-n1_editfnote-n2_text-n1">Inhaltsübersicht: präambel Fußnote</p>
+          </li>
+        </ul>
+      </div>
+    </section>`;
+
+  it("adds official toc footnotes to the official toc", async () => {
+    mockFetch.mockReturnValueOnce(mockMetadata);
+    mockFetch.mockReturnValueOnce(preambleWithTocHtml);
 
     const { data } = await useFetchNormContent(expressionEli);
 
@@ -228,8 +243,23 @@ describe("useFetchNormContent", () => {
     expect(doc.querySelector(".official-toc")).not.toBeNull();
     expect(doc.querySelector(".fussnote")).not.toBeNull();
     expect(
-      doc.querySelector("#meta-n1_editfnote-n3_text-n1")?.textContent,
+      doc.querySelector("#meta-n1_editfnote-n2_text-n1")?.textContent,
     ).toBe("Inhaltsübersicht: präambel Fußnote");
+  });
+
+  it("keeps Eingangsformel footnotes out of the official toc", async () => {
+    mockFetch.mockReturnValueOnce(mockMetadata);
+    mockFetch.mockReturnValueOnce(preambleWithTocHtml);
+
+    const { data } = await useFetchNormContent(expressionEli);
+
+    expect(data.value.htmlParts.officialToc).not.toContain(
+      "Eingangsformel: Eingangsformel Fußnote",
+    );
+
+    expect(data.value.htmlParts.body).toContain(
+      "Eingangsformel: Eingangsformel Fußnote",
+    );
   });
 
   it("sets hasEmptyBody to false if akn-body has content", async () => {

--- a/frontend/src/composables/useFetchNormContent.ts
+++ b/frontend/src/composables/useFetchNormContent.ts
@@ -103,7 +103,7 @@ function extractHtmlParts(
 
   const officialTocElements = Array.from(
     document.querySelectorAll(
-      ".official-toc, section.eingangsformel .nichtamtliche-fussnoten",
+      ".official-toc, .eingangsformel .inhaltsuebersicht .nichtamtliche-fussnoten",
     ),
   );
 


### PR DESCRIPTION
Footnotes are not rendered automatically, but need to be "enabled" in the HTML transform per element. This was missing for Eingangsformeln. This PR enables it.

Changing this led to another issue: footnotes from the official TOC (located in the Eingangsformel) were rendered as a sibling of the TOC with no shared container. So rendering more footnotes would confuse the frontend about which footnotes belong to the TOC, and which belong to the Eingangsformel. This PR puts the TOC and it's footnotes into a shared container to distinguish them from regular Eingangsformel footnotes.