### PR TITLE
RISDEV-12340 improve log message

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
@@ -265,7 +265,7 @@ public class IndexNormsService implements IndexService {
 
     if (newestFileName.isEmpty()) {
       logger.error(
-          "Changelog file contained {}, but no manifestation files found for that norm expression.",
+          "Expression '{}' either doesn't exist or is missing a regelungstext-verkuendungsfassung.xml.",
           expressionEli);
       return Optional.empty();
     }


### PR DESCRIPTION
- the previous log message was misleading, as the error didn't always have something to do with the changelog file

RISDEV-12340