### PR TITLE
RISDEV-0000 various cleanup and simplifications in the frontend

### DIFF
--- a/frontend/src/components/Pagination.vue
+++ b/frontend/src/components/Pagination.vue
@@ -20,26 +20,23 @@ export type Page = {
   view: PartialCollectionView;
 };
 
-const props = withDefaults(
-  defineProps<{
-    page?: Page | null;
-    navigationPosition?: "top" | "bottom";
-  }>(),
-  { page: undefined, navigationPosition: "top" },
-);
+const { page, navigationPosition = "top" } = defineProps<{
+  page?: Page | null;
+  navigationPosition?: "top" | "bottom";
+}>();
 
 const emit = defineEmits<(e: "updatePage", page: number) => void>();
 
 const route = useRoute();
 
 const previousPageNumber = computed(() => {
-  if (!props.page?.view.previous) return undefined;
-  return parsePageNumber(props.page.view.previous).page;
+  if (!page?.view.previous) return undefined;
+  return parsePageNumber(page.view.previous).page;
 });
 
 const nextPageNumber = computed(() => {
-  if (!props.page?.view.next) return undefined;
-  return parsePageNumber(props.page.view.next).page;
+  if (!page?.view.next) return undefined;
+  return parsePageNumber(page.view.next).page;
 });
 
 const previousPageRoute = computed<RouteLocationRaw | undefined>(() => {
@@ -83,27 +80,25 @@ async function previousPage() {
 }
 
 const currentPageIndex = computed(() => {
-  if (!props.page?.["@id"]) return undefined;
-  return parsePageNumber(props.page["@id"]).page;
+  if (!page?.["@id"]) return undefined;
+  return parsePageNumber(page["@id"]).page;
 });
 
-const isOnlyPage = computed(
-  () => !(props.page?.view.previous || props.page?.view.next),
-);
+const isOnlyPage = computed(() => !(page?.view.previous || page?.view.next));
 
-const itemsOnPage = computed(() => buildItemsOnPageString(props.page));
+const itemsOnPage = computed(() => buildItemsOnPageString(page));
 </script>
 
 <template>
-  <slot v-if="props.navigationPosition == 'bottom'" />
+  <slot v-if="navigationPosition == 'bottom'" />
 
   <nav
     v-if="page?.member && page?.member.length"
     aria-label="Paginierung"
     class="flex flex-col items-center"
     :class="{
-      'mt-48': props.navigationPosition === 'bottom',
-      'mb-48': props.navigationPosition === 'top',
+      'mt-48': navigationPosition === 'bottom',
+      'mb-48': navigationPosition === 'top',
     }"
   >
     <div class="flex w-full items-center">
@@ -152,5 +147,5 @@ const itemsOnPage = computed(() => buildItemsOnPageString(props.page));
     </div>
   </nav>
 
-  <slot v-if="props.navigationPosition == 'top'" />
+  <slot v-if="navigationPosition == 'top'" />
 </template>

--- a/frontend/src/components/search/CourtFilter.spec.ts
+++ b/frontend/src/components/search/CourtFilter.spec.ts
@@ -1,4 +1,4 @@
-import { mockNuxtImport, renderSuspended } from "@nuxt/test-utils/runtime";
+import { renderSuspended } from "@nuxt/test-utils/runtime";
 import { userEvent } from "@testing-library/user-event";
 import { screen, waitFor } from "@testing-library/vue";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -8,10 +8,11 @@ import { courtFilterDefaultSuggestions } from "~/utils/search/courtFilter";
 const mockData = [{ id: "TG Berlin", label: "Tagesgericht Berlin", count: 1 }];
 
 const mockFetch = vi.hoisted(() => vi.fn());
-mockNuxtImport("$fetch", () => mockFetch);
 
+// The component fetches via the $risBackend injection, so the plugin providing
+// it is replaced rather than $fetch itself.
 vi.mock("~/plugins/risBackend", () => ({
-  default: vi.fn(),
+  default: defineNuxtPlugin(() => ({ provide: { risBackend: mockFetch } })),
   extendOnRequest: (...cbs: unknown[]) => cbs,
 }));
 
@@ -63,10 +64,9 @@ describe("court autocomplete", () => {
       await user.type(input, "Ber");
 
       await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith(
-          expect.anything(),
-          expect.objectContaining({ params: { prefix: "Ber" } }),
-        );
+        expect(mockFetch).toHaveBeenCalledWith("/v1/case-law/courts", {
+          query: { prefix: "Ber" },
+        });
       });
 
       expect(screen.getByText("Tagesgericht Berlin")).toBeInTheDocument();
@@ -126,10 +126,9 @@ describe("court autocomplete", () => {
       );
 
       await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith(
-          expect.anything(),
-          expect.objectContaining({ params: { prefix: "existing court" } }),
-        );
+        expect(mockFetch).toHaveBeenCalledWith("/v1/case-law/courts", {
+          query: { prefix: "existing court" },
+        });
       });
     });
   });

