### PR TITLE
RISDEV-12275, RISDEV-12144, RISDEV-12142 log level adjustments

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
@@ -1,12 +1,15 @@
 package de.bund.digitalservice.ris.search.config.opensearch;
 
 import java.time.Duration;
+import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.RetryTemplate;
+import org.springframework.core.retry.Retryable;
 
 /** RetryConfiguration fo configure behaviour of opensearch query retries */
 @Configuration
@@ -36,5 +39,28 @@ public class OpensearchRetryConfiguration {
             .build();
 
     return new RetryTemplate(retryPolicy);
+  }
+
+  /**
+   * Runs an operation through the given retry template, unwrapping the {@link RetryException} that
+   * Spring throws once the retries are exhausted.
+   *
+   * <p>Without unwrapping, callers only see a generic retry error and can no longer tell what made
+   * the operation fail, e.g. that OpenSearch rejected the query as unparseable. Rethrowing the
+   * original failure keeps the exceptions callers handle the same as if the operation hadn't been
+   * retried at all.
+   *
+   * @param <T> the type the operation returns
+   * @param retryTemplate the retry template controlling the retry behaviour
+   * @param operation the operation to execute
+   * @return the result of the operation
+   */
+  @SneakyThrows
+  public static <T> T executeWithRetries(RetryTemplate retryTemplate, Retryable<T> operation) {
+    try {
+      return retryTemplate.execute(operation);
+    } catch (RetryException e) {
+      throw e.getCause();
+    }
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
@@ -1,12 +1,15 @@
 package de.bund.digitalservice.ris.search.config.opensearch;
 
 import java.time.Duration;
+import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.RetryTemplate;
+import org.springframework.core.retry.Retryable;
 import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
 import org.springframework.http.HttpStatusCode;
 
@@ -45,6 +48,30 @@ public class OpensearchRetryConfiguration {
             .build();
 
     return new RetryTemplate(retryPolicy);
+  }
+
+  /**
+   * Runs an operation through the given retry template, unwrapping the {@link RetryException} that
+   * Spring throws once the operation either exhausts its retries or fails with an error the {@link
+   * RetryPolicy} decided not to retry.
+   *
+   * <p>Without unwrapping, callers only see a generic retry error and can no longer tell what made
+   * the operation fail, e.g. that OpenSearch rejected the query as unparseable. Rethrowing the
+   * original failure keeps the exceptions callers handle the same as if the operation hadn't been
+   * retried at all.
+   *
+   * @param <T> the type the operation returns
+   * @param retryTemplate the retry template controlling the retry behaviour
+   * @param operation the operation to execute
+   * @return the result of the operation
+   */
+  @SneakyThrows
+  public static <T> T executeWithRetries(RetryTemplate retryTemplate, Retryable<T> operation) {
+    try {
+      return retryTemplate.execute(operation);
+    } catch (RetryException e) {
+      throw e.getCause();
+    }
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
@@ -10,6 +10,8 @@ import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.core.retry.Retryable;
+import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
+import org.springframework.http.HttpStatusCode;
 
 /** RetryConfiguration fo configure behaviour of opensearch query retries */
 @Configuration
@@ -31,6 +33,9 @@ public class OpensearchRetryConfiguration {
             .multiplier(2.0) // Wait twice as long with each retry
             .predicate(
                 throwable -> {
+                  if (isClientError(throwable)) {
+                    return false;
+                  }
                   logger.warn(
                       "OpenSearch failure. Error: {}. Will attempt retry...",
                       throwable.getMessage());
@@ -39,6 +44,20 @@ public class OpensearchRetryConfiguration {
             .build();
 
     return new RetryTemplate(retryPolicy);
+  }
+
+  /**
+   * Whether the failure is Opensearch rejecting the request itself, e.g. because it can't parse the
+   * query. Retrying can't turn a client error into a success, it would only delay the response the
+   * caller is going to get anyway.
+   *
+   * @param throwable the failure to check
+   * @return whether the request was rejected with a 4xx status
+   */
+  private static boolean isClientError(Throwable throwable) {
+    return throwable instanceof UncategorizedElasticsearchException exception
+        && exception.getStatusCode() != null
+        && HttpStatusCode.valueOf(exception.getStatusCode()).is4xxClientError();
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
@@ -51,18 +51,23 @@ public class OpensearchRetryConfiguration {
   }
 
   /**
-   * Runs an operation through the given retry template, unwrapping the {@link RetryException} that
-   * Spring throws once the operation either exhausts its retries or fails with an error the {@link
-   * RetryPolicy} decided not to retry.
+   * Runs the operation through the given retry template.
    *
-   * <p>Without unwrapping, callers only see a generic retry error and can no longer tell what made
-   * the operation fail, e.g. that OpenSearch rejected the query as unparseable. Rethrowing the
-   * original failure keeps the exceptions callers handle the same as if the operation hadn't been
-   * retried at all.
+   * <p>This method unwraps the {@link RetryException} that Spring throws in two cases:
+   *
+   * <ul>
+   *   <li>the operation uses all its retries
+   *   <li>the {@link RetryPolicy} does not retry the failure
+   * </ul>
+   *
+   * <p>Without this step, the caller sees only a generic retry error. The caller cannot tell why
+   * the operation failed. For example, the caller cannot tell that OpenSearch rejected the query
+   * because it could not parse the query. This method rethrows the original failure. As a result,
+   * callers handle the same exceptions as when the operation runs without retries.
    *
    * @param <T> the type the operation returns
-   * @param retryTemplate the retry template controlling the retry behaviour
-   * @param operation the operation to execute
+   * @param retryTemplate the retry template that controls the retry behavior
+   * @param operation the operation to run
    * @return the result of the operation
    */
   @SneakyThrows

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
@@ -31,6 +31,10 @@ public class OpensearchRetryConfiguration {
             .predicate(
                 throwable -> {
                   if (isClientError(throwable)) {
+                    logger.warn(
+                        "OpenSearch rejected the request as a client error. Error: {}. Not"
+                            + " retrying.",
+                        throwable.getMessage());
                     return false;
                   }
                   logger.warn(

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
@@ -55,9 +55,12 @@ public class OpensearchRetryConfiguration {
    * @return whether the request was rejected with a 4xx status
    */
   private static boolean isClientError(Throwable throwable) {
-    return throwable instanceof UncategorizedElasticsearchException exception
-        && exception.getStatusCode() != null
-        && HttpStatusCode.valueOf(exception.getStatusCode()).is4xxClientError();
+    if (!(throwable instanceof UncategorizedElasticsearchException exception)) {
+      return false;
+    }
+
+    Integer statusCode = exception.getStatusCode();
+    return statusCode != null && HttpStatusCode.valueOf(statusCode).is4xxClientError();
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/OpensearchRetryConfiguration.java
@@ -1,15 +1,12 @@
 package de.bund.digitalservice.ris.search.config.opensearch;
 
 import java.time.Duration;
-import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.RetryTemplate;
-import org.springframework.core.retry.Retryable;
 import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
 import org.springframework.http.HttpStatusCode;
 
@@ -61,28 +58,5 @@ public class OpensearchRetryConfiguration {
 
     Integer statusCode = exception.getStatusCode();
     return statusCode != null && HttpStatusCode.valueOf(statusCode).is4xxClientError();
-  }
-
-  /**
-   * Runs an operation through the given retry template, unwrapping the {@link RetryException} that
-   * Spring throws once the retries are exhausted.
-   *
-   * <p>Without unwrapping, callers only see a generic retry error and can no longer tell what made
-   * the operation fail, e.g. that OpenSearch rejected the query as unparseable. Rethrowing the
-   * original failure keeps the exceptions callers handle the same as if the operation hadn't been
-   * retried at all.
-   *
-   * @param <T> the type the operation returns
-   * @param retryTemplate the retry template controlling the retry behaviour
-   * @param operation the operation to execute
-   * @return the result of the operation
-   */
-  @SneakyThrows
-  public static <T> T executeWithRetries(RetryTemplate retryTemplate, Retryable<T> operation) {
-    try {
-      return retryTemplate.execute(operation);
-    } catch (RetryException e) {
-      throw e.getCause();
-    }
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/RestClientConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/RestClientConfig.java
@@ -1,5 +1,6 @@
 package de.bund.digitalservice.ris.search.config.opensearch;
 
+import lombok.SneakyThrows;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.data.client.orhlc.AbstractOpenSearchConfiguration;
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
@@ -91,11 +93,14 @@ public class RestClientConfig extends AbstractOpenSearchConfiguration {
       ElasticsearchConverter elasticsearchConverter, RestHighLevelClient elasticsearchClient) {
 
     return new OpenSearchRestTemplate(opensearchClient(), elasticsearchConverter) {
-
+      @SneakyThrows
       @Override
       public <T> T execute(OpenSearchRestTemplate.ClientCallback<T> callback) {
-        return OpensearchRetryConfiguration.executeWithRetries(
-            retryTemplate, () -> super.execute(callback));
+        try {
+          return retryTemplate.execute(() -> super.execute(callback));
+        } catch (RetryException e) {
+          throw e.getCause();
+        }
       }
     };
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/RestClientConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/RestClientConfig.java
@@ -1,6 +1,5 @@
 package de.bund.digitalservice.ris.search.config.opensearch;
 
-import lombok.SneakyThrows;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.data.client.orhlc.AbstractOpenSearchConfiguration;
@@ -11,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
@@ -93,14 +91,10 @@ public class RestClientConfig extends AbstractOpenSearchConfiguration {
       ElasticsearchConverter elasticsearchConverter, RestHighLevelClient elasticsearchClient) {
 
     return new OpenSearchRestTemplate(opensearchClient(), elasticsearchConverter) {
-      @SneakyThrows
       @Override
       public <T> T execute(OpenSearchRestTemplate.ClientCallback<T> callback) {
-        try {
-          return retryTemplate.execute(() -> super.execute(callback));
-        } catch (RetryException e) {
-          throw e.getCause();
-        }
+        return OpensearchRetryConfiguration.executeWithRetries(
+            retryTemplate, () -> super.execute(callback));
       }
     };
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/RestClientConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/RestClientConfig.java
@@ -1,6 +1,5 @@
 package de.bund.digitalservice.ris.search.config.opensearch;
 
-import lombok.SneakyThrows;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.data.client.orhlc.AbstractOpenSearchConfiguration;
@@ -93,10 +92,10 @@ public class RestClientConfig extends AbstractOpenSearchConfiguration {
 
     return new OpenSearchRestTemplate(opensearchClient(), elasticsearchConverter) {
 
-      @SneakyThrows
       @Override
       public <T> T execute(OpenSearchRestTemplate.ClientCallback<T> callback) {
-        return retryTemplate.execute(() -> super.execute(callback));
+        return OpensearchRetryConfiguration.executeWithRetries(
+            retryTemplate, () -> super.execute(callback));
       }
     };
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/RestClientConfigDev.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/RestClientConfigDev.java
@@ -1,6 +1,5 @@
 package de.bund.digitalservice.ris.search.config.opensearch;
 
-import lombok.SneakyThrows;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.data.client.orhlc.AbstractOpenSearchConfiguration;
 import org.opensearch.data.client.orhlc.ClientConfiguration;
@@ -9,7 +8,6 @@ import org.opensearch.data.client.orhlc.RestClients;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
@@ -63,14 +61,10 @@ public class RestClientConfigDev extends AbstractOpenSearchConfiguration {
       ElasticsearchConverter elasticsearchConverter, RestHighLevelClient elasticsearchClient) {
 
     return new OpenSearchRestTemplate(opensearchClient(), elasticsearchConverter) {
-      @SneakyThrows
       @Override
       public <T> T execute(OpenSearchRestTemplate.ClientCallback<T> callback) {
-        try {
-          return retryTemplate.execute(() -> super.execute(callback));
-        } catch (RetryException e) {
-          throw e.getCause();
-        }
+        return OpensearchRetryConfiguration.executeWithRetries(
+            retryTemplate, () -> super.execute(callback));
       }
     };
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/RestClientConfigDev.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/RestClientConfigDev.java
@@ -1,6 +1,5 @@
 package de.bund.digitalservice.ris.search.config.opensearch;
 
-import lombok.SneakyThrows;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.data.client.orhlc.AbstractOpenSearchConfiguration;
 import org.opensearch.data.client.orhlc.ClientConfiguration;
@@ -63,10 +62,10 @@ public class RestClientConfigDev extends AbstractOpenSearchConfiguration {
 
     return new OpenSearchRestTemplate(opensearchClient(), elasticsearchConverter) {
 
-      @SneakyThrows
       @Override
       public <T> T execute(OpenSearchRestTemplate.ClientCallback<T> callback) {
-        return retryTemplate.execute(() -> super.execute(callback));
+        return OpensearchRetryConfiguration.executeWithRetries(
+            retryTemplate, () -> super.execute(callback));
       }
     };
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/RestClientConfigDev.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/opensearch/RestClientConfigDev.java
@@ -1,5 +1,6 @@
 package de.bund.digitalservice.ris.search.config.opensearch;
 
+import lombok.SneakyThrows;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.data.client.orhlc.AbstractOpenSearchConfiguration;
 import org.opensearch.data.client.orhlc.ClientConfiguration;
@@ -8,6 +9,7 @@ import org.opensearch.data.client.orhlc.RestClients;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
@@ -61,11 +63,14 @@ public class RestClientConfigDev extends AbstractOpenSearchConfiguration {
       ElasticsearchConverter elasticsearchConverter, RestHighLevelClient elasticsearchClient) {
 
     return new OpenSearchRestTemplate(opensearchClient(), elasticsearchConverter) {
-
+      @SneakyThrows
       @Override
       public <T> T execute(OpenSearchRestTemplate.ClientCallback<T> callback) {
-        return OpensearchRetryConfiguration.executeWithRetries(
-            retryTemplate, () -> super.execute(callback));
+        try {
+          return retryTemplate.execute(() -> super.execute(callback));
+        } catch (RetryException e) {
+          throw e.getCause();
+        }
       }
     };
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
@@ -12,6 +12,7 @@ import java.nio.file.AccessDeniedException;
 import java.util.List;
 import java.util.Objects;
 import org.apache.catalina.connector.ClientAbortException;
+import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.tomcat.util.http.InvalidParameterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -237,6 +238,11 @@ public class ControllerExceptionHandler {
    * Handles exceptions of type {@link OpenSearchFetchException} and returns a standardized error
    * response with HTTP status 500 (Internal Server Error).
    *
+   * <p>A connection from the client's pool that OpenSearch has closed on its side surfaces as a
+   * {@link ConnectionClosedException} the next time that connection is used. This is transient, it
+   * happens during regular operation and the next request succeeds again, so it is logged with
+   * level warn.
+   *
    * @param ex the {@link OpenSearchFetchException} instance thrown during OpenSearch data retrieval
    *     failure
    * @return a {@link ResponseEntity} containing a {@link CustomErrorResponse} object with error
@@ -245,7 +251,12 @@ public class ControllerExceptionHandler {
   @ExceptionHandler(OpenSearchFetchException.class)
   public ResponseEntity<CustomErrorResponse> handleElasticsearchException(
       OpenSearchFetchException ex) {
-    logger.error("Opensearch fetch error", ex);
+    if (NestedExceptionUtils.getMostSpecificCause(ex) instanceof ConnectionClosedException) {
+      logger.warn("Opensearch connection closed by peer: {}", ex.getMessage());
+    } else {
+      logger.error("Opensearch fetch error", ex);
+    }
+
     CustomError error =
         new CustomError(
             HttpStatus.INTERNAL_SERVER_ERROR.toString(),

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
@@ -17,6 +17,7 @@ import org.apache.tomcat.util.http.InvalidParameterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.NestedExceptionUtils;
+import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotWritableException;
@@ -266,6 +267,28 @@ public class ControllerExceptionHandler {
     CustomErrorResponse errorResponse =
         CustomErrorResponse.builder().errors(List.of(error)).build();
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+  }
+
+  /**
+   * Handles exceptions of type {@link UncategorizedElasticsearchException} and returns a
+   * standardized error response with HTTP status 500 (Internal Server Error).
+   *
+   * <p>This is reached once the {@code RetryTemplate} configured in {@code
+   * OpensearchRetryConfiguration} has given up: either the failure isn't retryable (e.g. a
+   * malformed query that a controller didn't already translate into a {@link
+   * de.bund.digitalservice.ris.search.exception.CustomValidationException}) or retries were
+   * exhausted. By this point there is nothing left to retry, so it is always logged as an error.
+   *
+   * @param ex the {@link UncategorizedElasticsearchException} instance thrown by an OpenSearch
+   *     operation
+   * @return a {@link ResponseEntity} containing a {@link CustomErrorResponse} object with error
+   *     details and an HTTP status of 500
+   */
+  @ExceptionHandler(UncategorizedElasticsearchException.class)
+  public ResponseEntity<CustomErrorResponse> handleUncategorizedElasticsearchException(
+      UncategorizedElasticsearchException ex) {
+    logger.error("OpenSearch request failed", ex);
+    return return500();
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
@@ -117,7 +117,7 @@ public class ControllerExceptionHandler {
   @ExceptionHandler(CustomValidationException.class)
   public ResponseEntity<CustomErrorResponse> handleCustomValidationException(
       CustomValidationException exception) {
-    logger.warn(exception.getMessage());
+    logger.warn("Validation failed: {}", exception.getErrors());
     var errorResponse = CustomErrorResponse.builder().errors(exception.getErrors()).build();
     return ResponseEntity.status(HttpStatus.UNPROCESSABLE_CONTENT).body(errorResponse);
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/ControllerExceptionHandler.java
@@ -251,8 +251,9 @@ public class ControllerExceptionHandler {
   @ExceptionHandler(OpenSearchFetchException.class)
   public ResponseEntity<CustomErrorResponse> handleElasticsearchException(
       OpenSearchFetchException ex) {
-    if (NestedExceptionUtils.getMostSpecificCause(ex) instanceof ConnectionClosedException) {
-      logger.warn("Opensearch connection closed by peer: {}", ex.getMessage());
+    if (NestedExceptionUtils.getMostSpecificCause(ex) instanceof ConnectionClosedException
+        && ex.getMessage().equals("Connection closed by peer")) {
+      logger.warn("Opensearch connection closed by peer");
     } else {
       logger.error("Opensearch fetch error", ex);
     }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/LuceneQueryTools.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/LuceneQueryTools.java
@@ -112,18 +112,25 @@ public class LuceneQueryTools {
       Pattern.compile("No mapping found for \\[([^]]+)] in order to sort on");
 
   /**
-   * Checks for invalid sort queries in an Elasticsearch exception and throws a custom validation
+   * Opensearch reports a query it can't parse as a {@code parse_exception}, both as the type of the
+   * root cause and in the reason of every exception wrapping it.
+   */
+  static final Pattern PARSE_EXCEPTION_PATTERN = Pattern.compile("parse_exception");
+
+  /**
+   * Checks for invalid queries in an Elasticsearch exception and throws a custom validation
    * exception if necessary.
    *
    * <p>The method identifies if the exception contains a suppressed cause with an error message
-   * indicating that a sort parameter is unsupported due to missing mapping. If such a condition is
-   * met, a {@code CustomValidationException} is constructed and thrown with detailed error
-   * information.
+   * indicating that a sort parameter is unsupported due to missing mapping, or that Opensearch
+   * could not parse the query. If such a condition is met, a {@code CustomValidationException} is
+   * constructed and thrown with detailed error information. Since both are caused by the request
+   * itself, they are client errors rather than failures we can act on.
    *
    * @param e An instance of {@code UncategorizedElasticsearchException} containing details of the
    *     error encountered in Elasticsearch operation.
    * @throws CustomValidationException If the exception indicates that sorting is not supported for
-   *     a given parameter due to missing mappings.
+   *     a given parameter due to missing mappings, or that the query could not be parsed.
    */
   public static void checkForInvalidQuery(UncategorizedElasticsearchException e)
       throws CustomValidationException {
@@ -131,7 +138,9 @@ public class LuceneQueryTools {
       return;
     }
     Throwable suppressed = e.getCause().getSuppressed()[0];
-    Matcher matcher = NO_MAPPING_FOUND_PATTERN.matcher(suppressed.getMessage());
+    String suppressedMessage = StringUtils.defaultString(suppressed.getMessage());
+
+    Matcher matcher = NO_MAPPING_FOUND_PATTERN.matcher(suppressedMessage);
     if (matcher.find()) {
       String parameter = matcher.group(1);
       String message = "Sorting is not supported for %s".formatted(parameter);
@@ -140,6 +149,16 @@ public class LuceneQueryTools {
               .code("invalid_sort_parameter")
               .parameter("sort")
               .message(message)
+              .build();
+      throw new CustomValidationException(error);
+    }
+
+    if (PARSE_EXCEPTION_PATTERN.matcher(suppressedMessage).find()) {
+      CustomError error =
+          CustomError.builder()
+              .code("invalid_lucene_query")
+              .parameter("query")
+              .message("The query could not be parsed")
               .build();
       throw new CustomValidationException(error);
     }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/AdvancedSearchControllerApiTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/AdvancedSearchControllerApiTest.java
@@ -429,6 +429,20 @@ class AdvancedSearchControllerApiTest extends ContainersIntegrationBase {
         .andExpect(jsonPath("$.errors[0].parameter").value("query"));
   }
 
+  @Test
+  @DisplayName("Should return an error when only Opensearch rejects the query as unparseable")
+  void queryOnlyOpensearchRejects() throws Exception {
+    // Valid Lucene, so it passes validation and matches norms, but the article query derived from
+    // it ends up with an empty clause, which Opensearch can't parse
+    mockMvc
+        .perform(
+            get(ApiConfig.Paths.LEGISLATION_ADVANCED_SEARCH + "?query=example OR \"\"")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnprocessableContent())
+        .andExpect(jsonPath("$.errors[0].code").value("invalid_lucene_query"))
+        .andExpect(jsonPath("$.errors[0].parameter").value("query"));
+  }
+
   private static Stream<Arguments> provideSortTestData() {
     return Stream.of(
         Arguments.of(

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/config/opensearch/OpensearchRetryConfigurationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/config/opensearch/OpensearchRetryConfigurationTest.java
@@ -1,0 +1,62 @@
+package de.bund.digitalservice.ris.search.unit.config.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import de.bund.digitalservice.ris.search.config.opensearch.OpensearchRetryConfiguration;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
+
+class OpensearchRetryConfigurationTest {
+
+  /** Retries without a delay, so the tests don't have to wait for the configured backoff */
+  private final RetryTemplate retryTemplate =
+      new RetryTemplate(
+          RetryPolicy.builder()
+              .maxRetries(2)
+              .delay(Duration.ofMillis(1))
+              .predicate(t -> true)
+              .build());
+
+  @Test
+  void itReturnsTheResultOfASuccessfulOperation() {
+    assertThat(OpensearchRetryConfiguration.executeWithRetries(retryTemplate, () -> "result"))
+        .isEqualTo("result");
+  }
+
+  @Test
+  void itRetriesFailingOperations() {
+    AtomicInteger attempts = new AtomicInteger();
+
+    assertThatExceptionOfType(UncategorizedElasticsearchException.class)
+        .isThrownBy(
+            () ->
+                OpensearchRetryConfiguration.executeWithRetries(
+                    retryTemplate,
+                    () -> {
+                      attempts.incrementAndGet();
+                      throw new UncategorizedElasticsearchException("all shards failed");
+                    }));
+
+    assertThat(attempts).hasValue(3);
+  }
+
+  @Test
+  void itRethrowsTheFailureInsteadOfTheRetryException() {
+    var failure = new UncategorizedElasticsearchException("all shards failed");
+
+    assertThatExceptionOfType(UncategorizedElasticsearchException.class)
+        .isThrownBy(
+            () ->
+                OpensearchRetryConfiguration.executeWithRetries(
+                    retryTemplate,
+                    () -> {
+                      throw failure;
+                    }))
+        .isSameAs(failure);
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/config/opensearch/OpensearchRetryConfigurationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/config/opensearch/OpensearchRetryConfigurationTest.java
@@ -1,26 +1,13 @@
 package de.bund.digitalservice.ris.search.unit.config.opensearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import de.bund.digitalservice.ris.search.config.opensearch.OpensearchRetryConfiguration;
-import java.time.Duration;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.retry.RetryPolicy;
-import org.springframework.core.retry.RetryTemplate;
 import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
 
 class OpensearchRetryConfigurationTest {
-
-  /** Retries without a delay, so the tests don't have to wait for the configured backoff */
-  private final RetryTemplate retryTemplate =
-      new RetryTemplate(
-          RetryPolicy.builder()
-              .maxRetries(2)
-              .delay(Duration.ofMillis(1))
-              .predicate(t -> true)
-              .build());
 
   private final RetryPolicy configuredPolicy =
       new OpensearchRetryConfiguration().openSearchRetryTemplate().getRetryPolicy();
@@ -41,43 +28,5 @@ class OpensearchRetryConfigurationTest {
 
     assertThat(configuredPolicy.shouldRetry(serverFailure)).isTrue();
     assertThat(configuredPolicy.shouldRetry(connectionFailure)).isTrue();
-  }
-
-  @Test
-  void itReturnsTheResultOfASuccessfulOperation() {
-    assertThat(OpensearchRetryConfiguration.executeWithRetries(retryTemplate, () -> "result"))
-        .isEqualTo("result");
-  }
-
-  @Test
-  void itRetriesFailingOperations() {
-    AtomicInteger attempts = new AtomicInteger();
-
-    assertThatExceptionOfType(UncategorizedElasticsearchException.class)
-        .isThrownBy(
-            () ->
-                OpensearchRetryConfiguration.executeWithRetries(
-                    retryTemplate,
-                    () -> {
-                      attempts.incrementAndGet();
-                      throw new UncategorizedElasticsearchException("all shards failed");
-                    }));
-
-    assertThat(attempts).hasValue(3);
-  }
-
-  @Test
-  void itRethrowsTheFailureInsteadOfTheRetryException() {
-    var failure = new UncategorizedElasticsearchException("all shards failed");
-
-    assertThatExceptionOfType(UncategorizedElasticsearchException.class)
-        .isThrownBy(
-            () ->
-                OpensearchRetryConfiguration.executeWithRetries(
-                    retryTemplate,
-                    () -> {
-                      throw failure;
-                    }))
-        .isSameAs(failure);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/config/opensearch/OpensearchRetryConfigurationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/config/opensearch/OpensearchRetryConfigurationTest.java
@@ -1,13 +1,26 @@
 package de.bund.digitalservice.ris.search.unit.config.opensearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import de.bund.digitalservice.ris.search.config.opensearch.OpensearchRetryConfiguration;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
 import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
 
 class OpensearchRetryConfigurationTest {
+
+  /** Retries without a delay, so the tests don't have to wait for the configured backoff */
+  private final RetryTemplate retryTemplate =
+      new RetryTemplate(
+          RetryPolicy.builder()
+              .maxRetries(2)
+              .delay(Duration.ofMillis(1))
+              .predicate(t -> true)
+              .build());
 
   private final RetryPolicy configuredPolicy =
       new OpensearchRetryConfiguration().openSearchRetryTemplate().getRetryPolicy();
@@ -28,5 +41,64 @@ class OpensearchRetryConfigurationTest {
 
     assertThat(configuredPolicy.shouldRetry(serverFailure)).isTrue();
     assertThat(configuredPolicy.shouldRetry(connectionFailure)).isTrue();
+  }
+
+  @Test
+  void itReturnsTheResultOfASuccessfulOperation() {
+    assertThat(OpensearchRetryConfiguration.executeWithRetries(retryTemplate, () -> "result"))
+        .isEqualTo("result");
+  }
+
+  @Test
+  void itRetriesFailingOperationsUntilTheConfiguredMaximumIsReached() {
+    AtomicInteger attempts = new AtomicInteger();
+
+    assertThatExceptionOfType(UncategorizedElasticsearchException.class)
+        .isThrownBy(
+            () ->
+                OpensearchRetryConfiguration.executeWithRetries(
+                    retryTemplate,
+                    () -> {
+                      attempts.incrementAndGet();
+                      throw new UncategorizedElasticsearchException("all shards failed");
+                    }));
+
+    assertThat(attempts).hasValue(3);
+  }
+
+  @Test
+  void itRethrowsTheOriginalFailureInsteadOfTheRetryExceptionOnceRetriesAreExhausted() {
+    var failure = new UncategorizedElasticsearchException("all shards failed");
+
+    assertThatExceptionOfType(UncategorizedElasticsearchException.class)
+        .isThrownBy(
+            () ->
+                OpensearchRetryConfiguration.executeWithRetries(
+                    retryTemplate,
+                    () -> {
+                      throw failure;
+                    }))
+        .isSameAs(failure);
+  }
+
+  @Test
+  void itDoesNotRetryClientErrorsAndRethrowsTheOriginalFailure() {
+    var configuredRetryTemplate = new OpensearchRetryConfiguration().openSearchRetryTemplate();
+    AtomicInteger attempts = new AtomicInteger();
+    var clientFailure =
+        new UncategorizedElasticsearchException("all shards failed", 400, "response body", null);
+
+    assertThatExceptionOfType(UncategorizedElasticsearchException.class)
+        .isThrownBy(
+            () ->
+                OpensearchRetryConfiguration.executeWithRetries(
+                    configuredRetryTemplate,
+                    () -> {
+                      attempts.incrementAndGet();
+                      throw clientFailure;
+                    }))
+        .isSameAs(clientFailure);
+
+    assertThat(attempts).hasValue(1);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/config/opensearch/OpensearchRetryConfigurationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/config/opensearch/OpensearchRetryConfigurationTest.java
@@ -22,6 +22,27 @@ class OpensearchRetryConfigurationTest {
               .predicate(t -> true)
               .build());
 
+  private final RetryPolicy configuredPolicy =
+      new OpensearchRetryConfiguration().openSearchRetryTemplate().getRetryPolicy();
+
+  @Test
+  void itDoesNotRetryRequestsOpensearchRejectedAsClientErrors() {
+    var parseFailure =
+        new UncategorizedElasticsearchException("all shards failed", 400, "response body", null);
+
+    assertThat(configuredPolicy.shouldRetry(parseFailure)).isFalse();
+  }
+
+  @Test
+  void itRetriesServerSideAndConnectionFailures() {
+    var serverFailure =
+        new UncategorizedElasticsearchException("all shards failed", 503, "response body", null);
+    var connectionFailure = new UncategorizedElasticsearchException("connection closed by peer");
+
+    assertThat(configuredPolicy.shouldRetry(serverFailure)).isTrue();
+    assertThat(configuredPolicy.shouldRetry(connectionFailure)).isTrue();
+  }
+
   @Test
   void itReturnsTheResultOfASuccessfulOperation() {
     assertThat(OpensearchRetryConfiguration.executeWithRetries(retryTemplate, () -> "result"))

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/utils/LuceneQueryToolsTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/utils/LuceneQueryToolsTest.java
@@ -31,21 +31,8 @@ class LuceneQueryToolsTest {
 
   @Test
   void testCheckForInvalidQueryException() throws IOException {
-    Response mockResponse = mock(Response.class);
-    when(mockResponse.getRequestLine())
-        .thenReturn(new RequestLine("GET", "uri", new ProtocolVersion("HTTP", 1, 1)));
-
-    when(mockResponse.getStatusLine())
-        .thenReturn(
-            new StatusLine(
-                new ProtocolVersion("HTTP", 1, 1),
-                422,
-                "No mapping found for [param_field] in order to sort on"));
-
-    var outerException = mock(UncategorizedElasticsearchException.class);
-    var innerException = new Exception("message");
-    innerException.addSuppressed(new ResponseException(mockResponse));
-    when(outerException.getCause()).thenReturn(innerException);
+    var outerException =
+        mockElasticsearchException("No mapping found for [param_field] in order to sort on");
 
     assertThatExceptionOfType(CustomValidationException.class)
         .isThrownBy(() -> checkForInvalidQuery(outerException))
@@ -55,6 +42,49 @@ class LuceneQueryToolsTest {
               assertThat(e.getErrors().getFirst().message())
                   .isEqualTo("Sorting is not supported for param_field");
             });
+  }
+
+  @Test
+  void testCheckForInvalidQueryReportsQueriesOpensearchCannotParse() throws IOException {
+    var outerException =
+        mockElasticsearchException(
+            """
+            {"error":{"root_cause":[{"type":"parse_exception","reason":"parse_exception: \
+            Encountered " <OR> "OR "" at line 1, column 32."}],"status":400}}\
+            """);
+
+    assertThatExceptionOfType(CustomValidationException.class)
+        .isThrownBy(() -> checkForInvalidQuery(outerException))
+        .satisfies(
+            e -> {
+              assertThat(e.getErrors().getFirst().code()).isEqualTo("invalid_lucene_query");
+              assertThat(e.getErrors().getFirst().parameter()).isEqualTo("query");
+              assertThat(e.getErrors().getFirst().message())
+                  .isEqualTo("The query could not be parsed");
+            });
+  }
+
+  @Test
+  void testCheckForInvalidQueryIgnoresFailuresThatAreNotCausedByTheRequest() throws IOException {
+    var outerException = mockElasticsearchException("all shards failed");
+
+    assertThatCode(() -> checkForInvalidQuery(outerException)).doesNotThrowAnyException();
+  }
+
+  /** Builds an exception shaped like the ones the Opensearch client throws for a failed request. */
+  private UncategorizedElasticsearchException mockElasticsearchException(String reason)
+      throws IOException {
+    Response mockResponse = mock(Response.class);
+    when(mockResponse.getRequestLine())
+        .thenReturn(new RequestLine("GET", "uri", new ProtocolVersion("HTTP", 1, 1)));
+    when(mockResponse.getStatusLine())
+        .thenReturn(new StatusLine(new ProtocolVersion("HTTP", 1, 1), 400, reason));
+
+    var outerException = mock(UncategorizedElasticsearchException.class);
+    var innerException = new Exception("message");
+    innerException.addSuppressed(new ResponseException(mockResponse));
+    when(outerException.getCause()).thenReturn(innerException);
+    return outerException;
   }
 
   @Test

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -8,12 +8,7 @@ if (config.public.sentryDSN) {
     environment: config.public.sentryEnvironment,
     tracesSampleRate: 1,
 
-    // Errors thrown via `createError` (e.g. 404s) surface through Nuxt's
-    // `vue:error` hook, which the Sentry SDK reports without filtering by status
-    // code at all, and through its `app:error` hook, which only filters errors
-    // it recognizes as Nuxt errors. Drop client errors here so they don't reach
-    // Sentry. Client-only: the server side already filters these via the Nitro
-    // error handler.
+    // Drops error noise, see `shouldSuppressSentryEvent`:
     beforeSend(event, hint) {
       return shouldSuppressSentryEvent(hint.originalException) ? null : event;
     },

--- a/frontend/src/utils/sentry.spec.ts
+++ b/frontend/src/utils/sentry.spec.ts
@@ -61,6 +61,29 @@ describe("sentry", () => {
       expect(shouldSuppressSentryEvent({ statusCode: 500 })).toBe(false);
     });
 
+    it("suppresses aborted requests", () => {
+      expect(
+        shouldSuppressSentryEvent(
+          new DOMException("The user aborted a request.", "AbortError"),
+        ),
+      ).toBe(true);
+    });
+
+    it("suppresses aborted requests wrapped in another error", () => {
+      const fetchError = new Error('[GET] "/v1/document": <no response>', {
+        cause: new DOMException("The user aborted a request.", "AbortError"),
+      });
+
+      expect(shouldSuppressSentryEvent(fetchError)).toBe(true);
+    });
+
+    it("reports errors with a circular cause chain and no abort error", () => {
+      const error: Error & { cause?: unknown } = new Error("Something failed");
+      error.cause = error;
+
+      expect(shouldSuppressSentryEvent(error)).toBe(false);
+    });
+
     it.each([undefined, null, "404", 404, {}, { status: "not a status" }])(
       "reports %o, which carries no usable status",
       (error) => {

--- a/frontend/src/utils/sentry.ts
+++ b/frontend/src/utils/sentry.ts
@@ -1,6 +1,25 @@
+function isAbortError(err: unknown): err is DOMException {
+  if (!err) return false;
+  return typeof err === "object" && "name" in err && err.name === "AbortError";
+}
+
+function isOrContainsAbortError(error: unknown, maxDepth = 5): boolean {
+  let current = error;
+
+  // aborterror may be wrapped inside another error, we we recurse but cap it in
+  // case the error chain is circular.
+  for (let depth = 0; current && depth < maxDepth; depth++) {
+    if (isAbortError(current)) return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+
+  return false;
+}
+
 /**
- * Whether an error captured by Sentry is a 3xx/4xx error page error, e.g. a 404
- * created via `createError` or `showError`, which we don't want to report.
+ * Whether an error captured by Sentry is an error we don't want to report:
+ * either an aborted request (see `isAbortError`), or a 3xx/4xx error page
+ * error, e.g. a 404 created via `createError` or `showError`.
  *
  * Checking `isNuxtError` is not sufficient here, because that is only true for
  * errors thrown on the client. An error thrown on the server is serialized to
@@ -15,6 +34,7 @@
  *   reported.
  */
 export function shouldSuppressSentryEvent(error: unknown): boolean {
+  if (isOrContainsAbortError(error)) return true;
   if (!error || typeof error !== "object") return false;
   if (error instanceof Error && !isNuxtError(error)) return false;
 


### PR DESCRIPTION
This PR adjusts some logging to reduce noise in Sentry:

- RISDEV-12144: Connection closed by peer should be a warning
- RISDEV-12275: `AbortException` is a normal part of how Nuxt operates, it should not be reported

It also changes logging of invalid user-submitted queries (RISDEV-12142), although that is a bit more involved than a simple logging level change:

- Controllers catch `UncategorizedElasticsearchException`s, but the retry template throws `RetryException`s that contain the original exception. The controller's `catch` therefore never matched. Added a helper that unwraps the `RetryException`, so the endpoint now correctly returns a 422 instead of 500 and logs the issue as a warning.
- Extended `LuceneQueryTools.checkForInvalidQuery` to also detect parsing errors similar to other error types.
- The 422 handler in `ControllerExceptionHandler` logged `exception.getMessage()`, which is always `null` on `CustomValidationException`. It now logs the errors.
- The retry policy retried things three times even if we know they won't succeed, so an unparseable query causes 3 warnings before erroring. Excluded client-error responses from retrying.

---

@andrew-cenkner-digitalservice: I went into this thinking it would be a simple log level change. It turned out to be a bit more complicated. Disclaimer: the 2 commits for RISDEV-12142 have been written by Claude, I think the explanation and code changes make sense but I don't 100% understand them, or all of the implications for the backend. Let me know if you think they're useless. Happy to drop those commits then.