### PR TITLE
risdev-12220-code-smells

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/SitemapController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/SitemapController.java
@@ -208,7 +208,7 @@ public class SitemapController {
       try {
         int batchNumber = Integer.parseInt(filename);
         file = portalBucket.get(sitemapService.getBatchSitemapPath(batchNumber, documentKind));
-      } catch (NumberFormatException exception) {
+      } catch (NumberFormatException _) {
         return ResponseEntity.notFound().build();
       }
     }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/TranslatedLegislationController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/TranslatedLegislationController.java
@@ -87,7 +87,7 @@ public class TranslatedLegislationController {
         return ResponseEntity.ok(translationHtmlString.get());
       }
       return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Translation not found.");
-    } catch (ObjectStoreServiceException exception) {
+    } catch (ObjectStoreServiceException _) {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
           .body("Error accessing the object store.");
     }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/importer/ImportTaskProcessor.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/importer/ImportTaskProcessor.java
@@ -125,7 +125,7 @@ public class ImportTaskProcessor {
         try {
           String target = args[i + 1];
           targets.add(target);
-        } catch (IndexOutOfBoundsException e) {
+        } catch (IndexOutOfBoundsException _) {
           throw new IllegalArgumentException(
               "Expected a target argument following %s".formatted(TASK_ARGUMENT));
         }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureLdmlMappingUtils.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureLdmlMappingUtils.java
@@ -1,0 +1,42 @@
+package de.bund.digitalservice.ris.search.mapper;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/** Shared mapping functions between uli/sli literature */
+public class LiteratureLdmlMappingUtils {
+  private LiteratureLdmlMappingUtils() {}
+
+  /**
+   * extracts value of first year of publication based on its date format
+   *
+   * @param yearsOfPublication List of publication years
+   * @return LocalDate of the first publication year
+   */
+  public static @Nullable LocalDate extractFirstYearOfPublication(List<String> yearsOfPublication) {
+    final String firstValue = yearsOfPublication.getFirst().trim();
+    try {
+      if (firstValue.matches("\\d{4}")) {
+        // Format: YYYY → YYYY-01-01
+        return LocalDate.of(Integer.parseInt(firstValue), Month.JANUARY, 1);
+      } else if (firstValue.matches("\\d{4}-\\d{2}")) {
+        // Format: YYYY-MM → YYYY-MM-01
+        YearMonth yearMonth = YearMonth.parse(firstValue);
+        return yearMonth.atDay(1);
+      } else if (firstValue.matches("\\d{4}-\\d{2}-\\d{2}")) {
+        // Format: YYYY-MM-DD
+        return LocalDate.parse(firstValue);
+      } else {
+        // Any other unexpected format → return null or handle differently
+        return null;
+      }
+    } catch (DateTimeParseException | NumberFormatException _) {
+      // Handle malformed numeric values gracefully
+      return null;
+    }
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureLdmlToOpenSearchMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureLdmlToOpenSearchMapper.java
@@ -26,10 +26,6 @@ import jakarta.xml.bind.JAXB;
 import jakarta.xml.bind.ValidationException;
 import java.io.StringReader;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.Month;
-import java.time.YearMonth;
-import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -83,7 +79,8 @@ public class LiteratureLdmlToOpenSearchMapper {
   private static Literature mapToEntity(LiteratureLdml literatureLdml) throws ValidationException {
     var documentNumber = extractDocumentNumber(literatureLdml);
     var yearsOfPublication = extractYearsOfPublication(literatureLdml);
-    var firstYearOfPublication = extractFirstYearOfPublication(yearsOfPublication);
+    var firstYearOfPublication =
+        LiteratureLdmlMappingUtils.extractFirstYearOfPublication(yearsOfPublication);
     return Literature.builder()
         .id(documentNumber)
         .documentNumber(documentNumber)
@@ -105,29 +102,6 @@ public class LiteratureLdmlToOpenSearchMapper {
         .outline((extractOutline(literatureLdml)))
         .indexedAt(Instant.now().toString())
         .build();
-  }
-
-  private static LocalDate extractFirstYearOfPublication(List<String> yearsOfPublication) {
-    final String firstValue = yearsOfPublication.getFirst().trim();
-    try {
-      if (firstValue.matches("\\d{4}")) {
-        // Format: YYYY → YYYY-01-01
-        return LocalDate.of(Integer.parseInt(firstValue), Month.JANUARY, 1);
-      } else if (firstValue.matches("\\d{4}-\\d{2}")) {
-        // Format: YYYY-MM → YYYY-MM-01
-        YearMonth yearMonth = YearMonth.parse(firstValue);
-        return yearMonth.atDay(1);
-      } else if (firstValue.matches("\\d{4}-\\d{2}-\\d{2}")) {
-        // Format: YYYY-MM-DD
-        return LocalDate.parse(firstValue);
-      } else {
-        // Any other unexpected format → return null or handle differently
-        return null;
-      }
-    } catch (DateTimeParseException | NumberFormatException e) {
-      // Handle malformed numeric values gracefully
-      return null;
-    }
   }
 
   private static String extractDocumentNumber(LiteratureLdml literatureLdml)

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/SliLiteratureLdmlToOpenSearchMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/SliLiteratureLdmlToOpenSearchMapper.java
@@ -29,10 +29,6 @@ import jakarta.xml.bind.JAXB;
 import jakarta.xml.bind.ValidationException;
 import java.io.StringReader;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.Month;
-import java.time.YearMonth;
-import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -92,7 +88,8 @@ public class SliLiteratureLdmlToOpenSearchMapper {
       throws ValidationException {
     var documentNumber = extractDocumentNumber(literatureLdml);
     var yearsOfPublication = extractYearsOfPublication(literatureLdml);
-    var firstYearOfPublication = extractFirstYearOfPublication(yearsOfPublication);
+    var firstYearOfPublication =
+        LiteratureLdmlMappingUtils.extractFirstYearOfPublication(yearsOfPublication);
     return Literature.builder()
         .id(documentNumber)
         .documentNumber(documentNumber)
@@ -156,29 +153,6 @@ public class SliLiteratureLdmlToOpenSearchMapper {
     return extractRisMeta(literatureLdml)
         .map(RisMeta::getTitelKurzformen)
         .orElse(Collections.emptyList());
-  }
-
-  private static LocalDate extractFirstYearOfPublication(List<String> yearsOfPublication) {
-    final String firstValue = yearsOfPublication.getFirst().trim();
-    try {
-      if (firstValue.matches("\\d{4}")) {
-        // Format: YYYY → YYYY-01-01
-        return LocalDate.of(Integer.parseInt(firstValue), Month.JANUARY, 1);
-      } else if (firstValue.matches("\\d{4}-\\d{2}")) {
-        // Format: YYYY-MM → YYYY-MM-01
-        YearMonth yearMonth = YearMonth.parse(firstValue);
-        return yearMonth.atDay(1);
-      } else if (firstValue.matches("\\d{4}-\\d{2}-\\d{2}")) {
-        // Format: YYYY-MM-DD
-        return LocalDate.parse(firstValue);
-      } else {
-        // Any other unexpected format → return null or handle differently
-        return null;
-      }
-    } catch (DateTimeParseException | NumberFormatException e) {
-      // Handle malformed numeric values gracefully
-      return null;
-    }
   }
 
   private static String extractDocumentNumber(LiteratureLdml literatureLdml)

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/LocalFilesystemObjectStorageClient.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/LocalFilesystemObjectStorageClient.java
@@ -160,7 +160,7 @@ public class LocalFilesystemObjectStorageClient implements ObjectStorageClient {
           .filter(f -> f.toString().contains(prefix))
           .map(mappingFunction)
           .toList();
-    } catch (IOException e) {
+    } catch (IOException _) {
       LOGGER.info("Could not list files in {}", basePath);
       return List.of();
     }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectStorage.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/objectstorage/ObjectStorage.java
@@ -123,7 +123,7 @@ public class ObjectStorage {
             throw new ObjectStoreServiceException(e.getCause().getMessage());
           }
           logger.error("an exception occured furing object retrieval", e.getCause());
-        } catch (InterruptedException interruptedException) {
+        } catch (InterruptedException _) {
           downloadExecutor.shutdownNow();
           logger.error("object retrieval thread was interrupted");
           Thread.currentThread().interrupt();
@@ -149,7 +149,7 @@ public class ObjectStorage {
       final var response = getStream(objectKey);
       return Optional.of(response.readAllBytes());
     } catch (NoSuchKeyException e) {
-      logger.warn("Object key {} does not exist", objectKey);
+      logger.warn("Object key does not exist: {}", e.getMessage());
       return Optional.empty();
     } catch (IOException | AwsServiceException | SdkClientException e) {
       throw new ObjectStoreServiceException(

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/AdministrativeDirectiveService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/AdministrativeDirectiveService.java
@@ -85,7 +85,7 @@ public class AdministrativeDirectiveService {
   public Optional<byte[]> getFileByDocumentNumber(String documentNumber) {
     try {
       return bucket.get(String.format("%s.akn.xml", documentNumber));
-    } catch (ObjectStoreServiceException e) {
+    } catch (ObjectStoreServiceException _) {
       return Optional.empty();
     }
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/CaseLawService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/CaseLawService.java
@@ -201,7 +201,7 @@ public class CaseLawService {
     }
     try {
       return Optional.of(marshaller.fromString(contentOption.get()));
-    } catch (OpenSearchMapperException ex) {
+    } catch (OpenSearchMapperException _) {
       return Optional.empty();
     }
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexStatusService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexStatusService.java
@@ -55,7 +55,7 @@ public class IndexStatusService {
         return new IndexingState();
       }
       return mapper.readValue(content, IndexingState.class);
-    } catch (JsonProcessingException e) {
+    } catch (JsonProcessingException _) {
       return new IndexingState();
     }
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapService.java
@@ -127,7 +127,7 @@ public class SitemapService {
       StringWriter sitemapFileContent = new StringWriter();
       mar.marshal(sitemapFile, sitemapFileContent);
       return sitemapFileContent.toString();
-    } catch (JAXBException exception) {
+    } catch (JAXBException _) {
       return "";
     }
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/eclicrawler/EcliCrawlerDocumentService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/eclicrawler/EcliCrawlerDocumentService.java
@@ -170,21 +170,17 @@ public class EcliCrawlerDocumentService {
   }
 
   private Optional<EcliCrawlerDocument> getFromBucket(String filename) {
-    try {
-      return caselawService
-          .getFromBucket(filename)
-          .flatMap(
-              unit -> {
-                if (isValidEcliDocument(unit)) {
-                  return Optional.of(
-                      EcliCrawlerDocumentMapper.fromCaseLawDocumentationUnit(
-                          documentUrl, filename, unit));
-                }
-                return Optional.empty();
-              });
-    } catch (ObjectStoreServiceException e) {
-      throw new FatalEcliSitemapJobException("no connection to bucket");
-    }
+    return caselawService
+        .getFromBucket(filename)
+        .flatMap(
+            unit -> {
+              if (isValidEcliDocument(unit)) {
+                return Optional.of(
+                    EcliCrawlerDocumentMapper.fromCaseLawDocumentationUnit(
+                        documentUrl, filename, unit));
+              }
+              return Optional.empty();
+            });
   }
 
   private Optional<EcliCrawlerDocument> getPublishedDocument(String filename) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/eclicrawler/EcliSitemapWriter.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/eclicrawler/EcliSitemapWriter.java
@@ -112,11 +112,7 @@ public class EcliSitemapWriter {
    * @return An Optional containing the byte array of the sitemap file if found, otherwise empty.
    */
   public Optional<byte[]> getSitemapFile(String filename) {
-    try {
-      return portalBucket.get(PATH_PREFIX + filename);
-    } catch (ObjectStoreServiceException e) {
-      return Optional.empty();
-    }
+    return portalBucket.get(PATH_PREFIX + filename);
   }
 
   /**
@@ -125,11 +121,7 @@ public class EcliSitemapWriter {
    * @return An Optional containing the byte array of the robots.txt file if found, otherwise empty.
    */
   public Optional<byte[]> getRobots() {
-    try {
-      return portalBucket.get(ROBOTS_TXT_PATH);
-    } catch (ObjectStoreServiceException e) {
-      return Optional.empty();
-    }
+    return portalBucket.get(ROBOTS_TXT_PATH);
   }
 
   /** Write the initial robots.txt file to disallow all crawlers except DG_JUSTICE_CRAWLER. */

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/xslt/NormXsltTransformerService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/xslt/NormXsltTransformerService.java
@@ -118,7 +118,7 @@ public class NormXsltTransformerService extends XsltTransformer {
     try {
       parameters.put("article-eid", eId);
       return transformLegalDocMlFromBytes(source, parameters);
-    } catch (XMLElementNotFoundException ex) {
+    } catch (XMLElementNotFoundException _) {
       String encodedId = UriUtils.encode(eId, StandardCharsets.UTF_8).toLowerCase(Locale.ROOT);
       parameters.put("article-eid", encodedId);
       return transformLegalDocMlFromBytes(source, parameters);

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/XmlDocument.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/XmlDocument.java
@@ -136,7 +136,7 @@ public class XmlDocument {
   public Optional<Node> getFirstMatchedNodeByXpath(String xpath, Node item) {
     try {
       return Optional.ofNullable((Node) xpathInstance.evaluate(xpath, item, XPathConstants.NODE));
-    } catch (XPathExpressionException e) {
+    } catch (XPathExpressionException _) {
       return Optional.empty();
     }
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/eli/EliFile.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/eli/EliFile.java
@@ -84,7 +84,7 @@ public record EliFile(
                   matcher.group("pointInTimeManifestation"), DateTimeFormatter.ISO_LOCAL_DATE),
               matcher.group("fileName"),
               matcher.group("format")));
-    } catch (IllegalStateException | IllegalArgumentException | DateTimeParseException e) {
+    } catch (IllegalStateException | IllegalArgumentException | DateTimeParseException _) {
       return Optional.empty();
     }
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/TestXmlUtils.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/TestXmlUtils.java
@@ -60,7 +60,7 @@ public class TestXmlUtils {
       transformer.transform(new DOMSource(doc), new StreamResult(writer));
       return writer.toString();
     } catch (TransformerException e) {
-      throw new FileTransformationException("Error trying to convert XML document to string");
+      throw new FileTransformationException("Error trying to convert XML document to string", e);
     }
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/config/obs/MockS3Client.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/config/obs/MockS3Client.java
@@ -43,10 +43,11 @@ public abstract class MockS3Client implements S3Client {
   protected List<String> getFileNamesByPath(String directory) {
     try (Stream<Path> stream = Files.walk(Paths.get(directory))) {
       return stream.filter(Files::isRegularFile).map(Path::toString).toList();
-    } catch (NoSuchFileException e) {
+    } catch (NoSuchFileException _) {
       return new ArrayList<>();
     } catch (IOException e) {
-      throw new FileTransformationException(String.format("Could not list files in %s", directory));
+      throw new FileTransformationException(
+          String.format("Could not list files in %s", directory), e);
     }
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/config/obs/TestMockS3Client.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/config/obs/TestMockS3Client.java
@@ -147,7 +147,7 @@ public class TestMockS3Client extends MockS3Client implements S3Client {
       fileMap.put(key, bytes);
       return PutObjectResponse.builder().build();
     } catch (IOException e) {
-      LOGGER.error("Couldn't put object to local storage: {}", key);
+      LOGGER.error("Couldn't put object to local storage: {}", key, e);
       return null;
     }
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/CaseLawControllerApiTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/CaseLawControllerApiTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 import org.opensearch.core.common.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -304,7 +303,7 @@ class CaseLawControllerApiTest extends ContainersIntegrationBase {
   @Test
   @DisplayName("Returns 500 if placeholder.png is missing")
   void shouldReturn500IfPlaceholderMissing() throws Exception {
-    try (MockedConstruction<ClassPathResource> ignored =
+    try (var _ =
         Mockito.mockConstruction(
             ClassPathResource.class,
             (mock, context) ->

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/LiteratureLdmlMappingUtilsTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/LiteratureLdmlMappingUtilsTest.java
@@ -1,0 +1,37 @@
+package de.bund.digitalservice.ris.search.unit.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.bund.digitalservice.ris.search.mapper.LiteratureLdmlMappingUtils;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class LiteratureLdmlMappingUtilsTest {
+
+  private static Stream<Arguments> provideYearsOfPublication() {
+    return Stream.of(
+        Arguments.of(" 2020 ", LocalDate.of(2020, Month.JANUARY, 1)),
+        Arguments.of("2020", LocalDate.of(2020, Month.JANUARY, 1)),
+        Arguments.of(" 2020-05 ", LocalDate.of(2020, Month.MAY, 1)),
+        Arguments.of("2020-05", LocalDate.of(2020, Month.MAY, 1)),
+        Arguments.of(" 2020-05-23 ", LocalDate.of(2020, Month.MAY, 23)),
+        Arguments.of("2020-05-23", LocalDate.of(2020, Month.MAY, 23)),
+        Arguments.of("XX", null),
+        Arguments.of("1986 - 1987", null),
+        Arguments.of("2001 (vermutlich)", null),
+        Arguments.of("2003, 127-133 (Schriften des Vereins für Socialpolitik", null));
+  }
+
+  @ParameterizedTest()
+  @MethodSource("provideYearsOfPublication")
+  void firstPublicationDateIsNullOnInvalidDate(String yearValue, LocalDate expectedDate) {
+
+    assertThat(LiteratureLdmlMappingUtils.extractFirstYearOfPublication(List.of(yearValue)))
+        .isEqualTo(expectedDate);
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/LiteratureLdmlToOpenSearchMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/LiteratureLdmlToOpenSearchMapperTest.java
@@ -10,12 +10,8 @@ import de.bund.digitalservice.ris.search.models.opensearch.Literature;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -134,55 +130,5 @@ class LiteratureLdmlToOpenSearchMapperTest {
     assertThat(literature.normReferences()).isEmpty();
     assertThat(literature.shortReport()).isNull();
     assertThat(literature.outline()).isNull();
-  }
-
-  @ParameterizedTest(name = "Parses \"{0}\" → {1}")
-  @MethodSource("provideYearsOfPublication")
-  @DisplayName("Correctly parses veroeffentlichungsJahr into firstPublicationDate")
-  void parsesVariousYearFormats(String yearValue, LocalDate expectedDate) {
-    final String xmlTemplate =
-        """
-                  <akn:akomaNtoso xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
-                                   xmlns:ris="http://ldml.neuris.de/literature/unselbstaendig/meta/">
-                    <akn:doc name="offene-struktur">
-                      <akn:meta>
-                        <akn:identification>
-                          <akn:FRBRWork>
-                            <akn:FRBRalias name="Dokumentnummer" value="XXLU000000001" />
-                          </akn:FRBRWork>
-                        </akn:identification>
-                        <akn:classification source="doktyp">
-                          <akn:keyword dictionary="attributsemantik-noch-undefiniert" showAs="Auf" value="Auf"/>
-                        </akn:classification>
-                        <akn:proprietary source="test">
-                          <ris:meta>
-                            <ris:veroeffentlichungsJahre>
-                              <ris:veroeffentlichungsJahr>%s</ris:veroeffentlichungsJahr>
-                            </ris:veroeffentlichungsJahre>
-                          </ris:meta>
-                        </akn:proprietary>
-                      </akn:meta>
-                    </akn:doc>
-                  </akn:akomaNtoso>
-                  """;
-
-    String xml = xmlTemplate.formatted(yearValue);
-    Literature literature = LiteratureLdmlToOpenSearchMapper.mapLdml(xml);
-
-    assertThat(literature.firstPublicationDate()).isEqualTo(expectedDate);
-  }
-
-  private static Stream<Arguments> provideYearsOfPublication() {
-    return Stream.of(
-        Arguments.of(" 2020 ", LocalDate.of(2020, Month.JANUARY, 1)),
-        Arguments.of("2020", LocalDate.of(2020, Month.JANUARY, 1)),
-        Arguments.of(" 2020-05 ", LocalDate.of(2020, Month.MAY, 1)),
-        Arguments.of("2020-05", LocalDate.of(2020, Month.MAY, 1)),
-        Arguments.of(" 2020-05-23 ", LocalDate.of(2020, Month.MAY, 23)),
-        Arguments.of("2020-05-23", LocalDate.of(2020, Month.MAY, 23)),
-        Arguments.of("XX", null),
-        Arguments.of("1986 - 1987", null),
-        Arguments.of("2001 (vermutlich)", null),
-        Arguments.of("2003, 127-133 (Schriften des Vereins für Socialpolitik", null));
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/eclicrawler/EcliSitemapWriterTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/eclicrawler/EcliSitemapWriterTest.java
@@ -129,15 +129,6 @@ class EcliSitemapWriterTest {
   }
 
   @Test
-  void itReturnsEmptyOnObjectStoreExceptionWhileGettingRobotsFile()
-      throws ObjectStoreServiceException {
-    when(bucket.get(ROBOTS_TXT_PATH)).thenThrow(ObjectStoreServiceException.class);
-
-    var result = service.getRobots();
-    Assertions.assertTrue(result.isEmpty());
-  }
-
-  @Test
   void itReturnsASpecificEcliFile() throws ObjectStoreServiceException {
     String filename = "2025/01/01/sitemap_1.xml";
     Optional<byte[]> expectedContent = Optional.of("test".getBytes(StandardCharsets.UTF_16));


### PR DESCRIPTION
use unnamed pattern when applicable, 
remove redundant objectstore exception catches