### PR TITLE
RISDEV-0000 consistent loading states

### DIFF
--- a/frontend/e2e/erweiterteSuche.spec.ts
+++ b/frontend/e2e/erweiterteSuche.spec.ts
@@ -134,7 +134,7 @@ test.describe("general advanced search page features", () => {
     await pagination.getByRole("link", { name: "Weiter" }).click();
     await page.waitForURL(/pageIndex=1/);
 
-    expect(resultCounter).toHaveText(nonZeroResultCount);
+    await expect(resultCounter).toHaveText(nonZeroResultCount);
     // Warning: this is potentially flaky and only works because the previous
     // assertion about the result counter has already "stabilized" the page.
     // Unfortunately there is no other way of asserting a number that isn't
@@ -430,7 +430,7 @@ test.describe("searching legislation", () => {
 
     const results = getSearchResults(page);
 
-    expect(results).toHaveText([
+    await expect(results).toHaveText([
       /Zukünftig in Kraft/,
       /Aktuell gültig/,
       /Außer Kraft/,
@@ -452,7 +452,7 @@ test.describe("searching legislation", () => {
 
     const results = getSearchResults(page);
 
-    expect(results).toHaveText(/Aktuell gültig/);
+    await expect(results).toHaveText(/Aktuell gültig/);
   });
 
   test("filters to show specific date", async ({ page, isMobileTest }) => {

--- a/frontend/e2e/gesetze.spec.ts
+++ b/frontend/e2e/gesetze.spec.ts
@@ -131,8 +131,8 @@ test.describe("view norm page", async () => {
     const toc = page.getByRole("region", {
       name: "Amtliches Inhaltsverzeichnis ausblenden",
     });
-    expect(toc).toBeVisible();
-    expect(toc.getByRole("listitem")).toBeVisible();
+    await expect(toc).toBeVisible();
+    await expect(toc.getByRole("listitem").first()).toBeVisible();
   });
 
   test(

--- a/frontend/e2e/suche.spec.ts
+++ b/frontend/e2e/suche.spec.ts
@@ -1332,7 +1332,7 @@ noJsTest("pagination works without JavaScript", async ({ page }) => {
     .getByRole("navigation", { name: "Paginierung" })
     .getByRole("link", { name: "Zurück" })
     .click();
-  expect(page).not.toHaveURL(/pageIndex=\d+/);
+  await expect(page).not.toHaveURL(/pageIndex=\d+/);
 
   await expect(getResultCounter(page)).toHaveText(nonZeroResultCount);
   await expect(getSearchResults(page)).toHaveCount(10);

--- a/frontend/src/components/Pagination.spec.ts
+++ b/frontend/src/components/Pagination.spec.ts
@@ -52,15 +52,6 @@ describe("Pagination", () => {
     expect(container.querySelector("nav")).not.toBeInTheDocument();
   });
 
-  it("renders nothing when isLoading is true", async () => {
-    const page = createMockPage();
-    const { container } = await renderSuspended(Pagination, {
-      props: { page, isLoading: true },
-    });
-
-    expect(container.querySelector("nav")).not.toBeInTheDocument();
-  });
-
   it("renders page information with items on page", async () => {
     const page = createMockPage();
     await renderSuspended(Pagination, {

--- a/frontend/src/components/Pagination.vue
+++ b/frontend/src/components/Pagination.vue
@@ -24,9 +24,8 @@ const props = withDefaults(
   defineProps<{
     page?: Page | null;
     navigationPosition?: "top" | "bottom";
-    isLoading?: boolean;
   }>(),
-  { page: undefined, navigationPosition: "top", isLoading: false },
+  { page: undefined, navigationPosition: "top" },
 );
 
 const emit = defineEmits<(e: "updatePage", page: number) => void>();
@@ -99,7 +98,7 @@ const itemsOnPage = computed(() => buildItemsOnPageString(props.page));
   <slot v-if="props.navigationPosition == 'bottom'" />
 
   <nav
-    v-if="page?.member && page?.member.length && !isLoading"
+    v-if="page?.member && page?.member.length"
     aria-label="Paginierung"
     class="flex flex-col items-center"
     :class="{

--- a/frontend/src/components/search/SimpleSearchInput.spec.ts
+++ b/frontend/src/components/search/SimpleSearchInput.spec.ts
@@ -64,6 +64,36 @@ describe("SimpleSearchInput", () => {
     expect(emitted("update:modelValue")).toEqual([["test query"]]);
   });
 
+  it("shows a loading state on the submit button", () => {
+    const { container } = render(SimpleSearchInput, {
+      props: { loading: true },
+    });
+
+    expect(screen.getByRole("button", { name: "Suchen" })).toBeDisabled();
+    expect(
+      container.querySelector("[aria-label='Ladestatus']"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not submit while loading", async () => {
+    const user = userEvent.setup();
+
+    const { container, emitted } = render(SimpleSearchInput, {
+      props: { loading: true },
+    });
+
+    await user.type(screen.getByRole("searchbox"), "test query");
+
+    const form = container.querySelector("form");
+    expect(form).toBeInTheDocument();
+    form?.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    );
+    await nextTick();
+
+    expect(emitted("update:modelValue")).toBeFalsy();
+  });
+
   it("allows customizing labels via props", () => {
     render(SimpleSearchInput, {
       props: {

--- a/frontend/src/components/search/SimpleSearchInput.vue
+++ b/frontend/src/components/search/SimpleSearchInput.vue
@@ -4,11 +4,13 @@ import IconSearch from "~icons/ic/search";
 const {
   inputLabel = "Suchbegriff eingeben",
   inputPlaceholder = "Suchbegriff eingeben",
+  loading = false,
   submitLabel = "Suchen",
 } = defineProps<{
   fullWidth?: boolean;
   inputLabel?: string;
   inputPlaceholder?: string;
+  loading?: boolean;
   submitLabel?: string;
 }>();
 
@@ -26,6 +28,8 @@ watch(model, (newValue) => {
 const emit = defineEmits(["emptySearch"]);
 
 const performSearch = () => {
+  if (loading) return;
+
   // if the user hasn't entered any text, updating the model will have no effect
   // since they might still want to trigger an empty search, use "emit"
   if (!currentText.value) emit("emptySearch");
@@ -51,7 +55,7 @@ const searchInputId = useId();
           type="search"
           size="large"
         />
-        <UiButton :aria-label="submitLabel" type="submit" size="large">
+        <UiButton :aria-label="submitLabel" type="submit" size="large" :loading>
           <template #icon><IconSearch /></template>
         </UiButton>
       </div>

--- a/frontend/src/composables/useNormVersions.spec.ts
+++ b/frontend/src/composables/useNormVersions.spec.ts
@@ -32,9 +32,9 @@ beforeEach(() => {
 });
 
 describe("useNormVersions", () => {
-  it("returns a sorted list when there is no error", () => {
-    const { sortedVersions } = useNormVersions("dummy-eli");
-    expect(useRisBackendMock).toBeCalledWith(
+  it("returns a sorted list when there is no error", async () => {
+    const { sortedVersions } = await useNormVersions("dummy-eli");
+    expect(useRisBackendMock).toHaveBeenCalledWith(
       "/v1/legislation/work-example/dummy-eli",
       {
         immediate: true,
@@ -49,13 +49,13 @@ describe("useNormVersions", () => {
     );
   });
 
-  it("exposes the error without throwing when an error occurs", () => {
+  it("exposes the error without throwing when an error occurs", async () => {
     vi.mocked(useRisBackendMock).mockReturnValue({
       status: ref("error"),
       data: computed(() => undefined),
       error: ref("Error occurred"),
     } as unknown as ReturnType<typeof useRisBackendMock>);
-    const { error, sortedVersions } = useNormVersions("dummy-eli");
+    const { error, sortedVersions } = await useNormVersions("dummy-eli");
     expect(error.value).toBe("Error occurred");
     expect(sortedVersions.value).toEqual([]);
   });

--- a/frontend/src/composables/useNormVersions.ts
+++ b/frontend/src/composables/useNormVersions.ts
@@ -8,15 +8,16 @@ import type {
 } from "~/types/api";
 import { getCurrentDateInGermanyFormatted } from "~/utils/dateFormatting";
 
-export function useNormVersions(eli: string) {
-  const { data, status, error } = useRisBackend<
+export async function useNormVersions(eli: string) {
+  const { data, status, error } = await useRisBackend<
     JSONLDList<LegislationExpression>
   >(`/v1/legislation/work-example/${eli}`, { immediate: true });
+
   const sortedVersions = computed(() => data.value?.member ?? []);
   return { data, status, error, sortedVersions };
 }
 
-export function useValidNormVersions(eli: string) {
+export async function useValidNormVersions(eli: string) {
   const today = getCurrentDateInGermanyFormatted();
   return getNorms({
     eli: eli,
@@ -30,9 +31,6 @@ function getNorms(params: LegislationSearchParams) {
   const immediate = params.eli !== undefined;
   return useRisBackend<JSONLDList<SearchResult<LegislationWork>>>(
     `/v1/legislation`,
-    {
-      params,
-      immediate: immediate,
-    },
+    { params, immediate: immediate },
   );
 }

--- a/frontend/src/composables/useSearchLoadingIndicator.spec.ts
+++ b/frontend/src/composables/useSearchLoadingIndicator.spec.ts
@@ -1,0 +1,115 @@
+import { mockNuxtImport, mountSuspended } from "@nuxt/test-utils/runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AsyncDataRequestStatus } from "#app";
+import { useSearchLoadingIndicator } from "./useSearchLoadingIndicator";
+
+const { startMock, finishMock, useLoadingIndicatorMock } = vi.hoisted(() => {
+  const start = vi.fn();
+  const finish = vi.fn();
+
+  return {
+    startMock: start,
+    finishMock: finish,
+    useLoadingIndicatorMock: vi.fn(() => ({ start, finish })),
+  };
+});
+
+mockNuxtImport("useLoadingIndicator", () => {
+  return useLoadingIndicatorMock;
+});
+
+// The page:loading:end hook lives on the shared Nuxt app, so a component left
+// mounted would keep reacting to it in later tests.
+let mounted: { unmount: () => void } | undefined;
+
+async function mountWithStatus(status: Ref<AsyncDataRequestStatus>) {
+  let indicator!: ReturnType<typeof useSearchLoadingIndicator>;
+
+  const wrapper = await mountSuspended(
+    defineComponent({
+      setup() {
+        indicator = useSearchLoadingIndicator(status);
+      },
+      template: "<div/>",
+    }),
+  );
+  mounted = wrapper;
+
+  return { indicator, wrapper };
+}
+
+/** Simulates Nuxt ending the indicator, as it does on every navigation. */
+async function endPageLoading() {
+  await useNuxtApp().callHook("page:loading:end");
+}
+
+describe("useSearchLoadingIndicator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mounted?.unmount();
+    mounted = undefined;
+  });
+
+  it("reports whether a search is currently running", async () => {
+    const status = ref<AsyncDataRequestStatus>("pending");
+    const { indicator } = await mountWithStatus(status);
+
+    expect(indicator.isSearching.value).toBe(true);
+
+    status.value = "success";
+    expect(indicator.isSearching.value).toBe(false);
+  });
+
+  it("restarts the indicator when Nuxt ends it while a search runs", async () => {
+    const status = ref<AsyncDataRequestStatus>("pending");
+    await mountWithStatus(status);
+
+    await endPageLoading();
+
+    expect(startMock).toHaveBeenCalled();
+  });
+
+  it("leaves the indicator alone when no search is running", async () => {
+    const status = ref<AsyncDataRequestStatus>("success");
+    await mountWithStatus(status);
+
+    await endPageLoading();
+
+    expect(startMock).not.toHaveBeenCalled();
+  });
+
+  it("finishes the indicator once the search settles", async () => {
+    const status = ref<AsyncDataRequestStatus>("pending");
+    await mountWithStatus(status);
+
+    expect(finishMock).not.toHaveBeenCalled();
+
+    status.value = "success";
+    await nextTick();
+
+    expect(finishMock).toHaveBeenCalled();
+  });
+
+  it("finishes the indicator when the search fails", async () => {
+    const status = ref<AsyncDataRequestStatus>("pending");
+    await mountWithStatus(status);
+
+    status.value = "error";
+    await nextTick();
+
+    expect(finishMock).toHaveBeenCalled();
+  });
+
+  it("stops restarting the indicator once unmounted", async () => {
+    const status = ref<AsyncDataRequestStatus>("pending");
+    const { wrapper } = await mountWithStatus(status);
+
+    wrapper.unmount();
+    await endPageLoading();
+
+    expect(startMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/composables/useSearchLoadingIndicator.ts
+++ b/frontend/src/composables/useSearchLoadingIndicator.ts
@@ -1,0 +1,41 @@
+import type { AsyncDataRequestStatus } from "#app";
+
+/**
+ * Drives Nuxt's global loading indicator for a search that is re-run from the
+ * page already showing its results, so it looks like a full page load.
+ *
+ * Nuxt starts the indicator on every navigation, but ends it again on the next
+ * tick when only the query changed, because the page component isn't re-created
+ * and Suspense never goes pending. That would leave the indicator invisible for
+ * the entire search, so this re-asserts it for as long as the search runs.
+ *
+ * Re-creating the page instead, via `key` in `definePageMeta`, would let Nuxt
+ * drive the indicator on its own. It also discards the unsubmitted query draft
+ * and the drawer state that the search pages keep in plain refs, which is why
+ * we do it this way round.
+ *
+ * @param searchStatus - Request status of the search shown on this page
+ * @returns Whether a search is currently running
+ */
+export function useSearchLoadingIndicator(
+  searchStatus: MaybeRefOrGetter<AsyncDataRequestStatus>,
+) {
+  const nuxtApp = useNuxtApp();
+  const { start, finish } = useLoadingIndicator();
+
+  const isSearching = computed(() => toValue(searchStatus) === "pending");
+
+  // This handler is registered after the indicator's own, which runs on the
+  // same hook, so start() lands after the finish() that Nuxt triggers.
+  onScopeDispose(
+    nuxtApp.hook("page:loading:end", () => {
+      if (isSearching.value) start();
+    }),
+  );
+
+  watch(isSearching, (searching) => {
+    if (!searching) finish();
+  });
+
+  return { isSearching };
+}

--- a/frontend/src/pages/erweiterte-suche/index.vue
+++ b/frontend/src/pages/erweiterte-suche/index.vue
@@ -399,7 +399,6 @@ watch(searchStatus, async (newStatus, oldStatus) => {
         <div class="col-span-12 lg:col-span-7">
           <Pagination
             v-if="searchStatus !== 'idle'"
-            :is-loading="searchStatus === 'pending'"
             :page="searchResults"
             navigation-position="bottom"
             @update-page="handlePageUpdate"

--- a/frontend/src/pages/erweiterte-suche/index.vue
+++ b/frontend/src/pages/erweiterte-suche/index.vue
@@ -398,7 +398,6 @@ watch(searchStatus, async (newStatus, oldStatus) => {
 
         <div class="col-span-12 lg:col-span-7">
           <Pagination
-            v-if="searchStatus !== 'idle'"
             :page="searchResults"
             navigation-position="bottom"
             @update-page="handlePageUpdate"

--- a/frontend/src/pages/erweiterte-suche/index.vue
+++ b/frontend/src/pages/erweiterte-suche/index.vue
@@ -230,6 +230,8 @@ const formattedResultCount = computed(() =>
   formatResultCount(totalItemCount.value),
 );
 
+const { isSearching } = useSearchLoadingIndicator(searchStatus);
+
 // User action handlers ------------------------------------
 
 function submit() {
@@ -319,7 +321,7 @@ watch(searchStatus, async (newStatus, oldStatus) => {
           v-model="localQuery"
           :data-fields="queryableDataFields"
           :document-kind
-          :loading="searchStatus === 'pending'"
+          :loading="isSearching"
           :form-id="searchFormId"
           :count
           @submit="submit"

--- a/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
+++ b/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
@@ -184,7 +184,7 @@ const detailsSectionId = useId();
           ></div>
         </section>
 
-        <template #sidebar v-if="tocEntries?.length">
+        <template #sidebar v-if="tocEntries.length">
           <client-only>
             <DocumentsTableOfContents :table-of-contents="tocEntries" />
           </client-only>

--- a/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
+++ b/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
@@ -22,14 +22,15 @@ const route = useRoute();
 const documentNumber = route.params.documentNumber?.toString();
 if (!documentNumber) throw createError({ status: 404 });
 
-const { data: caseLaw, error: metadataError } = await useRisBackend<CaseLaw>(
-  `/v1/case-law/${documentNumber}`,
-);
-if (metadataError?.value) throw createError(metadataError.value);
+const [
+  { data: caseLaw, error: metadataError },
+  { data: html, error: contentError },
+] = await Promise.all([
+  useRisBackend<CaseLaw>(`/v1/case-law/${documentNumber}`),
+  useRisBackend<string>(`/v1/case-law/${documentNumber}.html`),
+]);
 
-const { data: html, error: contentError } = await useRisBackend<string>(
-  `/v1/case-law/${documentNumber}.html`,
-);
+if (metadataError?.value) throw createError(metadataError.value);
 if (contentError?.value) throw createError(contentError.value);
 
 const document = computed(() => {

--- a/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
+++ b/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
@@ -75,14 +75,13 @@ const breadcrumbs = computed(() => [
   { label: title.value ?? "Titelzeile nicht vorhanden" },
 ]);
 
-const tocEntries = computed<TreeItem[] | null>(() => {
-  return document.value
-    ? getAllSectionsFromDocument(document.value, "section").map((entry) => ({
-        key: entry.id,
-        subtitle: entry.title, // Subtitle for more subtle appearance
-        to: { hash: `#${entry.id}`, query: { from: route.query.from } },
-      }))
-    : null;
+const tocEntries = computed<TreeItem[]>(() => {
+  if (!document.value) return [];
+  return getAllSectionsFromDocument(document.value, "section").map((entry) => ({
+    key: entry.id,
+    subtitle: entry.title, // Subtitle for more subtle appearance
+    to: { hash: `#${entry.id}`, query: { from: route.query.from } },
+  }));
 });
 
 const headerMetadata = computed<MetadataItem[]>(() => [

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -195,24 +195,18 @@ const htmlTitle = computed(() => data.value.articleHeading);
 const validVersions =
   norm.value?.legislationLegalForce === "InForce"
     ? undefined
-    : useValidNormVersions(norm.value?.exampleOfWork.legislationIdentifier);
+    : await useValidNormVersions(
+        norm.value?.exampleOfWork.legislationIdentifier,
+      );
 
 if (validVersions?.error.value) {
   throw createError(validVersions.error.value);
 }
 
 const inForceNormLink = computed(() => {
-  if (
-    !validVersions ||
-    validVersions.status.value !== "success" ||
-    !validVersions.data.value?.member ||
-    validVersions.data.value.member.length === 0
-  ) {
-    return undefined;
-  }
-
-  const validVersion = validVersions.data.value.member[0];
-  return `/gesetze/${validVersion?.item.legislationIdentifier}`;
+  const validVersion = validVersions?.data.value?.member?.[0];
+  if (!validVersion) return undefined;
+  return `/gesetze/${validVersion.item.legislationIdentifier}`;
 });
 
 const metadataItems = computed<MetadataItem[]>(() => {

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -79,9 +79,7 @@ const [
   { sortedVersions: normVersions, error: normVersionsError },
 ] = await Promise.all([
   fetchTranslationUrl(),
-  useNormVersions(
-    data.value.legislation.exampleOfWork?.legislationIdentifier ?? "",
-  ),
+  useNormVersions(data.value.legislation.exampleOfWork.legislationIdentifier),
 ]);
 
 if (normVersionsError.value) {
@@ -284,7 +282,7 @@ const fassungenDateFilterInputId = useId();
               <div v-html="htmlParts.body" />
             </DocumentsNormsLegislationContent>
 
-            <template #sidebar v-if="tableOfContents?.length">
+            <template #sidebar v-if="tableOfContents.length">
               <client-only>
                 <DocumentsTableOfContents
                   :subheading="normBreadcrumbTitle"
@@ -333,9 +331,7 @@ const fassungenDateFilterInputId = useId();
                 />
               </div>
               <DocumentsNormsVersionList
-                :current-legislation-identifier="
-                  metadata.legislationIdentifier ?? ''
-                "
+                :current-legislation-identifier="metadata.legislationIdentifier"
                 :versions="filteredNormVersions"
               />
             </template>

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -63,16 +63,30 @@ const metadata: Ref<LegislationExpression> = computed(() => {
 
 const abbreviation = data.value.legislation.abbreviation;
 
-const { translations } = abbreviation
-  ? await fetchTranslationListWithIdFilter(abbreviation)
-  : { translations: { value: [] } };
+/**
+ * Resolves the link to the English translation of this norm, if one exists.
+ * Returns the finished URL rather than the request state, since it can no
+ * longer change once the page has loaded.
+ */
+async function fetchTranslationUrl() {
+  if (!abbreviation) return "";
+  const { translations } = await fetchTranslationListWithIdFilter(abbreviation);
+  return translations.value?.length ? `/translations/${abbreviation}` : "";
+}
 
-const translationUrl = computed(() => {
-  if (translations.value && translations.value.length > 0) {
-    return `/translations/${abbreviation}`;
-  }
-  return "";
-});
+const [
+  translationUrl,
+  { sortedVersions: normVersions, error: normVersionsError },
+] = await Promise.all([
+  fetchTranslationUrl(),
+  useNormVersions(
+    data.value.legislation.exampleOfWork?.legislationIdentifier ?? "",
+  ),
+]);
+
+if (normVersionsError.value) {
+  throw createError(normVersionsError.value);
+}
 
 const htmlParts = computed(() => data.value.htmlParts);
 
@@ -161,16 +175,6 @@ useNormSeo({
 const normBreadcrumbTitle = computed(() =>
   getNormBreadcrumbTitle(metadata.value),
 );
-
-const {
-  status: normVersionsStatus,
-  sortedVersions: normVersions,
-  error: normVersionsError,
-} = useNormVersions(metadata.value.exampleOfWork?.legislationIdentifier ?? "");
-
-if (normVersionsError.value) {
-  throw createError(normVersionsError.value);
-}
 
 const searchBackLink = useSearchBackLink(DocumentKind.Norm);
 
@@ -261,7 +265,6 @@ const fassungenDateFilterInputId = useId();
       />
 
       <DocumentsNormsVersionWarning
-        v-if="normVersionsStatus === 'success'"
         :versions="normVersions"
         :current-version="metadata"
       />

--- a/frontend/src/pages/literaturnachweise/[documentNumber].vue
+++ b/frontend/src/pages/literaturnachweise/[documentNumber].vue
@@ -63,14 +63,13 @@ const document = computed(() =>
 );
 const isEmptyDocument = computed(() => isDocumentEmpty(document.value));
 
-const tocEntries = computed<TreeItem[] | null>(() => {
-  return document.value
-    ? getAllSectionsFromDocument(document.value, "section").map((entry) => ({
-        key: entry.id,
-        subtitle: entry.title, // Subtitle for more subtle appearance
-        to: { hash: `#${entry.id}`, query: { from: route.query.from } },
-      }))
-    : null;
+const tocEntries = computed<TreeItem[]>(() => {
+  if (!document.value) return [];
+  return getAllSectionsFromDocument(document.value, "section").map((entry) => ({
+    key: entry.id,
+    subtitle: entry.title, // Subtitle for more subtle appearance
+    to: { hash: `#${entry.id}`, query: { from: route.query.from } },
+  }));
 });
 
 const searchBackLink = useSearchBackLink(DocumentKind.Literature);

--- a/frontend/src/pages/literaturnachweise/[documentNumber].vue
+++ b/frontend/src/pages/literaturnachweise/[documentNumber].vue
@@ -130,7 +130,7 @@ const detailItems = computed(() => getLiteratureDetailItems(literature.value));
         <template #sidebar>
           <client-only>
             <DocumentsTableOfContents
-              v-if="tocEntries?.length"
+              v-if="tocEntries.length"
               :table-of-contents="tocEntries"
             />
           </client-only>

--- a/frontend/src/pages/literaturnachweise/[documentNumber].vue
+++ b/frontend/src/pages/literaturnachweise/[documentNumber].vue
@@ -22,9 +22,18 @@ if (!documentNumber) throw createError({ status: 404 });
 
 const documentMetadataUrl = `/v1/literature/${documentNumber}`;
 
-const { data: literature, error: metadataError } =
-  await useRisBackend<Literature>(documentMetadataUrl);
+const [
+  { data: literature, error: metadataError },
+  { data: html, error: contentError },
+] = await Promise.all([
+  useRisBackend<Literature>(documentMetadataUrl),
+  useRisBackend<string>(`${documentMetadataUrl}.html`, {
+    headers: { Accept: "text/html" },
+  }),
+]);
+
 if (metadataError?.value) throw createError(metadataError.value);
+if (contentError?.value) throw createError(contentError.value);
 
 useLiteratureSeo({
   documentTypes: literature.value?.documentTypes ?? [],
@@ -32,12 +41,6 @@ useLiteratureSeo({
   headline: literature.value?.headline,
   alternativeHeadline: literature.value?.alternativeHeadline,
 });
-
-const { data: html, error: contentError } = await useRisBackend<string>(
-  `${documentMetadataUrl}.html`,
-  { headers: { Accept: "text/html" } },
-);
-if (contentError?.value) throw createError(contentError.value);
 
 // Page contents ------------------------------------------
 

--- a/frontend/src/pages/suche/index.vue
+++ b/frontend/src/pages/suche/index.vue
@@ -211,7 +211,6 @@ const formattedResultCount = computed(() => {
   return formatResultCount(totalItemCount.value);
 });
 
-const isLoading = computed(() => searchStatus.value === "pending");
 
 // User action handlers ------------------------------------
 
@@ -345,7 +344,7 @@ watch(searchStatus, async (newStatus, oldStatus) => {
             aria-live="polite"
             class="typo-label2-regular border-b border-b-gray-400 pb-16 md:border-none md:pb-0"
           >
-            {{ isLoading ? "Lade ..." : formattedResultCount }}
+            {{ formattedResultCount }}
           </output>
 
           <div class="hidden flex-wrap gap-x-32 gap-y-16 md:flex">
@@ -409,7 +408,6 @@ watch(searchStatus, async (newStatus, oldStatus) => {
           class="col-span-12 scroll-mt-16 flex-col justify-end gap-8 md:col-span-8 lg:col-span-8 lg:col-start-5 xl:col-span-7 xl:col-start-5"
         >
           <Pagination
-            :is-loading="isLoading"
             :page="searchResults"
             navigation-position="bottom"
             @update-page="updatePage"
@@ -439,13 +437,6 @@ watch(searchStatus, async (newStatus, oldStatus) => {
                 <SearchResult :search-result :order="index" />
               </li>
             </ul>
-
-            <div
-              v-if="isLoading"
-              class="flex h-full min-h-48 w-full items-center justify-center"
-            >
-              <UiProgressSpinner />
-            </div>
           </Pagination>
         </div>
       </div>

--- a/frontend/src/pages/suche/index.vue
+++ b/frontend/src/pages/suche/index.vue
@@ -210,6 +210,7 @@ const formattedResultCount = computed(() =>
   formatResultCount(totalItemCount.value),
 );
 
+const { isSearching } = useSearchLoadingIndicator(searchStatus);
 
 // User action handlers ------------------------------------
 
@@ -272,7 +273,7 @@ watch(searchStatus, async (newStatus, oldStatus) => {
       <div id="search">
         <SearchSimpleSearchInput
           :model-value="query"
-          :loading="searchStatus === 'pending'"
+          :loading="isSearching"
           @update:model-value="updateQuery"
           @empty-search="handleEmptySearch"
         />

--- a/frontend/src/pages/suche/index.vue
+++ b/frontend/src/pages/suche/index.vue
@@ -274,6 +274,7 @@ watch(searchStatus, async (newStatus, oldStatus) => {
       <div id="search">
         <SearchSimpleSearchInput
           :model-value="query"
+          :loading="searchStatus === 'pending'"
           @update:model-value="updateQuery"
           @empty-search="handleEmptySearch"
         />

--- a/frontend/src/pages/suche/index.vue
+++ b/frontend/src/pages/suche/index.vue
@@ -206,10 +206,9 @@ watch(
   { immediate: true },
 );
 
-const formattedResultCount = computed(() => {
-  if (isLoading.value) return "";
-  return formatResultCount(totalItemCount.value);
-});
+const formattedResultCount = computed(() =>
+  formatResultCount(totalItemCount.value),
+);
 
 
 // User action handlers ------------------------------------

--- a/frontend/src/pages/translations/[id].vue
+++ b/frontend/src/pages/translations/[id].vue
@@ -28,12 +28,14 @@ useHead({
 const route = useRoute();
 const id = route.params.id as string;
 
-const { data, error } = await fetchTranslationAndHTML(id);
+const [{ data, error }, { legislation }] = await Promise.all([
+  fetchTranslationAndHTML(id),
+  getGermanOriginal(id),
+]);
+
 if (error.value || !data.value) {
   throw createError({ statusCode: error.value?.status ?? 500 });
 }
-
-const { legislation } = await getGermanOriginal(id);
 
 const currentTranslation = data.value.content;
 const html = data.value.htmlBody;

--- a/frontend/src/pages/verwaltungsregelungen/[documentNumber].vue
+++ b/frontend/src/pages/verwaltungsregelungen/[documentNumber].vue
@@ -56,14 +56,13 @@ const document = computed(() =>
 );
 const isEmptyDocument = computed(() => isDocumentEmpty(document.value));
 
-const tocEntries = computed<TreeItem[] | null>(() => {
-  return document.value
-    ? getAllSectionsFromDocument(document.value, "section").map((entry) => ({
-        key: entry.id,
-        subtitle: entry.title, // Subtitle for more subtle appearance
-        to: { hash: `#${entry.id}`, query: { from: route.query.from } },
-      }))
-    : null;
+const tocEntries = computed<TreeItem[]>(() => {
+  if (!document.value) return [];
+  return getAllSectionsFromDocument(document.value, "section").map((entry) => ({
+    key: entry.id,
+    subtitle: entry.title, // Subtitle for more subtle appearance
+    to: { hash: `#${entry.id}`, query: { from: route.query.from } },
+  }));
 });
 
 const searchBackLink = useSearchBackLink(DocumentKind.AdministrativeDirective);

--- a/frontend/src/pages/verwaltungsregelungen/[documentNumber].vue
+++ b/frontend/src/pages/verwaltungsregelungen/[documentNumber].vue
@@ -22,21 +22,22 @@ if (!documentNumber) throw createError({ status: 404 });
 
 const documentMetadataUrl = `/v1/administrative-directive/${documentNumber}`;
 
-const { data, error: metadataError } =
-  await useRisBackend<AdministrativeDirective>(documentMetadataUrl);
+const [{ data, error: metadataError }, { data: html, error: contentError }] =
+  await Promise.all([
+    useRisBackend<AdministrativeDirective>(documentMetadataUrl),
+    useRisBackend<string>(`${documentMetadataUrl}.html`, {
+      headers: { Accept: "text/html" },
+    }),
+  ]);
+
 if (metadataError?.value) throw createError(metadataError.value);
+if (contentError?.value) throw createError(contentError.value);
 
 useAdministrativeDirectiveSeo({
   documentType: data.value?.documentType,
   entryIntoForceDate: data.value?.entryIntoForceDate,
   headline: data.value?.headline,
 });
-
-const { data: html, error: contentError } = await useRisBackend<string>(
-  `${documentMetadataUrl}.html`,
-  { headers: { Accept: "text/html" } },
-);
-if (contentError?.value) throw createError(contentError.value);
 
 // Page contents ------------------------------------------
 

--- a/frontend/src/pages/verwaltungsregelungen/[documentNumber].vue
+++ b/frontend/src/pages/verwaltungsregelungen/[documentNumber].vue
@@ -127,7 +127,7 @@ const detailItems = computed(() =>
         <template #sidebar>
           <client-only>
             <DocumentsTableOfContents
-              v-if="tocEntries?.length"
+              v-if="tocEntries.length"
               :table-of-contents="tocEntries"
             />
           </client-only>


### PR DESCRIPTION
This PR unifies all page-level data fetching to follow the same, consistent pattern:

- data loading happens at the beginning of the page and is `await`-ed, blocking any further rendering
- immediately after, results are checked for errors or missing required data; error handling is triggered
- cleans up templates and code paths that are unreachable now that pages can better rely on their data
- parallelizes some requests that used to run one after another, despite being independent
- consistently uses Nuxt's loading indicator + loading state on the search button to indicate activity on search pages
- adds some missing `await`s in E2E tests along the way that should mitigate flakyness