--- a/frontend/src/components/search/CourtFilter.vue
+++ b/frontend/src/components/search/CourtFilter.vue
@@ -21,13 +21,13 @@ const model = defineModel<string | undefined>();
 
 const searchResults = ref<CourtSearchResult[]>([]);
 
+const { $risBackend } = useNuxtApp();
+
 const search = async (prefix?: string) => {
-  const params: CourtsSearchParams = prefix ? { prefix } : {};
-  searchResults.value = await $fetch<CourtSearchResult[]>(
-    useBackendUrl("/v1/case-law/courts"),
-    {
-      params: params,
-    },
+  const query: CourtsSearchParams = prefix ? { prefix } : {};
+  searchResults.value = await $risBackend<CourtSearchResult[]>(
+    "/v1/case-law/courts",
+    { query },
   );
 };
 

--- a/frontend/src/composables/useAdvancedSearch.ts
+++ b/frontend/src/composables/useAdvancedSearch.ts
@@ -78,7 +78,7 @@ export async function useAdvancedSearch(
     };
   });
 
-  const { data, error, status, pending, execute } = await useRisBackend<Page>(
+  const { data, error, status, execute } = await useRisBackend<Page>(
     searchEndpointUrl,
     {
       query: combinedQuery,
@@ -95,7 +95,6 @@ export async function useAdvancedSearch(
 
   return {
     searchError: error,
-    searchIsPending: pending,
     searchResults: data,
     searchStatus: status,
     submitSearch: execute,

--- a/frontend/src/composables/useNormVersions.spec.ts
+++ b/frontend/src/composables/useNormVersions.spec.ts
@@ -36,9 +36,6 @@ describe("useNormVersions", () => {
     const { sortedVersions } = await useNormVersions("dummy-eli");
     expect(useRisBackendMock).toHaveBeenCalledWith(
       "/v1/legislation/work-example/dummy-eli",
-      {
-        immediate: true,
-      },
     );
     expect(sortedVersions.value).toHaveLength(2);
     expect(sortedVersions.value[0]?.temporalCoverage).toBe(

--- a/frontend/src/composables/useNormVersions.ts
+++ b/frontend/src/composables/useNormVersions.ts
@@ -9,28 +9,26 @@ import type {
 import { getCurrentDateInGermanyFormatted } from "~/utils/dateFormatting";
 
 export async function useNormVersions(eli: string) {
-  const { data, status, error } = await useRisBackend<
+  const { data, error } = await useRisBackend<
     JSONLDList<LegislationExpression>
-  >(`/v1/legislation/work-example/${eli}`, { immediate: true });
+  >(`/v1/legislation/work-example/${eli}`);
 
   const sortedVersions = computed(() => data.value?.member ?? []);
-  return { data, status, error, sortedVersions };
+  return { error, sortedVersions };
 }
 
 export async function useValidNormVersions(eli: string) {
   const today = getCurrentDateInGermanyFormatted();
-  return getNorms({
-    eli: eli,
+
+  const query: LegislationSearchParams = {
+    eli,
     temporalCoverageFrom: today,
     temporalCoverageTo: today,
     size: 300,
-  });
-}
+  };
 
-function getNorms(params: LegislationSearchParams) {
-  const immediate = params.eli !== undefined;
   return useRisBackend<JSONLDList<SearchResult<LegislationWork>>>(
-    `/v1/legislation`,
-    { params, immediate: immediate },
+    "/v1/legislation",
+    { query },
   );
 }

--- a/frontend/src/composables/useSimpleSearch.ts
+++ b/frontend/src/composables/useSimpleSearch.ts
@@ -126,7 +126,13 @@ export async function useSimpleSearch(
     searchEndpointUrl,
     {
       query: combinedQuery,
+
+      // The page decides when to search, both for the initial load and for
+      // every later change, so neither the eager initial fetch nor refetching
+      // on the reactive sources is wanted here.
       watch: false,
+      immediate: false,
+
       dedupe: "defer",
 
       // PostHog integration

--- a/frontend/src/composables/useTranslationData.spec.ts
+++ b/frontend/src/composables/useTranslationData.spec.ts
@@ -52,11 +52,10 @@ describe("fetchTranslationList", () => {
   it("returns a list when there is no error", async () => {
     const mockTranslationResponse = [{ "@id": "Cde" }, { "@id": "AbC" }];
     dataRef.value = mockTranslationResponse;
-    const { translations, translationsError } = await fetchTranslationList();
+    const { translations } = await fetchTranslationList();
 
     expect(useRisBackendMock).toHaveBeenCalledWith("/v1/translatedLegislation");
     expect(translations.value).toEqual(mockTranslationResponse);
-    expect(translationsError.value).toBeNull();
   });
 });
 
@@ -170,54 +169,31 @@ describe("getGermanOriginal", () => {
     vi.useRealTimers();
   });
 
-  it("returns first legislation work when API returns results", async () => {
+  it("returns the first legislation work when the abbreviation matches", async () => {
     const mockResult = { item: { abbreviation: "test-id" } };
     dataRef.value = { member: [mockResult] };
 
-    const { legislation, legislationSearchError } =
-      await getGermanOriginal("test-id");
-
-    expect(legislation.value).toEqual(mockResult);
-    expect(legislationSearchError.value).toBeNull();
+    expect(await getGermanOriginal("test-id")).toEqual(mockResult);
     expect(useRisBackendMock).toHaveBeenCalledWith(
       "/v1/legislation?searchTerm=test-id&temporalCoverageFrom=2025-10-13&temporalCoverageTo=2025-10-13&size=100&pageIndex=0",
     );
   });
 
-  it("returns 404 error when API returns empty member list", async () => {
+  it("returns null when the API returns an empty member list", async () => {
     dataRef.value = { member: [] };
 
-    const { legislation, legislationSearchError, legislationSearchStatus } =
-      await getGermanOriginal("test-id");
-
-    expect(legislation.value).toBeNull();
-    expect(legislationSearchError.value).not.toBeNull();
-    expect(legislationSearchStatus.value).toBe("404");
-    expect(legislationSearchError.value?.message).toBe(
-      "The fetched legislation does not match the requested ID: test-id",
-    );
+    expect(await getGermanOriginal("test-id")).toBeNull();
   });
 
-  it("returns 404 error when API returns null", async () => {
+  it("returns null when the API returns no data", async () => {
     dataRef.value = null;
 
-    const { legislation, legislationSearchError, legislationSearchStatus } =
-      await getGermanOriginal("test-id");
-
-    expect(legislation.value).toBeNull();
-    expect(legislationSearchError.value).not.toBeNull();
-    expect(legislationSearchStatus.value).toBe("404");
-    expect(legislationSearchError.value?.message).toBe(
-      "No results found for test-id",
-    );
+    expect(await getGermanOriginal("test-id")).toBeNull();
   });
-  it("throws an error when the ids don't macht", async () => {
-    dataRef.value = {
-      member: [{ item: { abbreviation: "test-id" } }],
-    };
-    const { legislationSearchError } = await getGermanOriginal("cde");
-    expect(legislationSearchError.value?.message).toBe(
-      "The fetched legislation does not match the requested ID: cde",
-    );
+
+  it("returns null when the returned abbreviation does not match", async () => {
+    dataRef.value = { member: [{ item: { abbreviation: "test-id" } }] };
+
+    expect(await getGermanOriginal("cde")).toBeNull();
   });
 });

--- a/frontend/src/composables/useTranslationData.ts
+++ b/frontend/src/composables/useTranslationData.ts
@@ -42,29 +42,17 @@ function legislationSearchURL(id: string, currentDate: string) {
 }
 
 export async function fetchTranslationList() {
-  const { data, error, status, pending, execute } = await useRisBackend<
-    TranslationContent[]
-  >(translationsListURL());
-  return {
-    translations: data,
-    translationsError: error,
-    translationsIsPending: pending,
-    translationsStatus: status,
-    executeTranslations: execute,
-  };
+  const { data } = await useRisBackend<TranslationContent[]>(
+    translationsListURL(),
+  );
+  return { translations: data };
 }
 
 export async function fetchTranslationListWithIdFilter(id: string) {
-  const { data, error, status, pending, execute } = await useRisBackend<
-    TranslationContent[]
-  >(translationDetailURL(id));
-  return {
-    translations: data,
-    translationsError: error,
-    translationsIsPending: pending,
-    translationsStatus: status,
-    executeTranslations: execute,
-  };
+  const { data } = await useRisBackend<TranslationContent[]>(
+    translationDetailURL(id),
+  );
+  return { translations: data };
 }
 
 export function fetchTranslationAndHTML(
@@ -108,47 +96,22 @@ export function fetchTranslationAndHTML(
   );
 }
 
+/**
+ * Looks up the German original of a translation.
+ *
+ * Deliberately does not throw: a translation without a matching German norm is
+ * a normal state, and so is a failed lookup — the link to the original is a
+ * supplement to the page, not part of it. Both cases return null, and the
+ * caller simply doesn't render the link.
+ *
+ * @param id - Abbreviation of the translated norm, e.g. "BGB"
+ * @returns The matching German original, or null if there isn't one
+ */
 export async function getGermanOriginal(id: string) {
-  const currentDateInGermanyFormatted = getCurrentDateInGermanyFormatted();
-  const searchEndpoint = legislationSearchURL(
-    id,
-    currentDateInGermanyFormatted,
-  );
+  const { data } = await useRisBackend<
+    JSONLDList<SearchResult<LegislationExpression>>
+  >(legislationSearchURL(id, getCurrentDateInGermanyFormatted()));
 
-  const legislation = ref<SearchResult<LegislationExpression> | null>(null);
-  const legislationSearchError = ref<Error | null>(null);
-  const legislationSearchStatus = ref<string | null>(null);
-
-  const { data, error, status, pending, execute } =
-    await useRisBackend<JSONLDList<SearchResult<LegislationExpression>>>(
-      searchEndpoint,
-    );
-
-  legislationSearchStatus.value = status.value;
-
-  if (data.value?.totalItems === 0 || data.value == null) {
-    legislation.value = null;
-    legislationSearchError.value = new Error(`No results found for ${id}`);
-    legislationSearchStatus.value = "404";
-  } else if (error.value) {
-    legislationSearchError.value = error.value;
-  } else {
-    const firstResult = data.value?.member?.[0] ?? null;
-    if (firstResult?.item?.abbreviation === id) {
-      legislation.value = firstResult;
-    } else {
-      legislationSearchError.value = new Error(
-        `The fetched legislation does not match the requested ID: ${id}`,
-      );
-      legislationSearchStatus.value = "404";
-    }
-  }
-
-  return {
-    legislation,
-    legislationSearchError,
-    legislationSearchIsPending: pending,
-    legislationSearchStatus,
-    executeLegislationSearch: execute,
-  };
+  const firstResult = data.value?.member?.[0];
+  return firstResult?.item?.abbreviation === id ? firstResult : null;
 }

--- a/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
+++ b/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
@@ -27,7 +27,9 @@ const [
   { data: html, error: contentError },
 ] = await Promise.all([
   useRisBackend<CaseLaw>(`/v1/case-law/${documentNumber}`),
-  useRisBackend<string>(`/v1/case-law/${documentNumber}.html`),
+  useRisBackend<string>(`/v1/case-law/${documentNumber}.html`, {
+    headers: { Accept: "text/html" },
+  }),
 ]);
 
 if (metadataError?.value) throw createError(metadataError.value);

--- a/frontend/src/pages/translations/[id].vue
+++ b/frontend/src/pages/translations/[id].vue
@@ -33,7 +33,7 @@ const [{ data, error }, { legislation }] = await Promise.all([
   getGermanOriginal(id),
 ]);
 
-if (error.value || !data.value) {
+if (error.value) {
   throw createError({ statusCode: error.value?.status ?? 500 });
 }
 

--- a/frontend/src/pages/translations/[id].vue
+++ b/frontend/src/pages/translations/[id].vue
@@ -28,7 +28,7 @@ useHead({
 const route = useRoute();
 const id = route.params.id as string;
 
-const [{ data, error }, { legislation }] = await Promise.all([
+const [{ data, error }, germanOriginal] = await Promise.all([
   fetchTranslationAndHTML(id),
   getGermanOriginal(id),
 ]);
@@ -45,9 +45,7 @@ useTranslationSeo({
   translationOfWork: currentTranslation.translationOfWork,
 });
 
-const germanOriginalWorkEli = computed(() => {
-  return legislation.value?.item?.legislationIdentifier;
-});
+const germanOriginalWorkEli = germanOriginal?.item?.legislationIdentifier;
 
 const breadcrumbItems = computed(() => {
   return [
@@ -123,7 +121,10 @@ const detailsTabPanelTitleId = useId();
         </h1>
       </hgroup>
 
-      <UiMessage v-if="legislation" class="my-24 space-y-24 sm:my-32 md:my-40">
+      <UiMessage
+        v-if="germanOriginal"
+        class="my-24 space-y-24 sm:my-32 md:my-40"
+      >
         <p class="typo-label2-bold mt-2">Version Information</p>
         <p class="typo-label2-regular mt-2">
           Translations may not be updated at the same time as the German legal


### PR DESCRIPTION
- removes an unnecessary `data` check, fixing PR review feedback from #2378 
- sends the `Accept` header for caselaw HTML, consistent with other HTML requests
- reduces some needlessly broad return values, reducing API surface
- removes redundant custom error handling from translations-related API composables
- prevent simple search from firing immediately, consistent with advanced search (page controls when the search should be submitted)
- replace `withDefaults` in pagination, simplify props access
- turns a value that never changes from a `computed` to a simple variable
- makes the court filter use the RIS backend API helper instead of plain fetch