### PR TITLE
RISDEV-10568 badges for meta data items

### DIFF
--- a/backend/e2e-data/literature/XXLS000000001.akn.xml
+++ b/backend/e2e-data/literature/XXLS000000001.akn.xml
@@ -59,9 +59,6 @@
                     <akn:implicitReference showAs="FooBar, 1982, 123-123">
                         <ris:fundstelleUnselbstaendig periodikum="FooBar" zitatstelle="1982, 123-123"/>
                     </akn:implicitReference>
-                    <akn:implicitReference showAs="17153/11, 17157/11, 17160/11, 17163/11, 17168/11, 17173/11, 17178/11, 17181/11, 17182/11, 17186/11, 17343/11, 17344/11, 17362/11, 17364/11, 17367/11, 17370/11, 17372/11, 17377/11, 17380/11, 17382/11, 17386/11, 17421/11, 17424/11, 17428/11, 17431/11, 17435/11, 17438/11, 17439/11, 17440/11 und 17443/11">
-                        <ris:fundstelleUnselbstaendig periodikum="" zitatstelle="17153/11, 17157/11, 17160/11, 17163/11, 17168/11, 17173/11, 17178/11, 17181/11, 17182/11, 17186/11, 17343/11, 17344/11, 17362/11, 17364/11, 17367/11, 17370/11, 17372/11, 17377/11, 17380/11, 17382/11, 17386/11, 17421/11, 17424/11, 17428/11, 17431/11, 17435/11, 17438/11, 17439/11, 17440/11 und 17443/11"/>
-                    </akn:implicitReference>
                     <akn:implicitReference showAs="SelbstFund, 1982, 123-123">
                         <ris:fundstelleSelbstaendig titel="SelbstFund" zitatstelle="2024, 456-456"/>
                     </akn:implicitReference>

--- a/backend/e2e-data/literature/XXLS000000001.akn.xml
+++ b/backend/e2e-data/literature/XXLS000000001.akn.xml
@@ -59,6 +59,9 @@
                     <akn:implicitReference showAs="FooBar, 1982, 123-123">
                         <ris:fundstelleUnselbstaendig periodikum="FooBar" zitatstelle="1982, 123-123"/>
                     </akn:implicitReference>
+                    <akn:implicitReference showAs="17153/11, 17157/11, 17160/11, 17163/11, 17168/11, 17173/11, 17178/11, 17181/11, 17182/11, 17186/11, 17343/11, 17344/11, 17362/11, 17364/11, 17367/11, 17370/11, 17372/11, 17377/11, 17380/11, 17382/11, 17386/11, 17421/11, 17424/11, 17428/11, 17431/11, 17435/11, 17438/11, 17439/11, 17440/11 und 17443/11">
+                        <ris:fundstelleUnselbstaendig periodikum="" zitatstelle="17153/11, 17157/11, 17160/11, 17163/11, 17168/11, 17173/11, 17178/11, 17181/11, 17182/11, 17186/11, 17343/11, 17344/11, 17362/11, 17364/11, 17367/11, 17370/11, 17372/11, 17377/11, 17380/11, 17382/11, 17386/11, 17421/11, 17424/11, 17428/11, 17431/11, 17435/11, 17438/11, 17439/11, 17440/11 und 17443/11"/>
+                    </akn:implicitReference>
                     <akn:implicitReference showAs="SelbstFund, 1982, 123-123">
                         <ris:fundstelleSelbstaendig titel="SelbstFund" zitatstelle="2024, 456-456"/>
                     </akn:implicitReference>

--- a/frontend/e2e/gerichtsentscheidungen.spec.ts
+++ b/frontend/e2e/gerichtsentscheidungen.spec.ts
@@ -191,22 +191,23 @@ test.describe("actions menu", () => {
   });
 });
 
