### PR TITLE
RISDEV-12247 badges in search results

### DIFF
--- a/frontend/src/assets/typography.css
+++ b/frontend/src/assets/typography.css
@@ -47,11 +47,11 @@
 }
 
 @utility typo-label2-regular {
-  @apply ris-label2-regular 2xl:text-[1.125rem];
+  @apply ris-label2-regular 2xl:ris-label1-regular;
 }
 
 @utility typo-label2-bold {
-  @apply ris-label2-bold 2xl:text-[1.125rem];
+  @apply ris-label2-bold 2xl:ris-label1-bold;
 }
 
 @utility typo-mono {

--- a/frontend/src/components/documents/Metadata.spec.ts
+++ b/frontend/src/components/documents/Metadata.spec.ts
@@ -14,6 +14,7 @@ describe("Metadata", () => {
             type: "badge",
             label: "Label 2",
             values: [],
+            color: "gray",
           },
         ],
       },
@@ -53,11 +54,13 @@ describe("Metadata", () => {
             type: "badge",
             label: "Label 1",
             values: ["Badge 1"],
+            color: "gray",
           },
           {
             type: "badge",
             label: "Label 2",
             values: ["Badge 2", "Badge 3"],
+            color: "green",
           },
         ],
       },
@@ -66,11 +69,11 @@ describe("Metadata", () => {
     const terms = screen.getAllByRole("term");
 
     expect(terms[0]).toHaveTextContent("Label 1");
-    expect(screen.getByText("Badge 1")).toHaveClass("border-gray-400");
+    expect(screen.getByText("Badge 1")).toHaveClass(/border-gray/);
 
     expect(terms[1]).toHaveTextContent("Label 2");
-    expect(screen.getByText("Badge 2")).toHaveClass("border-gray-400");
-    expect(screen.getByText("Badge 3")).toHaveClass("border-gray-400");
+    expect(screen.getByText("Badge 2")).toHaveClass(/border-green/);
+    expect(screen.getByText("Badge 3")).toHaveClass(/border-green/);
   });
 
   it("renders mixed metadata items", async () => {
@@ -81,6 +84,7 @@ describe("Metadata", () => {
             type: "badge",
             label: "Label 1",
             values: ["Badge 1"],
+            color: "gray",
           },
           {
             type: "text",
@@ -94,7 +98,7 @@ describe("Metadata", () => {
     const terms = screen.getAllByRole("term");
 
     expect(terms[0]).toHaveTextContent("Label 1");
-    expect(screen.getByText("Badge 1")).toHaveClass("border-gray-400");
+    expect(screen.getByText("Badge 1")).toHaveClass(/border-gray/);
 
     expect(terms[1]).toHaveTextContent("Label 2");
     expect(terms[1]?.nextElementSibling).toHaveTextContent("Value 1");

--- a/frontend/src/components/documents/Metadata.vue
+++ b/frontend/src/components/documents/Metadata.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
+import type { BadgeColor } from "~/components/ui/Badge.vue";
+
 export type MetadataItemBadge = {
   type: "badge";
   label: string;
   values: string[];
+  color: BadgeColor;
 };
 
 export type MetadataItemText = {
@@ -28,7 +31,7 @@ const emptyValuePlaceholder = "—"; // Note: this is an 'em dash'
           <UiBadge
             v-for="value in item.values"
             :key="value"
-            color="gray"
+            :color="item.color"
             :label="value"
             variant="extraSmall"
             class="font-bold!"

--- a/frontend/src/components/search/AdministrativeDirectiveSearchResult.spec.ts
+++ b/frontend/src/components/search/AdministrativeDirectiveSearchResult.spec.ts
@@ -64,7 +64,9 @@ describe("AdministrativeDirectiveSearchResult", () => {
 
     it("renders first referenceNumber", async () => {
       await renderComponent();
-      expect(screen.getByText("Foo - 123")).toBeVisible();
+      const referenceNumberBadge = screen.getByText("Foo - 123");
+      expect(referenceNumberBadge).toBeVisible();
+      expect(referenceNumberBadge).toHaveClass(/border-gray/);
 
       // Don't render other referenceNumbers
       expect(screen.queryByText("Bar - 123")).not.toBeInTheDocument();

--- a/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
+++ b/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import RuleIcon from "~icons/ic/outline-rule";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
 import type { AdministrativeDirective, SearchResult } from "~/types/api";
 import { getMatch, getTitleWithFallback } from "~/utils/search/searchResults";
@@ -28,14 +27,30 @@ const headline = computed(() =>
 
 const resultTypeId = useId();
 
-const headerItems = computed<SearchResultHeaderItem[]>(() => {
+const headerItems = computed(() => {
   const item = searchResult.item;
-  return [
-    { value: item.documentType, id: resultTypeId },
-    { value: item.legislationAuthority },
-    { value: item.referenceNumbers?.[0] },
-    { value: dateFormattedDDMMYYYY(item.entryIntoForceDate) },
-  ].filter((i): i is SearchResultHeaderItem => i.value !== undefined);
+
+  const items: SearchResultHeaderItem[] = [];
+
+  if (item.legislationAuthority) {
+    items.push({ value: item.legislationAuthority });
+  }
+
+  if (item.referenceNumbers?.[0]) {
+    items.push({ value: item.referenceNumbers?.[0] });
+  }
+
+  const formattedEntryIntoForce = dateFormattedDDMMYYYY(
+    item.entryIntoForceDate,
+  );
+  if (formattedEntryIntoForce) {
+    items.push({ value: formattedEntryIntoForce });
+  }
+
+  return {
+    documentType: { value: searchResult.item.documentType, id: resultTypeId },
+    otherItems: items,
+  };
 });
 
 const detailPageRoute = computed(() => ({
@@ -59,7 +74,10 @@ function trackResultClick() {
 
 <template>
   <div class="flex flex-col gap-8 hyphens-auto">
-    <SearchResultHeader :icon="RuleIcon" :items="headerItems" />
+    <SearchResultHeader
+      :document-type="headerItems.documentType"
+      :items="headerItems.otherItems"
+    />
     <NuxtLink
       :to="detailPageRoute"
       :aria-describedby="resultTypeId"

--- a/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
+++ b/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
@@ -54,12 +54,14 @@ const headerItems = computed(() => {
     items.push({ type: "text", value: formattedEntryIntoForce });
   }
 
+  const docTypeItem: TextHeaderItem = {
+    type: "text",
+    value: searchResult.item.documentType,
+    id: resultTypeId,
+  };
+
   return {
-    documentType: {
-      type: "text",
-      value: searchResult.item.documentType,
-      id: resultTypeId,
-    } as TextHeaderItem,
+    documentType: docTypeItem,
     otherItems: items,
   };
 });

--- a/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
+++ b/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
+import type {
+  SearchResultHeaderItem,
+  TextHeaderItem,
+} from "~/components/search/SearchResultHeader.vue";
 import type { AdministrativeDirective, SearchResult } from "~/types/api";
 import { getMatch, getTitleWithFallback } from "~/utils/search/searchResults";
 
@@ -33,22 +36,30 @@ const headerItems = computed(() => {
   const items: SearchResultHeaderItem[] = [];
 
   if (item.legislationAuthority) {
-    items.push({ value: item.legislationAuthority });
+    items.push({ type: "text", value: item.legislationAuthority });
   }
 
   if (item.referenceNumbers?.[0]) {
-    items.push({ value: item.referenceNumbers?.[0] });
+    items.push({
+      type: "badge",
+      value: item.referenceNumbers?.[0],
+      color: "gray",
+    });
   }
 
   const formattedEntryIntoForce = dateFormattedDDMMYYYY(
     item.entryIntoForceDate,
   );
   if (formattedEntryIntoForce) {
-    items.push({ value: formattedEntryIntoForce });
+    items.push({ type: "text", value: formattedEntryIntoForce });
   }
 
   return {
-    documentType: { value: searchResult.item.documentType, id: resultTypeId },
+    documentType: {
+      type: "text",
+      value: searchResult.item.documentType,
+      id: resultTypeId,
+    } as TextHeaderItem,
     otherItems: items,
   };
 });

--- a/frontend/src/components/search/CaseLawSearchResult.spec.ts
+++ b/frontend/src/components/search/CaseLawSearchResult.spec.ts
@@ -62,6 +62,18 @@ function renderComponent({
 }
 
 describe("CaselawSearchResult", () => {
+  it("renders the documentType", () => {
+    renderComponent({});
+    expect(screen.getByText("Document Type")).toBeVisible();
+  });
+
+  it("renders 'Entscheidung' if documentType is undefined", () => {
+    renderComponent({
+      item: { ...searchResult.item, documentType: undefined },
+    });
+    expect(screen.getByText("Entscheidung")).toBeVisible();
+  });
+
   it("renders the expected title and secondary header row", () => {
     renderComponent({});
     expect(screen.getByRole("link")).toHaveTextContent("Test Headline");

--- a/frontend/src/components/search/CaseLawSearchResult.spec.ts
+++ b/frontend/src/components/search/CaseLawSearchResult.spec.ts
@@ -104,7 +104,7 @@ describe("CaselawSearchResult", () => {
     expect(highlightedElements[0]).toHaveTextContent("highlighted headline");
   });
 
-  it("displays highlighted file numbers", () => {
+  it("displays file numbers as badges", () => {
     const textMatch: TextMatch = {
       "@type": "SearchResultMatch",
       name: "fileNumbers",
@@ -114,17 +114,15 @@ describe("CaselawSearchResult", () => {
 
     const { container } = renderComponent({ textMatches: [textMatch] });
 
-    const highlightedElements = container.querySelectorAll("mark");
-    expect(highlightedElements).toHaveLength(1);
-    expect(highlightedElements[0]).toHaveTextContent("highlighted file number");
+    // first filenumber without markup
+    expect(screen.getByText("123")).toBeVisible();
 
-    expect(
-      screen.getByText(
-        (_, element) =>
-          element?.textContent ===
-          "123, testing highlighted file number is here",
-      ),
-    ).toBeInTheDocument();
+    // second filenumber with markup
+    const fileNumberWithMarkup = container.querySelector("span:has(mark)");
+    expect(fileNumberWithMarkup?.innerHTML).toContain(
+      "testing <mark>highlighted file number</mark> is here",
+    );
+    expect(fileNumberWithMarkup).toHaveClass(/border-gray/);
   });
 
   it("displays highlighted text with correct class", () => {

--- a/frontend/src/components/search/CaselawSearchResult.vue
+++ b/frontend/src/components/search/CaselawSearchResult.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import GavelIcon from "~icons/ic/outline-gavel";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
 import type { CaseLaw, SearchResult } from "~/types/api";
 import {
@@ -54,9 +53,7 @@ const resultTypeId = useId();
 const headerItems = computed(() => {
   const item = searchResult.item;
 
-  const items: SearchResultHeaderItem[] = [
-    { value: item.documentType || "Entscheidung", id: resultTypeId },
-  ];
+  const items: SearchResultHeaderItem[] = [];
 
   if (item.courtName) items.push({ value: item.courtName });
 
@@ -66,7 +63,13 @@ const headerItems = computed(() => {
   const fileNumbers = getFileNumbers(item);
   if (fileNumbers) items.push({ value: fileNumbers, isMarkup: true });
 
-  return items;
+  return {
+    documentType: {
+      value: searchResult.item.documentType || "Entscheidung",
+      id: resultTypeId,
+    },
+    otherItems: items,
+  };
 });
 
 function getFileNumbers(item: CaseLaw) {
@@ -109,8 +112,8 @@ function trackResultClick() {
 <template>
   <div class="flex flex-col gap-8 hyphens-auto">
     <SearchResultHeader
-      :icon="GavelIcon"
-      :items="headerItems"
+      :document-type="headerItems.documentType"
+      :items="headerItems.otherItems"
       :secondary-item="secondaryTitle"
     />
     <NuxtLink

--- a/frontend/src/components/search/CaselawSearchResult.vue
+++ b/frontend/src/components/search/CaselawSearchResult.vue
@@ -74,12 +74,14 @@ const headerItems = computed(() => {
     });
   }
 
+  const docTypeItem: TextHeaderItem = {
+    type: "text",
+    value: searchResult.item.documentType || "Entscheidung",
+    id: resultTypeId,
+  };
+
   return {
-    documentType: {
-      type: "text",
-      value: searchResult.item.documentType || "Entscheidung",
-      id: resultTypeId,
-    } as TextHeaderItem,
+    documentType: docTypeItem,
     otherItems: items,
   };
 });

--- a/frontend/src/components/search/CaselawSearchResult.vue
+++ b/frontend/src/components/search/CaselawSearchResult.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
+import type {
+  SearchResultHeaderItem,
+  TextHeaderItem,
+} from "~/components/search/SearchResultHeader.vue";
 import type { CaseLaw, SearchResult } from "~/types/api";
 import {
   getMatch,
@@ -43,9 +46,9 @@ const headline = computed(() =>
   ),
 );
 
-const secondaryTitle = computed<SearchResultHeaderItem | undefined>(() => {
+const secondaryTitle = computed<TextHeaderItem | undefined>(() => {
   const title = getCaselawSecondaryTitle(searchResult.item);
-  return title ? { value: title } : undefined;
+  return title ? { type: "text", value: title } : undefined;
 });
 
 const resultTypeId = useId();
@@ -55,19 +58,28 @@ const headerItems = computed(() => {
 
   const items: SearchResultHeaderItem[] = [];
 
-  if (item.courtName) items.push({ value: item.courtName });
+  if (item.courtName) items.push({ type: "text", value: item.courtName });
 
   const formattedDate = dateFormattedDDMMYYYY(item.decisionDate);
-  if (formattedDate) items.push({ value: formattedDate });
+  if (formattedDate) items.push({ type: "text", value: formattedDate });
 
   const fileNumbers = getFileNumbers(item);
-  if (fileNumbers) items.push({ value: fileNumbers, isMarkup: true });
+
+  for (const fileNumber of fileNumbers) {
+    items.push({
+      type: "badge",
+      isMarkup: true,
+      value: fileNumber,
+      color: "gray",
+    });
+  }
 
   return {
     documentType: {
+      type: "text",
       value: searchResult.item.documentType || "Entscheidung",
       id: resultTypeId,
-    },
+    } as TextHeaderItem,
     otherItems: items,
   };
 });
@@ -85,10 +97,10 @@ function getFileNumbers(item: CaseLaw) {
       }
     }
 
-    return replaced.join(", ");
+    return replaced;
   }
 
-  return item.fileNumbers?.join(", ");
+  return item.fileNumbers ?? [];
 }
 
 const detailPageRoute = computed(() => ({

--- a/frontend/src/components/search/LiteratureSearchResult.spec.ts
+++ b/frontend/src/components/search/LiteratureSearchResult.spec.ts
@@ -89,7 +89,9 @@ describe("LiteratureSearchResult", () => {
 
     it("renders first dependentReference", async () => {
       renderComponent();
-      expect(screen.getByText("DEP-122")).toBeVisible();
+      const referenceNumberBadge = screen.getByText("DEP-122");
+      expect(referenceNumberBadge).toBeVisible();
+      expect(referenceNumberBadge).toHaveClass(/border-gray/);
     });
 
     it("renders first independentReference if no dependentReference exists", async () => {
@@ -99,7 +101,10 @@ describe("LiteratureSearchResult", () => {
           dependentReferences: [],
         },
       });
-      expect(screen.getByText("INDEP-124")).toBeVisible();
+
+      const referenceNumberBadge = screen.getByText("INDEP-124");
+      expect(referenceNumberBadge).toBeVisible();
+      expect(referenceNumberBadge).toHaveClass(/border-gray/);
     });
 
     it("renders first year of publication", async () => {

--- a/frontend/src/components/search/LiteratureSearchResult.spec.ts
+++ b/frontend/src/components/search/LiteratureSearchResult.spec.ts
@@ -82,6 +82,11 @@ describe("LiteratureSearchResult", () => {
       expect(screen.getByText("Book")).toBeVisible();
     });
 
+    it("renders 'Literaturnachweis' if no documentType exists", async () => {
+      renderComponent({ item: { ...searchResult.item, documentTypes: [] } });
+      expect(screen.getByText("Literaturnachweis")).toBeVisible();
+    });
+
     it("renders first dependentReference", async () => {
       renderComponent();
       expect(screen.getByText("DEP-122")).toBeVisible();

--- a/frontend/src/components/search/LiteratureSearchResult.vue
+++ b/frontend/src/components/search/LiteratureSearchResult.vue
@@ -47,12 +47,14 @@ const headerItems = computed(() => {
     items.push({ type: "text", value: item.yearsOfPublication?.[0] });
   }
 
+  const docTypeItem: TextHeaderItem = {
+    type: "text",
+    value: item.documentTypes?.[0] ?? "Literaturnachweis",
+    id: resultTypeId,
+  };
+
   return {
-    documentType: {
-      type: "text",
-      value: item.documentTypes?.[0] ?? "Literaturnachweis",
-      id: resultTypeId,
-    } as TextHeaderItem,
+    documentType: docTypeItem,
     otherItems: items,
   };
 });

--- a/frontend/src/components/search/LiteratureSearchResult.vue
+++ b/frontend/src/components/search/LiteratureSearchResult.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import OutlineBookIcon from "~icons/ic/outline-book";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
 import type { Literature, SearchResult } from "~/types/api";
 import { getMatch, getTitleWithFallback } from "~/utils/search/searchResults";
@@ -30,15 +29,28 @@ const headline = computed(() =>
 
 const resultTypeId = useId();
 
-const headerItems = computed<SearchResultHeaderItem[]>(() => {
+const headerItems = computed(() => {
   const item = searchResult.item;
+  const items: SearchResultHeaderItem[] = [];
+
   const reference =
     item.dependentReferences?.[0] ?? item.independentReferences?.[0];
-  return [
-    { value: item.documentTypes?.[0], id: resultTypeId },
-    { value: reference },
-    { value: item.yearsOfPublication?.[0] },
-  ].filter((i): i is SearchResultHeaderItem => i.value !== undefined);
+
+  if (reference) {
+    items.push({ value: reference });
+  }
+
+  if (item.yearsOfPublication?.[0]) {
+    items.push({ value: item.yearsOfPublication?.[0] });
+  }
+
+  return {
+    documentType: {
+      value: item.documentTypes?.[0] ?? "Literaturnachweis",
+      id: resultTypeId,
+    },
+    otherItems: items,
+  };
 });
 
 const detailPageRoute = computed(() => ({
@@ -60,7 +72,10 @@ function trackResultClick() {
 
 <template>
   <div class="flex flex-col gap-8 hyphens-auto">
-    <SearchResultHeader :icon="OutlineBookIcon" :items="headerItems" />
+    <SearchResultHeader
+      :document-type="headerItems.documentType"
+      :items="headerItems.otherItems"
+    />
     <NuxtLink
       :to="detailPageRoute"
       :aria-describedby="resultTypeId"

--- a/frontend/src/components/search/LiteratureSearchResult.vue
+++ b/frontend/src/components/search/LiteratureSearchResult.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
+import type {
+  SearchResultHeaderItem,
+  TextHeaderItem,
+} from "~/components/search/SearchResultHeader.vue";
 import type { Literature, SearchResult } from "~/types/api";
 import { getMatch, getTitleWithFallback } from "~/utils/search/searchResults";
 
@@ -37,18 +40,19 @@ const headerItems = computed(() => {
     item.dependentReferences?.[0] ?? item.independentReferences?.[0];
 
   if (reference) {
-    items.push({ value: reference });
+    items.push({ type: "badge", value: reference, color: "gray" });
   }
 
   if (item.yearsOfPublication?.[0]) {
-    items.push({ value: item.yearsOfPublication?.[0] });
+    items.push({ type: "text", value: item.yearsOfPublication?.[0] });
   }
 
   return {
     documentType: {
+      type: "text",
       value: item.documentTypes?.[0] ?? "Literaturnachweis",
       id: resultTypeId,
-    },
+    } as TextHeaderItem,
     otherItems: items,
   };
 });

--- a/frontend/src/components/search/NormSearchResult.spec.ts
+++ b/frontend/src/components/search/NormSearchResult.spec.ts
@@ -116,11 +116,13 @@ describe("NormSearchResult", () => {
   it("renders correctly with all props", () => {
     mocks.usePrivateFeaturesFlag.mockReturnValue(true);
     renderComponent();
-    expect(screen.getByText("TN")).toBeInTheDocument();
     expect(screen.getByText(/Norm/)).toBeInTheDocument();
-    expect(screen.getByText("Alternate")).toBeInTheDocument();
+    expect(screen.getByText("TN")).toBeInTheDocument();
+    expect(screen.getByText("Aktuell gültig")).toBeInTheDocument();
     expect(screen.getByText("01.01.2000")).toBeInTheDocument();
     expect(screen.queryByText("14.12.1999")).not.toBeInTheDocument();
+
+    expect(screen.getByText("Alternate")).toBeInTheDocument();
 
     const heading = screen.getByRole("heading", { name: /Test Title/i });
     expect(heading.innerHTML).toBe("Highlighted <mark>Test Title</mark>");

--- a/frontend/src/components/search/NormSearchResult.vue
+++ b/frontend/src/components/search/NormSearchResult.vue
@@ -69,12 +69,14 @@ const headerItems = computed(() => {
     items.push({ type: "text", value: dateValue });
   }
 
+  const docTypeItem: TextHeaderItem = {
+    type: "text",
+    value: "Norm",
+    id: resultTypeId,
+  };
+
   return {
-    documentType: {
-      type: "text",
-      value: "Norm",
-      id: resultTypeId,
-    } as TextHeaderItem,
+    documentType: docTypeItem,
     otherItems: items,
   };
 });

--- a/frontend/src/components/search/NormSearchResult.vue
+++ b/frontend/src/components/search/NormSearchResult.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import IcBaselineBalance from "~icons/ic/baseline-balance";
 import type { RouteLocationRaw, RouteLocationAsPath } from "#vue-router";
 import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
 import type { LegislationExpression, SearchResult } from "~/types/api";
@@ -29,7 +28,13 @@ const secondaryTitle = computed<SearchResultHeaderItem | undefined>(() =>
 
 const resultTypeId = useId();
 
-const headerItems = computed<SearchResultHeaderItem[]>(() => {
+const headerItems = computed(() => {
+  const items: SearchResultHeaderItem[] = [];
+
+  if (searchResult.item.abbreviation) {
+    items.push({ value: searchResult.item.abbreviation });
+  }
+
   let dateValue: string | undefined = dateFormattedDDMMYYYY(
     searchResult.item.exampleOfWork.legislationDate,
   );
@@ -43,11 +48,14 @@ const headerItems = computed<SearchResultHeaderItem[]>(() => {
     dateValue = from && to ? `${from} - ${to}` : from;
   }
 
-  return [
-    { value: "Norm", id: resultTypeId },
-    { value: searchResult.item.abbreviation },
-    { value: dateValue },
-  ].filter((i): i is SearchResultHeaderItem => i.value !== undefined);
+  if (dateValue) {
+    items.push({ value: dateValue });
+  }
+
+  return {
+    documentType: { value: "Norm", id: resultTypeId },
+    otherItems: items,
+  };
 });
 
 const validityStatus = computed(() =>
@@ -86,8 +94,8 @@ const relevantHighlights = computed(() =>
 <template>
   <div class="flex flex-col gap-8 hyphens-auto">
     <SearchResultHeader
-      :icon="IcBaselineBalance"
-      :items="headerItems"
+      :document-type="headerItems.documentType"
+      :items="headerItems.otherItems"
       :secondary-item="secondaryTitle"
     >
       <template #trailing>

--- a/frontend/src/components/search/NormSearchResult.vue
+++ b/frontend/src/components/search/NormSearchResult.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import type { RouteLocationRaw, RouteLocationAsPath } from "#vue-router";
-import type { SearchResultHeaderItem } from "~/components/search/SearchResultHeader.vue";
+import type {
+  SearchResultHeaderItem,
+  TextHeaderItem,
+} from "~/components/search/SearchResultHeader.vue";
 import type { LegislationExpression, SearchResult } from "~/types/api";
 import { getMatch, getTitleWithFallback } from "~/utils/search/searchResults";
 
@@ -20,9 +23,12 @@ const headline = computed(() =>
   ),
 );
 
-const secondaryTitle = computed<SearchResultHeaderItem | undefined>(() =>
+const secondaryTitle = computed<TextHeaderItem | undefined>(() =>
   searchResult.item.alternateName
-    ? { value: truncateAtWord(searchResult.item.alternateName, 90, true) }
+    ? {
+        type: "text",
+        value: truncateAtWord(searchResult.item.alternateName, 90, true),
+      }
     : undefined,
 );
 
@@ -32,7 +38,18 @@ const headerItems = computed(() => {
   const items: SearchResultHeaderItem[] = [];
 
   if (searchResult.item.abbreviation) {
-    items.push({ value: searchResult.item.abbreviation });
+    items.push({ type: "text", value: searchResult.item.abbreviation });
+  }
+
+  const validityStatus = formatNormValidity(searchResult.item.temporalCoverage);
+
+  if (validityStatus) {
+    items.push({
+      type: "badge",
+      value: validityStatus.label,
+      color: validityStatus.color,
+      class: "font-bold!",
+    });
   }
 
   let dateValue: string | undefined = dateFormattedDDMMYYYY(
@@ -49,18 +66,18 @@ const headerItems = computed(() => {
   }
 
   if (dateValue) {
-    items.push({ value: dateValue });
+    items.push({ type: "text", value: dateValue });
   }
 
   return {
-    documentType: { value: "Norm", id: resultTypeId },
+    documentType: {
+      type: "text",
+      value: "Norm",
+      id: resultTypeId,
+    } as TextHeaderItem,
     otherItems: items,
   };
 });
-
-const validityStatus = computed(() =>
-  formatNormValidity(searchResult.item.temporalCoverage),
-);
 
 const detailPageRoute = computed<RouteLocationAsPath>(() => ({
   path: `/gesetze/${searchResult.item.legislationIdentifier}`,
@@ -98,13 +115,6 @@ const relevantHighlights = computed(() =>
       :items="headerItems.otherItems"
       :secondary-item="secondaryTitle"
     >
-      <template #trailing>
-        <UiBadge
-          v-if="validityStatus"
-          class="md:ml-auto"
-          v-bind="validityStatus"
-        />
-      </template>
     </SearchResultHeader>
 
     <NuxtLink

--- a/frontend/src/components/search/SearchResultHeader.spec.ts
+++ b/frontend/src/components/search/SearchResultHeader.spec.ts
@@ -10,9 +10,7 @@ function renderComponent(
 ) {
   return render(SearchResultHeader, {
     props: {
-      icon: markRaw({
-        template: "<span>icon-stub</span>",
-      }),
+      documentType: { value: "DocumentType", id: "DocTypeID" },
       items: items,
       secondaryItem,
     },
@@ -20,16 +18,29 @@ function renderComponent(
 }
 
 describe("SearchResultHeader", () => {
-  it("renders icon", async () => {
+  it("renders documentType", async () => {
     renderComponent();
 
-    expect(screen.getByText("icon-stub")).toBeVisible();
+    const docTypeSpan = screen.getByText("DocumentType");
+    expect(docTypeSpan).toBeVisible();
+    expect(docTypeSpan).toHaveAttribute("id", "DocTypeID");
+    expect(docTypeSpan).toHaveClass(/bold/);
+  });
+
+  it("does not render documentType when undefined", async () => {
+    render(SearchResultHeader, {
+      props: {
+        items: [],
+      },
+    });
+
+    expect(screen.queryByText("DocumentType")).not.toBeInTheDocument();
   });
 
   it("renders plain text items", async () => {
     renderComponent([{ value: "Item 1" }, { value: "<mark>Item 2</mark>" }]);
 
-    expect(screen.getByText("icon-stub")).toBeVisible();
+    expect(screen.getByText("DocumentType")).toBeVisible();
     expect(screen.getByText("Item 1")).toBeVisible();
     expect(screen.getByText("<mark>Item 2</mark>")).toBeVisible();
   });
@@ -40,7 +51,7 @@ describe("SearchResultHeader", () => {
       { isMarkup: true, value: "<mark>Item 2</mark>" },
     ]);
 
-    expect(screen.getByText("icon-stub")).toBeVisible();
+    expect(screen.getByText("DocumentType")).toBeVisible();
     expect(screen.getByText("Item 1")).toBeVisible();
     expect(screen.getByText("Item 2")).toBeVisible();
 
@@ -51,9 +62,7 @@ describe("SearchResultHeader", () => {
   it("renders trailing component", async () => {
     render(SearchResultHeader, {
       props: {
-        icon: markRaw({
-          template: "<span>icon-stub</span>",
-        }),
+        documentType: { value: "DocumentType" },
         items: [],
       },
       slots: {
@@ -61,7 +70,7 @@ describe("SearchResultHeader", () => {
       },
     });
 
-    expect(screen.getByText("icon-stub")).toBeVisible();
+    expect(screen.getByText("DocumentType")).toBeVisible();
     expect(screen.getByText("trailing-component")).toBeVisible();
   });
 

--- a/frontend/src/components/search/SearchResultHeader.spec.ts
+++ b/frontend/src/components/search/SearchResultHeader.spec.ts
@@ -48,15 +48,6 @@ describe("SearchResultHeader", () => {
     expect(screen.getByText("<mark>Item 2</mark>")).toBeVisible();
   });
 
-  it("renders items as markup", async () => {
-    const { container } = renderComponent([
-      { type: "text", isMarkup: true, value: "<mark>Item 1</mark>" },
-    ]);
-
-    const markupSpan = container.querySelector("span:has(mark)");
-    expect(markupSpan?.innerHTML).toContain("<mark>Item 1</mark>");
-  });
-
   it("renders items as badges", async () => {
     renderComponent([
       { type: "badge", value: "Item 1", color: "green" },
@@ -110,7 +101,6 @@ describe("SearchResultHeader", () => {
     const { container } = renderComponent([
       { type: "text", value: "Item 1" },
       { type: "text", value: "" },
-      { type: "text", value: "", isMarkup: true },
       { type: "badge", value: "Item 2", color: "green" },
       { type: "badge", value: "", color: "green" },
       { type: "badge", value: "", color: "green", isMarkup: true },

--- a/frontend/src/components/search/SearchResultHeader.spec.ts
+++ b/frontend/src/components/search/SearchResultHeader.spec.ts
@@ -2,15 +2,16 @@ import { render, screen } from "@testing-library/vue";
 import { describe, it, expect } from "vitest";
 import SearchResultHeader, {
   type SearchResultHeaderItem,
+  type TextHeaderItem,
 } from "~/components/search/SearchResultHeader.vue";
 
 function renderComponent(
   items: SearchResultHeaderItem[] = [],
-  secondaryItem?: SearchResultHeaderItem,
+  secondaryItem?: TextHeaderItem,
 ) {
   return render(SearchResultHeader, {
     props: {
-      documentType: { value: "DocumentType", id: "DocTypeID" },
+      documentType: { type: "text", value: "DocumentType", id: "DocTypeID" },
       items: items,
       secondaryItem,
     },
@@ -38,87 +39,98 @@ describe("SearchResultHeader", () => {
   });
 
   it("renders plain text items", async () => {
-    renderComponent([{ value: "Item 1" }, { value: "<mark>Item 2</mark>" }]);
+    renderComponent([
+      { type: "text", value: "Item 1" },
+      { type: "text", value: "<mark>Item 2</mark>" },
+    ]);
 
-    expect(screen.getByText("DocumentType")).toBeVisible();
     expect(screen.getByText("Item 1")).toBeVisible();
     expect(screen.getByText("<mark>Item 2</mark>")).toBeVisible();
   });
 
   it("renders items as markup", async () => {
     const { container } = renderComponent([
-      { value: "Item 1" },
-      { isMarkup: true, value: "<mark>Item 2</mark>" },
+      { type: "text", isMarkup: true, value: "<mark>Item 1</mark>" },
     ]);
 
-    expect(screen.getByText("DocumentType")).toBeVisible();
-    expect(screen.getByText("Item 1")).toBeVisible();
-    expect(screen.getByText("Item 2")).toBeVisible();
-
     const markupSpan = container.querySelector("span:has(mark)");
-    expect(markupSpan?.innerHTML).toContain("<mark>Item 2</mark>");
+    expect(markupSpan?.innerHTML).toContain("<mark>Item 1</mark>");
   });
 
-  it("renders trailing component", async () => {
-    render(SearchResultHeader, {
-      props: {
-        documentType: { value: "DocumentType" },
-        items: [],
-      },
-      slots: {
-        trailing: "<span>trailing-component</span>",
-      },
-    });
+  it("renders items as badges", async () => {
+    renderComponent([
+      { type: "badge", value: "Item 1", color: "green" },
+      { type: "badge", value: "Item 2", color: "blue", class: "bold" },
+    ]);
 
-    expect(screen.getByText("DocumentType")).toBeVisible();
-    expect(screen.getByText("trailing-component")).toBeVisible();
+    const item1 = screen.getByText("Item 1");
+    expect(item1).toBeVisible();
+    expect(item1).toHaveClass(/green/);
+
+    const item2 = screen.getByText("Item 2");
+    expect(item2).toBeVisible();
+    expect(item2).toHaveClass(/blue/, "bold");
+  });
+
+  it("renders item as badge with markup", async () => {
+    const { container } = renderComponent([
+      {
+        type: "badge",
+        value: "<mark>Item 1</mark>",
+        color: "green",
+        isMarkup: true,
+      },
+    ]);
+
+    const markupSpan = container.querySelector("span:has(mark)");
+    expect(markupSpan?.innerHTML).toContain("<mark>Item 1</mark>");
+    expect(markupSpan).toHaveClass(/green/);
   });
 
   it("renders IDs", async () => {
     renderComponent([
       {
+        type: "text",
         value: "Item 1",
         id: "foo",
+      },
+      {
+        type: "badge",
+        value: "Item 2",
+        color: "green",
+        id: "bar",
       },
     ]);
 
     expect(screen.getByText("Item 1")).toHaveAttribute("id", "foo");
+    expect(screen.getByText("Item 2")).toHaveAttribute("id", "bar");
   });
 
   it("does not render empty items", async () => {
     const { container } = renderComponent([
-      { value: "Item 1" },
-      { value: "" },
-      { value: "Item 2" },
+      { type: "text", value: "Item 1" },
+      { type: "text", value: "" },
+      { type: "text", value: "", isMarkup: true },
+      { type: "badge", value: "Item 2", color: "green" },
+      { type: "badge", value: "", color: "green" },
+      { type: "badge", value: "", color: "green", isMarkup: true },
     ]);
 
     expect(screen.getByText("Item 1")).toBeVisible();
     expect(screen.getByText("Item 2")).toBeVisible();
 
     const itemSpans = container.querySelectorAll("p > span");
-    expect(itemSpans).toHaveLength(3); // Icon + 2 text elements
+    expect(itemSpans).toHaveLength(3); // document type + 2 items
   });
 
   it("renders an optional secondary row", async () => {
-    renderComponent([], { value: "Secondary item" });
+    renderComponent([], { type: "text", value: "Secondary item" });
 
     expect(screen.getByText("Secondary item")).toBeVisible();
-  });
-
-  it("renders secondary row as markup", async () => {
-    const { container } = renderComponent([], {
-      value: "<mark>Secondary item</mark>",
-      isMarkup: true,
-    });
-
-    expect(screen.getByText("Secondary item")).toBeVisible();
-
-    const markupSpan = container.querySelector("p:has(mark)");
-    expect(markupSpan?.innerHTML).toContain("<mark>Secondary item</mark>");
   });
 
   it("does not render secondary row when value is empty", async () => {
-    const { container } = renderComponent([], { value: "" });
+    const { container } = renderComponent([], { type: "text", value: "" });
 
     const secondaryRows = container.querySelectorAll(".typo-label1-regular");
     expect(secondaryRows).toHaveLength(0);

--- a/frontend/src/components/search/SearchResultHeader.vue
+++ b/frontend/src/components/search/SearchResultHeader.vue
@@ -29,38 +29,38 @@ const itemsWithContent = computed(() => items.filter((i) => !!i.value));
 </script>
 
 <template>
-  <div class="flex items-center gap-8">
-    <div>
-      <p class="typo-label2-regular content-center space-x-12 hyphens-auto">
-        <span v-if="documentType" class="font-bold!" :id="documentType.id">{{
-          documentType.value
+  <div>
+    <p
+      class="typo-label2-regular flex flex-wrap items-baseline gap-x-12 gap-y-8 hyphens-auto"
+    >
+      <span v-if="documentType" class="font-bold!" :id="documentType.id">{{
+        documentType.value
+      }}</span>
+      <template v-for="item in itemsWithContent" :key="item.value">
+        <span v-if="item.type === 'text' && !item.isMarkup" :id="item.id">{{
+          item.value
         }}</span>
-        <template v-for="item in itemsWithContent" :key="item.value">
-          <span v-if="item.type === 'text' && !item.isMarkup" :id="item.id">{{
-            item.value
-          }}</span>
-          <span
-            v-if="item.type === 'text' && item.isMarkup"
-            :id="item.id"
-            v-html="item.value"
-          />
-          <UiBadge
-            v-if="item.type === 'badge'"
-            :is-markup="item.isMarkup"
-            :class="item.class"
-            :variant="'medium'"
-            :label="item.value"
-            :color="item.color"
-            :id="item.id"
-          />
-        </template>
-      </p>
-      <p
-        v-if="secondaryItem?.value"
-        class="typo-label1-regular mt-8 hyphens-auto"
-      >
-        <span>{{ secondaryItem.value }}</span>
-      </p>
-    </div>
+        <span
+          v-if="item.type === 'text' && item.isMarkup"
+          :id="item.id"
+          v-html="item.value"
+        />
+        <UiBadge
+          v-if="item.type === 'badge'"
+          :is-markup="item.isMarkup"
+          :class="item.class"
+          :variant="'medium'"
+          :label="item.value"
+          :color="item.color"
+          :id="item.id"
+        />
+      </template>
+    </p>
+    <p
+      v-if="secondaryItem?.value"
+      class="typo-label1-regular mt-8 hyphens-auto"
+    >
+      <span>{{ secondaryItem.value }}</span>
+    </p>
   </div>
 </template>

--- a/frontend/src/components/search/SearchResultHeader.vue
+++ b/frontend/src/components/search/SearchResultHeader.vue
@@ -5,8 +5,8 @@ export interface SearchResultHeaderItem {
   value: string;
 }
 
-const { icon, items, secondaryItem } = defineProps<{
-  icon?: Component;
+const { items, secondaryItem } = defineProps<{
+  documentType?: Omit<SearchResultHeaderItem, "isMarkup">;
   items: SearchResultHeaderItem[];
   secondaryItem?: SearchResultHeaderItem;
 }>();
@@ -17,14 +17,10 @@ const itemsWithContent = computed(() => items.filter((i) => !!i.value));
 <template>
   <div class="flex items-center gap-8">
     <div>
-      <p class="typo-label2-regular content-center space-x-8 hyphens-auto">
-        <span
-          v-if="icon"
-          class="inline-flex h-lh items-center align-text-bottom"
-        >
-          <component :is="icon" class="inline-block h-16 w-16 text-gray-900" />
-        </span>
-
+      <p class="typo-label2-regular content-center space-x-12 hyphens-auto">
+        <span v-if="documentType" class="font-bold!" :id="documentType.id">{{
+          documentType.value
+        }}</span>
         <template v-for="item in itemsWithContent" :key="item.value">
           <span v-if="item.isMarkup" :id="item.id" v-html="item.value" />
           <span v-else :id="item.id">{{ item.value }}</span>

--- a/frontend/src/components/search/SearchResultHeader.vue
+++ b/frontend/src/components/search/SearchResultHeader.vue
@@ -1,14 +1,28 @@
 <script setup lang="ts">
-export interface SearchResultHeaderItem {
-  isMarkup?: boolean;
-  id?: string;
+import type { BadgeColor } from "~/components/ui/Badge.vue";
+
+export interface TextHeaderItem {
+  type: "text";
   value: string;
+  id?: string;
+  isMarkup?: boolean;
 }
 
+export interface BadgeHeaderItem {
+  type: "badge";
+  value: string;
+  color: BadgeColor;
+  isMarkup?: boolean;
+  id?: string;
+  class?: string;
+}
+
+export type SearchResultHeaderItem = TextHeaderItem | BadgeHeaderItem;
+
 const { items, secondaryItem } = defineProps<{
-  documentType?: Omit<SearchResultHeaderItem, "isMarkup">;
+  documentType?: Omit<TextHeaderItem, "isMarkup">;
   items: SearchResultHeaderItem[];
-  secondaryItem?: SearchResultHeaderItem;
+  secondaryItem?: Omit<TextHeaderItem, "id" | "isMarkup">;
 }>();
 
 const itemsWithContent = computed(() => items.filter((i) => !!i.value));
@@ -22,19 +36,31 @@ const itemsWithContent = computed(() => items.filter((i) => !!i.value));
           documentType.value
         }}</span>
         <template v-for="item in itemsWithContent" :key="item.value">
-          <span v-if="item.isMarkup" :id="item.id" v-html="item.value" />
-          <span v-else :id="item.id">{{ item.value }}</span>
+          <span v-if="item.type === 'text' && !item.isMarkup" :id="item.id">{{
+            item.value
+          }}</span>
+          <span
+            v-if="item.type === 'text' && item.isMarkup"
+            :id="item.id"
+            v-html="item.value"
+          />
+          <UiBadge
+            v-if="item.type === 'badge'"
+            :is-markup="item.isMarkup"
+            :class="item.class"
+            :variant="'medium'"
+            :label="item.value"
+            :color="item.color"
+            :id="item.id"
+          />
         </template>
       </p>
       <p
         v-if="secondaryItem?.value"
         class="typo-label1-regular mt-8 hyphens-auto"
       >
-        <span v-if="secondaryItem.isMarkup" v-html="secondaryItem.value" />
-        <span v-else>{{ secondaryItem.value }}</span>
+        <span>{{ secondaryItem.value }}</span>
       </p>
     </div>
-
-    <slot name="trailing" />
   </div>
 </template>

--- a/frontend/src/components/search/SearchResultHeader.vue
+++ b/frontend/src/components/search/SearchResultHeader.vue
@@ -5,7 +5,6 @@ export interface TextHeaderItem {
   type: "text";
   value: string;
   id?: string;
-  isMarkup?: boolean;
 }
 
 export interface BadgeHeaderItem {
@@ -20,9 +19,9 @@ export interface BadgeHeaderItem {
 export type SearchResultHeaderItem = TextHeaderItem | BadgeHeaderItem;
 
 const { items, secondaryItem } = defineProps<{
-  documentType?: Omit<TextHeaderItem, "isMarkup">;
+  documentType?: TextHeaderItem;
   items: SearchResultHeaderItem[];
-  secondaryItem?: Omit<TextHeaderItem, "id" | "isMarkup">;
+  secondaryItem?: Omit<TextHeaderItem, "id">;
 }>();
 
 const itemsWithContent = computed(() => items.filter((i) => !!i.value));
@@ -37,14 +36,7 @@ const itemsWithContent = computed(() => items.filter((i) => !!i.value));
         documentType.value
       }}</span>
       <template v-for="item in itemsWithContent" :key="item.value">
-        <span v-if="item.type === 'text' && !item.isMarkup" :id="item.id">{{
-          item.value
-        }}</span>
-        <span
-          v-if="item.type === 'text' && item.isMarkup"
-          :id="item.id"
-          v-html="item.value"
-        />
+        <span v-if="item.type === 'text'" :id="item.id">{{ item.value }}</span>
         <UiBadge
           v-if="item.type === 'badge'"
           :is-markup="item.isMarkup"

--- a/frontend/src/components/ui/Badge.spec.ts
+++ b/frontend/src/components/ui/Badge.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from "vitest";
 import Badge from "./Badge.vue";
 
 describe("Badge", () => {
-  it("renders the label text", () => {
+  it("renders the label as plain text by default", () => {
     render(Badge, {
       props: {
         label: "Test Label",
@@ -12,6 +12,34 @@ describe("Badge", () => {
     });
 
     expect(screen.getByText("Test Label")).toBeInTheDocument();
+  });
+
+  it("renders content as html when 'isMarkup' is true", () => {
+    const { container } = render(Badge, {
+      props: {
+        label: "<mark>Highlighted Content</mark>",
+        color: "gray",
+        isMarkup: true,
+      },
+    });
+    expect(container.querySelector("mark")).toHaveTextContent(
+      "Highlighted Content",
+    );
+  });
+
+  it("sanitizes html content", () => {
+    const { container } = render(Badge, {
+      props: {
+        label: "<mark><script>CSS</script>Highlighted Content</mark>",
+        color: "gray",
+        isMarkup: true,
+      },
+    });
+
+    expect(container.querySelectorAll("script")).toHaveLength(0);
+    expect(container.querySelector("mark")).toHaveTextContent(
+      "Highlighted Content",
+    );
   });
 
   it("applies blue styling for blue color", () => {

--- a/frontend/src/components/ui/Badge.vue
+++ b/frontend/src/components/ui/Badge.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import sanitizeHtml from "sanitize-html";
 import { computed } from "vue";
 import { tw } from "../../utils/tags";
 
@@ -6,12 +7,14 @@ export type BadgeColor = "blue" | "green" | "yellow" | "red" | "gray";
 
 const props = withDefaults(
   defineProps<{
-    label: string;
+    label?: string;
     color: BadgeColor;
     variant?: "standard" | "extraSmall" | "small" | "medium" | "large";
+    isMarkup?: boolean;
   }>(),
   {
     variant: "standard",
+    isMarkup: false,
   },
 );
 
@@ -34,7 +37,7 @@ const extraSmall = tw`ris-label3-regular sm:ris-label2-regular 2xl:ris-label1-re
 const small = tw`ris-label2-regular sm:ris-label1-regular`;
 
 // for badges in the search result header
-const medium = tw`ris-label2-regular 2xl:ris-label1-regular`;
+const medium = tw`typo-label2-regular`;
 
 // for badges in the details tab and 'about this service' page
 const large = tw`typo-label1-regular`;
@@ -55,10 +58,15 @@ const rootClass = computed(() => {
     [large]: variant === "large",
   };
 });
+
+const sanitizedLabel = computed(() => {
+  return sanitizeHtml(props.label ?? "", { allowedTags: ["mark"] });
+});
 </script>
 
 <template>
-  <span :class="rootClass">
+  <span v-if="isMarkup" :class="rootClass" v-html="sanitizedLabel" />
+  <span v-else :class="rootClass">
     {{ label }}
   </span>
 </template>

--- a/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
+++ b/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
@@ -98,6 +98,7 @@ const headerMetadata = computed<MetadataItem[]>(() => [
     type: "badge",
     label: "Aktenzeichen",
     values: caseLaw.value?.fileNumbers ?? [],
+    color: "gray",
   },
 ]);
 

--- a/frontend/src/pages/translations/index.vue
+++ b/frontend/src/pages/translations/index.vue
@@ -137,8 +137,8 @@ const translationsListId = useId();
               <SearchResultHeader
                 lang="de"
                 :items="[
-                  { value: t['@id'] },
-                  { value: t.translationOfWork ?? '' },
+                  { type: 'text', value: t['@id'] },
+                  { type: 'text', value: t.translationOfWork ?? '' },
                 ]"
               />
 

--- a/frontend/src/utils/administrativeDirective.ts
+++ b/frontend/src/utils/administrativeDirective.ts
@@ -10,6 +10,7 @@ export function getAdministrativeDirectiveMetadataItems(
       type: "badge",
       label: "Aktenzeichen",
       values: administrativeDirective?.referenceNumbers ?? [],
+      color: "gray",
     },
     {
       type: "text",

--- a/frontend/src/utils/literature.ts
+++ b/frontend/src/utils/literature.ts
@@ -27,6 +27,7 @@ export function getLiteratureMetadataItems(
       type: "badge",
       label: "Fundstelle",
       values: references,
+      color: "gray",
     },
     {
       type: "text",

--- a/frontend/src/utils/norm.spec.ts
+++ b/frontend/src/utils/norm.spec.ts
@@ -192,16 +192,11 @@ describe("getNormMetadataItems", () => {
       "Gültig ab",
       "Gültig bis",
     ]);
-
-    expect(result[0]).toMatchObject({ type: "text", value: undefined });
-    expect(result[1]).toMatchObject({ type: "text", value: undefined });
-    expect(result[2]).toMatchObject({ type: "text", value: undefined });
-    expect(result[3]).toMatchObject({ type: "text", value: undefined });
   });
 
   it("converts empty properties to undefined values", () => {
     const result = getNormMetadataItems({
-      abbreviation: "",
+      abbreviation: undefined,
       legislationIdentifier: "",
       "@type": "Legislation",
       "@id": "",
@@ -219,8 +214,8 @@ describe("getNormMetadataItems", () => {
       hasPart: [],
     });
 
-    expect(result[0]).toMatchObject({ type: "text", value: "" });
-    expect(result[1]).toMatchObject({ type: "text", value: undefined });
+    expect(result[0]).toMatchObject({ type: "text", value: undefined });
+    expect(result[1]).toMatchObject({ type: "badge", values: [] });
     expect(result[2]).toMatchObject({ type: "text", value: undefined });
     expect(result[3]).toMatchObject({ type: "text", value: undefined });
   });
@@ -246,10 +241,43 @@ describe("getNormMetadataItems", () => {
     });
 
     expect(result[0]).toMatchObject({ type: "text", value: "ABC" });
-    expect(result[1]).toMatchObject({ type: "text", value: "Aktuell gültig" });
     expect(result[2]).toMatchObject({ type: "text", value: "06.05.2025" });
     expect(result[3]).toMatchObject({ type: "text", value: "31.03.2037" });
   });
+
+  it.each([
+    ["1900-01-01/1950-01-01", "Außer Kraft", "red"],
+    ["2025-05-06/2037-03-31", "Aktuell gültig", "green"],
+    ["2070-01-01/..", "Zukünftig in Kraft", "yellow"],
+  ])(
+    "displays validity status as badge with color %s and label %s",
+    (temporalCoverage, expectedLabel, expectedColor) => {
+      const result = getNormMetadataItems({
+        abbreviation: "ABC",
+        legislationIdentifier: "",
+        "@type": "Legislation",
+        "@id": "",
+        temporalCoverage: temporalCoverage,
+        legislationLegalForce: "InForce", // not relevant for validity status calculation
+        encoding: [
+          {
+            "@type": "LegislationObject",
+            "@id": "",
+            contentUrl: "",
+            encodingFormat: "",
+            inLanguage: "",
+          },
+        ],
+        hasPart: [],
+      });
+
+      expect(result[1]).toMatchObject({
+        type: "badge",
+        values: [expectedLabel],
+        color: expectedColor,
+      });
+    },
+  );
 });
 
 describe("isNormBodyEmpty", () => {

--- a/frontend/src/utils/norm.ts
+++ b/frontend/src/utils/norm.ts
@@ -142,9 +142,8 @@ export function getNormMetadataItems(
   const validityInterval = temporalCoverageToValidityInterval(
     norm?.temporalCoverage,
   );
-  const formattedStatus = getValidityStatusLabel(
-    getValidityStatus(validityInterval),
-  );
+
+  const validityStatus = formatNormValidity(norm?.temporalCoverage);
   return [
     {
       type: "text",
@@ -152,9 +151,10 @@ export function getNormMetadataItems(
       value: norm?.abbreviation,
     },
     {
-      type: "text",
+      type: "badge",
       label: "Status",
-      value: formattedStatus,
+      values: validityStatus?.label ? [validityStatus.label] : [],
+      color: validityStatus?.color ?? "gray",
     },
     {
       type: "text",


### PR DESCRIPTION
- remove icon and display document type in bold and first place in search result header
- move search result header validity status badge into the row with other items
- display fundstellen and aktenzeichen as badges in search result header
- display validity status of norms in metadata section as badges
- generally I tried to:
    - align the search result item creation across document types (only adding item if it has value, instead of adding all and then filtering out empty ones)
    - remove markup support in places where it is not needed (yet?). If needed in the future it can be added then. (e.g. only the badge item type in the search result header has markup support now, the simple text ones don't)


### Things I was unsure about
- does it make sense to have the `documentType` as extra property in the `SearchResultHeader` component? Should simply the first item in the list be the doc type rendered bold?

RISDEV-12247