-test("can view metadata", async ({ page }) => {
+test("can view metadata", { tag: ["@RISDEV-10568"] }, async ({ page }) => {
   await navigate(page, "/gerichtsentscheidungen/KORE600500000");
   const metadataList = page.getByTestId("metadata-list");
+  const defs = metadataList.getByRole("definition");
 
-  await expect(
-    metadataList.getByRole("term").or(metadataList.getByRole("definition")),
-  ).toHaveText([
+  await expect(metadataList.getByRole("term")).toHaveText([
     "Gericht",
-    "LG Test6 Label",
     "Dokumenttyp",
-    "Urteil",
     "Entscheidungsdatum",
-    "09.04.2025",
     "Aktenzeichen",
-    "TS 123456",
   ]);
+
+  await expect(defs.nth(0)).toHaveText("LG Test6 Label");
+  await expect(defs.nth(1)).toHaveText("Urteil");
+  await expect(defs.nth(2)).toHaveText("09.04.2025");
+  // Aktenzeichen are rendered as badges (spans)
+  await expect(defs.nth(3).locator("span")).toHaveText(["TS 123456"]);
 });
 
 test("can view details", { tag: ["@RISDEV-12108"] }, async ({ page }) => {

--- a/frontend/e2e/literaturnachweise.spec.ts
+++ b/frontend/e2e/literaturnachweise.spec.ts
@@ -13,118 +13,130 @@ async function getSidebar(page: Page) {
   return navigation;
 }
 
-test("displays literature page with metadata and text tab by default", async ({
-  page,
-}) => {
-  await navigate(page, "/literaturnachweise/XXLU000000001");
+test(
+  "displays literature page with metadata and text tab by default",
+  { tag: ["@RISDEV-10568"] },
+  async ({ page }) => {
+    await navigate(page, "/literaturnachweise/XXLU000000001");
 
-  // Main title
-  await expect(
-    page
-      .getByRole("main")
-      .getByRole("heading", { level: 1, name: "Erstes Test-Dokument ULI" })
-      .first(),
-  ).toBeVisible();
+    // Main title
+    await expect(
+      page
+        .getByRole("main")
+        .getByRole("heading", { level: 1, name: "Erstes Test-Dokument ULI" })
+        .first(),
+    ).toBeVisible();
 
-  // Metadata section
-  await expect(
-    page.getByRole("term").or(page.getByRole("definition")),
-  ).toHaveText([
-    "Dokumenttyp",
-    "Auf",
-    "Fundstelle",
-    "FooBar, 1982, 123-123, SelbstFund, 1982, 123-123",
-    "Autor",
-    "Sabine Musterfrau",
-    "Veröffentlichungsjahr",
-    "2024",
-  ]);
+    // Metadata section
+    const metadataList = page.getByTestId("metadata-list");
+    const defs = metadataList.getByRole("definition");
 
-  // Text section
-  const textSection = page.getByRole("tabpanel", { name: "Text" });
-  await expect(textSection.getByRole("status")).toContainText(
-    "Dieser Service befindet sich in der Testphase",
-  );
+    await expect(metadataList.getByRole("term")).toHaveText([
+      "Dokumenttyp",
+      "Fundstelle",
+      "Autor",
+      "Veröffentlichungsjahr",
+    ]);
 
-  await expect(
-    textSection.getByRole("heading", { level: 2, name: "Gliederung" }),
-  ).toBeVisible();
-  await expect(textSection.getByText("I. Problemstellung.")).toBeVisible();
-  await expect(textSection.getByText("II. Lösung.")).toBeVisible();
-  await expect(textSection.getByText("III. Zusammenfassung.")).toBeVisible();
+    await expect(defs.nth(0)).toHaveText("Auf");
+    // Fundstellen are rendered as badges (spans)
+    await expect(defs.nth(1).locator("span")).toHaveText([
+      "FooBar, 1982, 123-123",
+      "SelbstFund, 1982, 123-123",
+    ]);
+    await expect(defs.nth(2)).toHaveText("Sabine Musterfrau");
+    await expect(defs.nth(3)).toHaveText("2024");
 
-  await expect(
-    textSection.getByRole("heading", { level: 2, name: "Kurzreferat" }),
-  ).toBeVisible();
-  await expect(
-    textSection.getByText("Dies ist ein einfaches Test-Dokument."),
-  ).toBeVisible();
-  await expect(textSection.getByText("In sem neque")).toBeVisible();
+    // Text section
+    const textSection = page.getByRole("tabpanel", { name: "Text" });
+    await expect(textSection.getByRole("status")).toContainText(
+      "Dieser Service befindet sich in der Testphase",
+    );
 
-  await expect(
-    textSection.getByRole("heading", {
-      level: 2,
-      name: "Dieser Beitrag zitiert",
-    }),
-  ).toBeVisible();
-  await expect(
-    textSection.getByRole("heading", {
-      level: 3,
-      name: "Rechtsprechung",
-    }),
-  ).toBeVisible();
-  await expect(
-    textSection.getByText(
-      "Vergleiche aktiv EuGH 2. Kammer, 3. April 2008, Az: C-346/06",
-    ),
-  ).toBeVisible();
-  await expect(
-    textSection.getByText("Vergleiche aktiv FooBar 1. Kammer, 3. April 2008"),
-  ).toBeVisible();
+    await expect(
+      textSection.getByRole("heading", { level: 2, name: "Gliederung" }),
+    ).toBeVisible();
+    await expect(textSection.getByText("I. Problemstellung.")).toBeVisible();
+    await expect(textSection.getByText("II. Lösung.")).toBeVisible();
+    await expect(textSection.getByText("III. Zusammenfassung.")).toBeVisible();
 
-  await expect(
-    textSection
-      .getByRole("heading", {
+    await expect(
+      textSection.getByRole("heading", { level: 2, name: "Kurzreferat" }),
+    ).toBeVisible();
+    await expect(
+      textSection.getByText("Dies ist ein einfaches Test-Dokument."),
+    ).toBeVisible();
+    await expect(textSection.getByText("In sem neque")).toBeVisible();
+
+    await expect(
+      textSection.getByRole("heading", {
+        level: 2,
+        name: "Dieser Beitrag zitiert",
+      }),
+    ).toBeVisible();
+    await expect(
+      textSection.getByRole("heading", {
         level: 3,
-        name: "Literaturnachweise",
-      })
-      .first(),
-  ).toBeVisible();
-  await expect(
-    textSection.getByText("Vergleiche aktiv Selbstständigeliterature 2025"),
-  ).toBeVisible();
+        name: "Rechtsprechung",
+      }),
+    ).toBeVisible();
+    await expect(
+      textSection.getByText(
+        "Vergleiche aktiv EuGH 2. Kammer, 3. April 2008, Az: C-346/06",
+      ),
+    ).toBeVisible();
+    await expect(
+      textSection.getByText("Vergleiche aktiv FooBar 1. Kammer, 3. April 2008"),
+    ).toBeVisible();
 
-  await expect(
-    textSection.getByRole("heading", {
-      level: 2,
-      name: "Dieser Beitrag wird zitiert",
-    }),
-  ).toBeVisible();
-  await expect(
-    textSection.getByRole("heading", {
-      level: 3,
-      name: "Verwaltungsvorschriften",
-    }),
-  ).toBeVisible();
-  await expect(
-    textSection.getByText("Vergleiche passiv NaNu 1. Kammer, 2009, Az: XY"),
-  ).toBeVisible();
+    await expect(
+      textSection
+        .getByRole("heading", {
+          level: 3,
+          name: "Literaturnachweise",
+        })
+        .first(),
+    ).toBeVisible();
+    await expect(
+      textSection.getByText("Vergleiche aktiv Selbstständigeliterature 2025"),
+    ).toBeVisible();
 
-  await expect(
-    textSection
-      .getByRole("heading", {
+    await expect(
+      textSection.getByRole("heading", {
+        level: 2,
+        name: "Dieser Beitrag wird zitiert",
+      }),
+    ).toBeVisible();
+    await expect(
+      textSection.getByRole("heading", {
         level: 3,
-        name: "Literaturnachweise",
-      })
-      .nth(1),
-  ).toBeVisible();
-  await expect(
-    textSection.getByText("Vergleiche passiv Unselbstständigeliterature 2023"),
-  ).toBeVisible();
-  await expect(
-    textSection.getByText("Vergleiche passiv Unselbstständigeliterature 1989"),
-  ).toBeVisible();
-});
+        name: "Verwaltungsvorschriften",
+      }),
+    ).toBeVisible();
+    await expect(
+      textSection.getByText("Vergleiche passiv NaNu 1. Kammer, 2009, Az: XY"),
+    ).toBeVisible();
+
+    await expect(
+      textSection
+        .getByRole("heading", {
+          level: 3,
+          name: "Literaturnachweise",
+        })
+        .nth(1),
+    ).toBeVisible();
+    await expect(
+      textSection.getByText(
+        "Vergleiche passiv Unselbstständigeliterature 2023",
+      ),
+    ).toBeVisible();
+    await expect(
+      textSection.getByText(
+        "Vergleiche passiv Unselbstständigeliterature 1989",
+      ),
+    ).toBeVisible();
+  },
+);
 
 test("displays sli footnotes in text section", async ({ page }) => {
   await navigate(page, "/literaturnachweise/XXLS000000001");

--- a/frontend/e2e/verwaltungsregelungen.spec.ts
+++ b/frontend/e2e/verwaltungsregelungen.spec.ts
@@ -13,88 +13,93 @@ async function getSidebar(page: Page) {
   return navigation;
 }
 
-test("displays administrative directive page with metadata and text tab by default", async ({
-  page,
-}) => {
-  await navigate(page, "/verwaltungsregelungen/KSNR000000001");
+test(
+  "displays administrative directive page with metadata and text tab by default",
+  { tag: ["@RISDEV-10568"] },
+  async ({ page }) => {
+    await navigate(page, "/verwaltungsregelungen/KSNR000000001");
 
-  // Main title
-  await expect(
-    page
-      .getByRole("main")
-      .getByRole("heading", {
-        level: 1,
-        name: "Verwaltungsvorschrift für das Testen des Portals zur Darstellung von Verwaltungsvorschriften",
-      })
-      .first(),
-  ).toBeVisible();
+    // Main title
+    await expect(
+      page
+        .getByRole("main")
+        .getByRole("heading", {
+          level: 1,
+          name: "Verwaltungsvorschrift für das Testen des Portals zur Darstellung von Verwaltungsvorschriften",
+        })
+        .first(),
+    ).toBeVisible();
 
-  // Metadata section
-  await expect(
-    page.getByRole("term").or(page.getByRole("definition")),
-  ).toHaveText([
-    "Aktenzeichen",
-    "Foo - 123 - 4",
-    "Normgeber",
-    "DEU Neuris",
-    "Dokumenttyp",
-    "VR",
-    "Gültig ab",
-    "01.07.2025",
-  ]);
+    // Metadata section
+    const metadataList = page.getByTestId("metadata-list");
+    const defs = metadataList.getByRole("definition");
 
-  // Text section
-  const textSection = page.getByRole("tabpanel", { name: "Text" });
-  await expect(textSection.getByRole("status")).toContainText(
-    "Dieser Service befindet sich in der Testphase",
-  );
+    await expect(metadataList.getByRole("term")).toHaveText([
+      "Aktenzeichen",
+      "Normgeber",
+      "Dokumenttyp",
+      "Gültig ab",
+    ]);
 
-  // Short report
-  await expect(
-    textSection.getByRole("heading", { level: 2, name: "Kurzreferat" }),
-  ).toBeVisible();
-  await expect(
-    textSection.getByText("Dies ist ein Testdokument. Katze und Maus. "),
-  ).toBeVisible();
-  await expect(
-    textSection.getByText("Lorem ipsum dolor sit amet"),
-  ).toBeVisible();
+    // Aktenzeichen are rendered as badges (spans)
+    await expect(defs.nth(0).locator("span")).toHaveText(["Foo - 123 - 4"]);
+    await expect(defs.nth(1)).toHaveText("DEU Neuris");
+    await expect(defs.nth(2)).toHaveText("VR");
+    await expect(defs.nth(3)).toHaveText("01.07.2025");
 
-  // Outline
-  await expect(
-    textSection.getByRole("heading", { level: 2, name: "Inhalt" }),
-  ).toBeVisible();
-  await expect(textSection.getByText("1. Allgemeines")).toBeVisible();
-  await expect(textSection.getByText("2. Genaues")).toBeVisible();
-  await expect(textSection.getByText("3. Unwichtiges")).toBeVisible();
-  await expect(textSection.getByText("4. Sonstiges")).toBeVisible();
+    // Text section
+    const textSection = page.getByRole("tabpanel", { name: "Text" });
+    await expect(textSection.getByRole("status")).toContainText(
+      "Dieser Service befindet sich in der Testphase",
+    );
 
-  // References
-  await expect(
-    textSection.getByRole("heading", { level: 2, name: "Verweise" }),
-  ).toBeVisible();
-  await expect(textSection.getByText("BVG § 16c Abs 2")).toBeVisible();
-  await expect(
-    textSection.getByText("Verweis 890C Section B § 4 Abs. 1 8"),
-  ).toBeVisible();
+    // Short report
+    await expect(
+      textSection.getByRole("heading", { level: 2, name: "Kurzreferat" }),
+    ).toBeVisible();
+    await expect(
+      textSection.getByText("Dies ist ein Testdokument. Katze und Maus. "),
+    ).toBeVisible();
+    await expect(
+      textSection.getByText("Lorem ipsum dolor sit amet"),
+    ).toBeVisible();
 
-  // Citations
-  await expect(
-    textSection.getByRole("heading", {
-      level: 2,
-      name: "Dieser Beitrag zitiert",
-    }),
-  ).toBeVisible();
-  await expect(
-    textSection.getByRole("heading", { level: 3, name: "Rechtsprechung" }),
-  ).toBeVisible();
-  await expect(
-    textSection.getByText("FOO BAR RefNr 123 2025-07-01"),
-  ).toBeVisible();
-  await expect(
-    textSection.getByText("ABC BAZ RefNr 456 2023-01-01"),
-  ).toBeVisible();
-});
+    // Outline
+    await expect(
+      textSection.getByRole("heading", { level: 2, name: "Inhalt" }),
+    ).toBeVisible();
+    await expect(textSection.getByText("1. Allgemeines")).toBeVisible();
+    await expect(textSection.getByText("2. Genaues")).toBeVisible();
+    await expect(textSection.getByText("3. Unwichtiges")).toBeVisible();
+    await expect(textSection.getByText("4. Sonstiges")).toBeVisible();
+
+    // References
+    await expect(
+      textSection.getByRole("heading", { level: 2, name: "Verweise" }),
+    ).toBeVisible();
+    await expect(textSection.getByText("BVG § 16c Abs 2")).toBeVisible();
+    await expect(
+      textSection.getByText("Verweis 890C Section B § 4 Abs. 1 8"),
+    ).toBeVisible();
+
+    // Citations
+    await expect(
+      textSection.getByRole("heading", {
+        level: 2,
+        name: "Dieser Beitrag zitiert",
+      }),
+    ).toBeVisible();
+    await expect(
+      textSection.getByRole("heading", { level: 3, name: "Rechtsprechung" }),
+    ).toBeVisible();
+    await expect(
+      textSection.getByText("FOO BAR RefNr 123 2025-07-01"),
+    ).toBeVisible();
+    await expect(
+      textSection.getByText("ABC BAZ RefNr 456 2023-01-01"),
+    ).toBeVisible();
+  },
+);
 
 test("sidebar TOC renders on desktop and clicking a link scrolls to the section", async ({
   page,

--- a/frontend/src/components/documents/Metadata.spec.ts
+++ b/frontend/src/components/documents/Metadata.spec.ts
@@ -2,16 +2,39 @@ import { render, screen } from "@testing-library/vue";
 import Metadata from "./Metadata.vue";
 
 describe("Metadata", () => {
-  it("renders MetadataItems", async () => {
+  it("renders placeholders for missing values", async () => {
     render(Metadata, {
       props: {
         items: [
           {
+            type: "text",
             label: "Label 1",
-            value: "Value 1",
           },
           {
+            type: "badge",
             label: "Label 2",
+            values: [],
+          },
+        ],
+      },
+    });
+
+    const terms = screen.getAllByRole("term");
+    expect(terms[0]).toHaveTextContent("Label 1");
+    expect(terms[0]?.nextElementSibling).toHaveTextContent("—");
+
+    expect(terms[1]).toHaveTextContent("Label 2");
+    expect(terms[1]?.nextElementSibling).toHaveTextContent("—");
+  });
+
+  it("renders text metadata item", async () => {
+    render(Metadata, {
+      props: {
+        items: [
+          {
+            type: "text",
+            label: "Label 1",
+            value: "Value 1",
           },
         ],
       },
@@ -20,8 +43,64 @@ describe("Metadata", () => {
     const terms = screen.getAllByRole("term");
     expect(terms[0]).toHaveTextContent("Label 1");
     expect(terms[0]?.nextElementSibling).toHaveTextContent("Value 1");
+  });
+
+  it("renders badge metadata items", async () => {
+    render(Metadata, {
+      props: {
+        items: [
+          {
+            type: "badge",
+            label: "Label 1",
+            values: ["Badge 1"],
+          },
+          {
+            type: "badge",
+            label: "Label 2",
+            values: ["Badge 2", "Badge 3"],
+          },
+        ],
+      },
+    });
+
+    const terms = screen.getAllByRole("term");
+
+    expect(terms[0]).toHaveTextContent("Label 1");
+    const badge1 = screen.getByText("Badge 1");
+    expect(badge1).toHaveClass("bg-gray-100");
 
     expect(terms[1]).toHaveTextContent("Label 2");
-    expect(terms[1]?.nextElementSibling).toHaveTextContent("—");
+    const badge2 = screen.getByText("Badge 2");
+    const badge3 = screen.getByText("Badge 3");
+    expect(badge2).toHaveClass("bg-gray-100");
+    expect(badge3).toHaveClass("bg-gray-100");
+  });
+
+  it("renders mixed metadata items", async () => {
+    render(Metadata, {
+      props: {
+        items: [
+          {
+            type: "badge",
+            label: "Label 1",
+            values: ["Badge 1"],
+          },
+          {
+            type: "text",
+            label: "Label 2",
+            value: "Value 1",
+          },
+        ],
+      },
+    });
+
+    const terms = screen.getAllByRole("term");
+
+    expect(terms[0]).toHaveTextContent("Label 1");
+    const badge1 = screen.getByText("Badge 1");
+    expect(badge1).toHaveClass("bg-gray-100");
+
+    expect(terms[1]).toHaveTextContent("Label 2");
+    expect(terms[1]?.nextElementSibling).toHaveTextContent("Value 1");
   });
 });

--- a/frontend/src/components/documents/Metadata.vue
+++ b/frontend/src/components/documents/Metadata.vue
@@ -21,11 +21,11 @@ const emptyValuePlaceholder = "—"; // Note: this is an 'em dash'
 
 <template>
   <dl data-testid="metadata-list" class="flex flex-row flex-wrap gap-24">
-    <div v-for="item in items" :key="item.label" class="flex flex-col gap-4">
+    <div v-for="item in items" :key="item.label" class="flex flex-col">
       <dt class="typo-label1-regular text-gray-900">
         {{ item.label }}
       </dt>
-      <dd v-if="item.type === 'badge' && item.values.length > 0">
+      <dd v-if="item.type === 'badge' && item.values.length > 0" class="mt-2">
         <div class="flex flex-wrap gap-4">
           <UiBadge
             v-for="value in item.values"
@@ -37,11 +37,11 @@ const emptyValuePlaceholder = "—"; // Note: this is an 'em dash'
       </dd>
       <dd
         v-else-if="item.type === 'text' && item.value"
-        class="typo-label1-bold"
+        class="typo-label1-bold mt-4"
       >
         {{ item.value }}
       </dd>
-      <dd v-else class="typo-label1-bold">
+      <dd v-else class="typo-label1-bold mt-4">
         {{ emptyValuePlaceholder }}
       </dd>
     </div>

--- a/frontend/src/components/documents/Metadata.vue
+++ b/frontend/src/components/documents/Metadata.vue
@@ -32,6 +32,8 @@ const emptyValuePlaceholder = "—"; // Note: this is an 'em dash'
             :key="value"
             :color="BadgeColor.GRAY"
             :label="value"
+            variant="extraSmall"
+            class="font-bold!"
           ></UiBadge>
         </div>
       </dd>

--- a/frontend/src/components/documents/Metadata.vue
+++ b/frontend/src/components/documents/Metadata.vue
@@ -1,8 +1,19 @@
 <script setup lang="ts">
-export interface MetadataItem {
+import { BadgeColor } from "~/components/ui/Badge.vue";
+
+export type MetadataItemBadge = {
+  type: "badge";
+  label: string;
+  values: string[];
+};
+
+export type MetadataItemText = {
+  type: "text";
   label: string;
   value?: string;
-}
+};
+
+export type MetadataItem = MetadataItemText | MetadataItemBadge;
 
 const { items } = defineProps<{ items: MetadataItem[] }>();
 const emptyValuePlaceholder = "—"; // Note: this is an 'em dash'
@@ -14,8 +25,24 @@ const emptyValuePlaceholder = "—"; // Note: this is an 'em dash'
       <dt class="typo-label1-regular text-gray-900">
         {{ item.label }}
       </dt>
-      <dd class="typo-label1-bold">
-        {{ item.value || emptyValuePlaceholder }}
+      <dd v-if="item.type === 'badge' && item.values.length > 0">
+        <div class="flex flex-wrap gap-4">
+          <UiBadge
+            v-for="value in item.values"
+            :key="value"
+            :color="BadgeColor.GRAY"
+            :label="value"
+          ></UiBadge>
+        </div>
+      </dd>
+      <dd
+        v-else-if="item.type === 'text' && item.value"
+        class="typo-label1-bold"
+      >
+        {{ item.value }}
+      </dd>
+      <dd v-else class="typo-label1-bold">
+        {{ emptyValuePlaceholder }}
       </dd>
     </div>
   </dl>

--- a/frontend/src/components/ui/Badge.spec.ts
+++ b/frontend/src/components/ui/Badge.spec.ts
@@ -61,4 +61,16 @@ describe("Badge", () => {
     const badge = container.firstChild as HTMLElement;
     expect(badge).toHaveClass("bg-red-200");
   });
+
+  it("applies gray styling for GRAY color", () => {
+    const { container } = render(Badge, {
+      props: {
+        label: "Gray Badge",
+        color: BadgeColor.GRAY,
+      },
+    });
+
+    const badge = container.firstChild as HTMLElement;
+    expect(badge).toHaveClass("bg-gray-100");
+  });
 });

--- a/frontend/src/components/ui/Badge.stories.ts
+++ b/frontend/src/components/ui/Badge.stories.ts
@@ -21,6 +21,10 @@ const meta: Meta<typeof UiBadge> = {
         gray: BadgeColor.GRAY,
       },
     },
+    variant: {
+      control: "select",
+      options: ["extraSmall", "small", "medium", "large"],
+    },
   },
 };
 

--- a/frontend/src/components/ui/Badge.stories.ts
+++ b/frontend/src/components/ui/Badge.stories.ts
@@ -12,12 +12,13 @@ const meta: Meta<typeof UiBadge> = {
   argTypes: {
     color: {
       control: "select",
-      options: ["blue", "green", "yellow", "red"],
+      options: ["blue", "green", "yellow", "red", "gray"],
       mapping: {
         blue: BadgeColor.BLUE,
         green: BadgeColor.GREEN,
         yellow: BadgeColor.YELLOW,
         red: BadgeColor.RED,
+        gray: BadgeColor.GRAY,
       },
     },
   },

--- a/frontend/src/components/ui/Badge.vue
+++ b/frontend/src/components/ui/Badge.vue
@@ -11,20 +11,24 @@ export enum BadgeColor {
   GREEN,
   YELLOW,
   RED,
+  GRAY,
 }
 </script>
 
 <template>
   <span
-    class="typo-label2-bold inline-block flex-none px-8 py-4"
+    class="typo-label2-bold inline-block px-8 py-4"
     :class="{
-      'border border-green-400 bg-green-100 text-green-800':
+      'flex-none border border-green-400 bg-green-100 text-green-800':
         color === BadgeColor.GREEN,
-      'border border-yellow-600 bg-yellow-200 text-orange-800':
+      'flex-none border border-yellow-600 bg-yellow-200 text-orange-800':
         color === BadgeColor.YELLOW,
-      'border border-blue-500 bg-blue-200 text-blue-800':
+      'flex-none border border-blue-500 bg-blue-200 text-blue-800':
         color === BadgeColor.BLUE,
-      'border border-red-400 bg-red-200 text-red-800': color === BadgeColor.RED,
+      'flex-none border border-red-400 bg-red-200 text-red-800':
+        color === BadgeColor.RED,
+      'ris-label3-bold sm:ris-label2-bold 2xl:ris-label1-bold rounded-xs border border-gray-400 bg-gray-100 hyphens-auto':
+        color === BadgeColor.GRAY,
     }"
   >
     {{ label }}

--- a/frontend/src/components/ui/Badge.vue
+++ b/frontend/src/components/ui/Badge.vue
@@ -1,8 +1,54 @@
 <script setup lang="ts">
-defineProps<{
-  label: string;
-  color: BadgeColor;
-}>();
+import { computed } from "vue";
+import { tw } from "../../utils/tags";
+
+const props = withDefaults(
+  defineProps<{
+    label: string;
+    color: BadgeColor;
+    variant?: "standard" | "extraSmall" | "small" | "medium" | "large";
+  }>(),
+  {
+    variant: "standard",
+  },
+);
+
+const base = tw`inline-block rounded-xs border px-8 py-4 hyphens-auto`;
+
+const green = tw`border-green-400 bg-green-100 text-green-800`;
+const yellow = tw`border-yellow-600 bg-yellow-200 text-orange-800`;
+const blue = tw`border-blue-500 bg-blue-200 text-blue-800`;
+const red = tw`border-red-400 bg-red-200 text-red-800`;
+const gray = tw`text-gray-1000 border-gray-400 bg-gray-100`;
+
+// "old" styles, will be removed with the implementation of RISDEV-11103, RISDEV-12247
+// just kept for the transition phase
+const standard = tw`typo-label2-bold flex-none`;
+
+const extraSmall = tw`ris-label3-regular sm:ris-label2-regular 2xl:ris-label1-regular`;
+
+const small = tw`ris-label2-regular sm:ris-label1-regular`;
+
+const medium = tw`ris-label2-regular 2xl:ris-label1-regular`;
+
+const large = tw`typo-label1-regular`;
+
+const rootClass = computed(() => {
+  const { color, variant } = props;
+  return {
+    [base]: true,
+    [green]: color === BadgeColor.GREEN,
+    [yellow]: color === BadgeColor.YELLOW,
+    [blue]: color === BadgeColor.BLUE,
+    [red]: color === BadgeColor.RED,
+    [gray]: color === BadgeColor.GRAY,
+    [standard]: variant === "standard",
+    [extraSmall]: variant === "extraSmall",
+    [small]: variant === "small",
+    [medium]: variant === "medium",
+    [large]: variant === "large",
+  };
+});
 </script>
 
 <script lang="ts">
@@ -16,21 +62,7 @@ export enum BadgeColor {
 </script>
 
 <template>
-  <span
-    class="typo-label2-bold inline-block px-8 py-4"
-    :class="{
-      'flex-none border border-green-400 bg-green-100 text-green-800':
-        color === BadgeColor.GREEN,
-      'flex-none border border-yellow-600 bg-yellow-200 text-orange-800':
-        color === BadgeColor.YELLOW,
-      'flex-none border border-blue-500 bg-blue-200 text-blue-800':
-        color === BadgeColor.BLUE,
-      'flex-none border border-red-400 bg-red-200 text-red-800':
-        color === BadgeColor.RED,
-      'ris-label3-bold sm:ris-label2-bold 2xl:ris-label1-bold rounded-xs border border-gray-400 bg-gray-100 hyphens-auto':
-        color === BadgeColor.GRAY,
-    }"
-  >
+  <span :class="rootClass">
     {{ label }}
   </span>
 </template>

--- a/frontend/src/layouts/document.spec.ts
+++ b/frontend/src/layouts/document.spec.ts
@@ -102,8 +102,8 @@ describe("document", () => {
       props: {
         titlePlaceholder: "Title Placeholder",
         metadata: [
-          { label: "Label 1", value: "Value 1" },
-          { label: "Label 2" },
+          { type: "text", label: "Label 1", value: "Value 1" },
+          { type: "text", label: "Label 2" },
         ],
         views: defaultViews,
       },

--- a/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
+++ b/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
@@ -85,13 +85,15 @@ const tocEntries = computed<TreeItem[] | null>(() => {
 });
 
 const headerMetadata = computed<MetadataItem[]>(() => [
-  { label: "Gericht", value: caseLaw.value?.courtName },
-  { label: "Dokumenttyp", value: caseLaw.value?.documentType },
+  { type: "text", label: "Gericht", value: caseLaw.value?.courtName },
+  { type: "text", label: "Dokumenttyp", value: caseLaw.value?.documentType },
   {
+    type: "text",
     label: "Entscheidungsdatum",
     value: dateFormattedDDMMYYYY(caseLaw.value?.decisionDate),
   },
   {
+    type: "text",
     label: "Aktenzeichen",
     value: formatArray(caseLaw.value?.fileNumbers ?? []),
   },

--- a/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
+++ b/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
@@ -93,9 +93,9 @@ const headerMetadata = computed<MetadataItem[]>(() => [
     value: dateFormattedDDMMYYYY(caseLaw.value?.decisionDate),
   },
   {
-    type: "text",
+    type: "badge",
     label: "Aktenzeichen",
-    value: formatArray(caseLaw.value?.fileNumbers ?? []),
+    values: caseLaw.value?.fileNumbers ?? [],
   },
 ]);
 

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -7,6 +7,7 @@ import type {
   RouteLocationAsRelativeGeneric,
 } from "#vue-router";
 import type { BreadcrumbItem } from "~/components/Breadcrumbs.vue";
+import type { MetadataItem } from "~/components/documents/Metadata.vue";
 import { useArticleSeo } from "~/composables/useArticleSeo";
 import { useSearchBackLink } from "~/composables/useSearchBackLink";
 import {
@@ -214,16 +215,18 @@ const inForceNormLink = computed(() => {
   return `/gesetze/${validVersion?.item.legislationIdentifier}`;
 });
 
-const metadataItems = computed(() => {
+const metadataItems = computed<MetadataItem[]>(() => {
   const interval = temporalCoverageToValidityInterval(
     article.value?.temporalCoverage,
   );
   return [
     {
+      type: "text",
       label: "Gültig ab",
       value: dateFormattedDDMMYYYY(interval?.from),
     },
     {
+      type: "text",
       label: "Gültig bis",
       value: dateFormattedDDMMYYYY(interval?.to),
     },

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -5,6 +5,7 @@ import IcOutlineRestore from "~icons/ic/outline-settings-backup-restore";
 import { NuxtLink } from "#components";
 import type { BreadcrumbItem } from "~/components/Breadcrumbs.vue";
 import type { DetailsListItem } from "~/components/documents/DetailsList.vue";
+import type { MetadataItem } from "~/components/documents/Metadata.vue";
 import type { TabView } from "~/components/documents/TabsLayout.vue";
 import { useSearchBackLink } from "~/composables/useSearchBackLink";
 import { DocumentKind, type LegislationExpression } from "~/types/api";
@@ -186,16 +187,18 @@ const breadcrumbItems: ComputedRef<BreadcrumbItem[]> = computed(() => {
   ];
 });
 
-const metadataItems = computed(() => {
+const metadataItems = computed<MetadataItem[]>(() => {
   if (privateFeaturesEnabled) {
     return getNormMetadataItems(metadata.value);
   }
   return [
     {
+      type: "text",
       label: "Abkürzung",
       value: abbreviation ?? "",
     },
     {
+      type: "text",
       label: "Status",
     },
   ];

--- a/frontend/src/utils/administrativeDirective.spec.ts
+++ b/frontend/src/utils/administrativeDirective.spec.ts
@@ -15,33 +15,34 @@ describe("getAdministrativeDirectiveMetadataItems", () => {
       "Gültig ab",
     ]);
 
-    expect(result.map((item) => item.value)).toEqual([
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    ]);
+    expect(result[0]).toMatchObject({ type: "badge", values: [] });
+    expect(result[1]).toMatchObject({ type: "text", value: undefined });
+    expect(result[2]).toMatchObject({ type: "text", value: undefined });
+    expect(result[3]).toMatchObject({ type: "text", value: undefined });
   });
 
-  it("maps empty referenceNumber to undefined", () => {
+  it("maps empty referenceNumbers to empty array", () => {
     const result = getAdministrativeDirectiveMetadataItems({
       referenceNumbers: [],
     });
-    expect(result[0]?.value).toBeUndefined();
+    expect(result[0]).toMatchObject({ type: "badge", values: [] });
   });
 
   it("maps single referenceNumber", () => {
     const result = getAdministrativeDirectiveMetadataItems({
       referenceNumbers: ["123"],
     });
-    expect(result[0]?.value).toBe("123");
+    expect(result[0]).toMatchObject({ type: "badge", values: ["123"] });
   });
 
   it("maps multiple referenceNumbers", () => {
     const result = getAdministrativeDirectiveMetadataItems({
       referenceNumbers: ["123", "456"],
     });
-    expect(result[0]?.value).toBe("123, 456");
+    expect(result[0]).toMatchObject({
+      type: "badge",
+      values: ["123", "456"],
+    });
   });
 
   it("maps legislationAuthority", () => {
@@ -49,7 +50,7 @@ describe("getAdministrativeDirectiveMetadataItems", () => {
       legislationAuthority: "authority",
     });
 
-    expect(result[1]?.value).toBe("authority");
+    expect(result[1]).toMatchObject({ type: "text", value: "authority" });
   });
 
   it("maps documentType", () => {
@@ -57,7 +58,7 @@ describe("getAdministrativeDirectiveMetadataItems", () => {
       documentType: "docType",
     });
 
-    expect(result[2]?.value).toBe("docType");
+    expect(result[2]).toMatchObject({ type: "text", value: "docType" });
   });
 
   it("formats valid entryIntoForceDate", () => {
@@ -65,7 +66,7 @@ describe("getAdministrativeDirectiveMetadataItems", () => {
       entryIntoForceDate: "2025-04-07",
     });
 
-    expect(result[3]?.value).toBe("07.04.2025");
+    expect(result[3]).toMatchObject({ type: "text", value: "07.04.2025" });
   });
 
   it("maps invalid entryIntoForceDate to undefined", () => {
@@ -73,7 +74,7 @@ describe("getAdministrativeDirectiveMetadataItems", () => {
       entryIntoForceDate: "foobar",
     });
 
-    expect(result[3]?.value).toBeUndefined();
+    expect(result[3]).toMatchObject({ type: "text", value: undefined });
   });
 });
 

--- a/frontend/src/utils/administrativeDirective.ts
+++ b/frontend/src/utils/administrativeDirective.ts
@@ -1,15 +1,15 @@
 import type { DetailsListItem } from "~/components/documents/DetailsList.vue";
-import type { MetadataItemText } from "~/components/documents/Metadata.vue";
+import type { MetadataItem } from "~/components/documents/Metadata.vue";
 import type { AdministrativeDirective } from "~/types/api";
 
 export function getAdministrativeDirectiveMetadataItems(
   administrativeDirective?: Partial<AdministrativeDirective>,
-): MetadataItemText[] {
+): MetadataItem[] {
   return [
     {
-      type: "text",
+      type: "badge",
       label: "Aktenzeichen",
-      value: formatArray(administrativeDirective?.referenceNumbers ?? []),
+      values: administrativeDirective?.referenceNumbers ?? [],
     },
     {
       type: "text",

--- a/frontend/src/utils/administrativeDirective.ts
+++ b/frontend/src/utils/administrativeDirective.ts
@@ -1,25 +1,28 @@
 import type { DetailsListItem } from "~/components/documents/DetailsList.vue";
-import type { MetadataItem } from "~/components/documents/Metadata.vue";
+import type { MetadataItemText } from "~/components/documents/Metadata.vue";
 import type { AdministrativeDirective } from "~/types/api";
 
 export function getAdministrativeDirectiveMetadataItems(
   administrativeDirective?: Partial<AdministrativeDirective>,
-): MetadataItem[] {
+): MetadataItemText[] {
   return [
     {
+      type: "text",
       label: "Aktenzeichen",
       value: formatArray(administrativeDirective?.referenceNumbers ?? []),
     },
     {
+      type: "text",
       label: "Normgeber",
       value: administrativeDirective?.legislationAuthority,
     },
-
     {
+      type: "text",
       label: "Dokumenttyp",
       value: administrativeDirective?.documentType,
     },
     {
+      type: "text",
       label: "Gültig ab",
       value: dateFormattedDDMMYYYY(administrativeDirective?.entryIntoForceDate),
     },

--- a/frontend/src/utils/literature.spec.ts
+++ b/frontend/src/utils/literature.spec.ts
@@ -44,13 +44,6 @@ describe("getLiteratureMetadataItems", () => {
       "Autor",
       "Veröffentlichungsjahr",
     ]);
-
-    expect(result.map((item) => item.value)).toEqual([
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    ]);
   });
 
   it("converts empty properties to undefined values", () => {
@@ -61,12 +54,10 @@ describe("getLiteratureMetadataItems", () => {
       yearsOfPublication: [],
     });
 
-    expect(result.map((item) => item.value)).toEqual([
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    ]);
+    expect(result[0]).toMatchObject({ type: "text", value: undefined });
+    expect(result[1]).toMatchObject({ type: "badge", values: [] });
+    expect(result[2]).toMatchObject({ type: "text", value: undefined });
+    expect(result[3]).toMatchObject({ type: "text", value: undefined });
   });
 
   it("converts properties with one value", () => {
@@ -77,12 +68,10 @@ describe("getLiteratureMetadataItems", () => {
       yearsOfPublication: ["2015"],
     });
 
-    expect(result.map((item) => item.value)).toEqual([
-      "Foo",
-      "Ref",
-      "Max Mustermann",
-      "2015",
-    ]);
+    expect(result[0]).toMatchObject({ type: "text", value: "Foo" });
+    expect(result[1]).toMatchObject({ type: "badge", values: ["Ref"] });
+    expect(result[2]).toMatchObject({ type: "text", value: "Max Mustermann" });
+    expect(result[3]).toMatchObject({ type: "text", value: "2015" });
   });
 
   it("converts properties with multiple values", () => {
@@ -93,12 +82,16 @@ describe("getLiteratureMetadataItems", () => {
       yearsOfPublication: ["2015", "2016"],
     });
 
-    expect(result.map((item) => item.value)).toEqual([
-      "Foo, Bar",
-      "Ref1, Ref2",
-      "Max Mustermann, Sabine Musterfrau",
-      "2015, 2016",
-    ]);
+    expect(result[0]).toMatchObject({ type: "text", value: "Foo, Bar" });
+    expect(result[1]).toMatchObject({
+      type: "badge",
+      values: ["Ref1", "Ref2"],
+    });
+    expect(result[2]).toMatchObject({
+      type: "text",
+      value: "Max Mustermann, Sabine Musterfrau",
+    });
+    expect(result[3]).toMatchObject({ type: "text", value: "2015, 2016" });
   });
 
   it("concatenates dependent and independent references if they exist", () => {
@@ -107,12 +100,10 @@ describe("getLiteratureMetadataItems", () => {
       independentReferences: ["Indep Ref"],
     });
 
-    expect(result.map((item) => item.value)).toEqual([
-      undefined,
-      "Dep Ref, Indep Ref",
-      undefined,
-      undefined,
-    ]);
+    expect(result[1]).toMatchObject({
+      type: "badge",
+      values: ["Dep Ref", "Indep Ref"],
+    });
   });
 });
 

--- a/frontend/src/utils/literature.ts
+++ b/frontend/src/utils/literature.ts
@@ -19,19 +19,22 @@ export function getLiteratureMetadataItems(
   ];
   return [
     {
+      type: "text",
       label: "Dokumenttyp",
       value: formatArray(literature?.documentTypes ?? []),
     },
     {
+      type: "badge",
       label: "Fundstelle",
-      value: formatArray(references),
+      values: references,
     },
-
     {
+      type: "text",
       label: "Autor",
       value: formatArray(formatNames(literature?.authors ?? [])),
     },
     {
+      type: "text",
       label: "Veröffentlichungsjahr",
       value: formatArray(literature?.yearsOfPublication ?? []),
     },

--- a/frontend/src/utils/norm.spec.ts
+++ b/frontend/src/utils/norm.spec.ts
@@ -193,12 +193,10 @@ describe("getNormMetadataItems", () => {
       "Gültig bis",
     ]);
 
-    expect(result.map((item) => item.value)).toEqual([
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    ]);
+    expect(result[0]).toMatchObject({ type: "text", value: undefined });
+    expect(result[1]).toMatchObject({ type: "text", value: undefined });
+    expect(result[2]).toMatchObject({ type: "text", value: undefined });
+    expect(result[3]).toMatchObject({ type: "text", value: undefined });
   });
 
   it("converts empty properties to undefined values", () => {
@@ -221,12 +219,10 @@ describe("getNormMetadataItems", () => {
       hasPart: [],
     });
 
-    expect(result.map((item) => item.value)).toEqual([
-      "",
-      undefined,
-      undefined,
-      undefined,
-    ]);
+    expect(result[0]).toMatchObject({ type: "text", value: "" });
+    expect(result[1]).toMatchObject({ type: "text", value: undefined });
+    expect(result[2]).toMatchObject({ type: "text", value: undefined });
+    expect(result[3]).toMatchObject({ type: "text", value: undefined });
   });
 
   it("converts properties to correct values", () => {
@@ -249,12 +245,10 @@ describe("getNormMetadataItems", () => {
       hasPart: [],
     });
 
-    expect(result.map((item) => item.value)).toEqual([
-      "ABC",
-      "Aktuell gültig",
-      "06.05.2025",
-      "31.03.2037",
-    ]);
+    expect(result[0]).toMatchObject({ type: "text", value: "ABC" });
+    expect(result[1]).toMatchObject({ type: "text", value: "Aktuell gültig" });
+    expect(result[2]).toMatchObject({ type: "text", value: "06.05.2025" });
+    expect(result[3]).toMatchObject({ type: "text", value: "31.03.2037" });
   });
 });
 

--- a/frontend/src/utils/norm.ts
+++ b/frontend/src/utils/norm.ts
@@ -147,18 +147,22 @@ export function getNormMetadataItems(
   );
   return [
     {
+      type: "text",
       label: "Abkürzung",
       value: norm?.abbreviation,
     },
     {
+      type: "text",
       label: "Status",
       value: formattedStatus,
     },
     {
+      type: "text",
       label: "Gültig ab",
       value: dateFormattedDDMMYYYY(validityInterval?.from),
     },
     {
+      type: "text",
       label: "Gültig bis",
       value: dateFormattedDDMMYYYY(validityInterval?.to),
     },


### PR DESCRIPTION
**Metadata**
- refactor Metadata component to enable rendering values as badges

**Badge**
- add a new GRAY badge variant
- add new prop "variant" to expose different typography variants (will be needed for RISDEV-11103 RISDEV-12247)

**Notes**
- I am not super happy with the prop "variant": Not sure if the naming makes sense. Based on the values it should probably rather be called "size".. But also the typo variants don't really follow this strict size pattern (small, medium, large, etc...). So not sure if even better value names would be more descriptive, but I couldn't think of any. 
- I will remove the color enum and use a string union type for the colors instead in a separate PR

RISDEV-10568