### PR TITLE
RISDEV-12212 decouple url paths and storage location of sitemaps

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/config/ApiConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/config/ApiConfig.java
@@ -51,6 +51,11 @@ public class ApiConfig {
         DOCUMENT + "/lucene-search/administrative-directive";
 
     public static final String SITEMAP = BASE + "/sitemaps";
+    public static final String LEGISLATION_SITEMAPS = SITEMAP + "/norms";
+    public static final String CASELAW_SITEMAPS = SITEMAP + "/case-law";
+    public static final String ADMINISTRATIVE_DIRECTIVE_SITEMAPS =
+        SITEMAP + "/administrative-directives";
+    public static final String LITERATURE_SITEMAPS = SITEMAP + "/literature";
     public static final String ECLICRAWLER = BASE + "/eclicrawler";
     public static final String STATISTICS = BASE + "/statistics";
     public static final String BULK_ZIP_LINKS = BASE + "/bulk-zip-links";

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/SitemapController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/SitemapController.java
@@ -52,7 +52,7 @@ public class SitemapController {
    *     the object store.
    */
   @GetMapping(
-      path = ApiConfig.Paths.SITEMAP + "/administrative-directives/{filename}.xml",
+      path = ApiConfig.Paths.ADMINISTRATIVE_DIRECTIVE_SITEMAPS + "/{filename}.xml",
       produces = MediaType.APPLICATION_XML_VALUE)
   @Operation(
       summary = "Get administrative directive sitemap files",
@@ -91,7 +91,7 @@ public class SitemapController {
    *     the object store.
    */
   @GetMapping(
-      path = ApiConfig.Paths.SITEMAP + "/case-law/{filename}.xml",
+      path = ApiConfig.Paths.CASELAW_SITEMAPS + "/{filename}.xml",
       produces = MediaType.APPLICATION_XML_VALUE)
   @Operation(
       summary = "Get case law sitemap files",
@@ -130,7 +130,7 @@ public class SitemapController {
    *     the object store.
    */
   @GetMapping(
-      path = ApiConfig.Paths.SITEMAP + "/literature/{filename}.xml",
+      path = ApiConfig.Paths.LITERATURE_SITEMAPS + "/{filename}.xml",
       produces = MediaType.APPLICATION_XML_VALUE)
   @Operation(
       summary = "Get literature sitemap files",
@@ -169,7 +169,7 @@ public class SitemapController {
    *     the object store.
    */
   @GetMapping(
-      path = ApiConfig.Paths.SITEMAP + "/norms/{filename}.xml",
+      path = ApiConfig.Paths.LEGISLATION_SITEMAPS + "/{filename}.xml",
       produces = MediaType.APPLICATION_XML_VALUE)
   @Operation(
       summary = "Get norm sitemap files",
@@ -207,7 +207,7 @@ public class SitemapController {
     } else {
       try {
         int batchNumber = Integer.parseInt(filename);
-        file = portalBucket.get(sitemapService.getBatchSitemapPath(batchNumber, documentKind));
+        file = portalBucket.get(sitemapService.getBatchSitemapS3Path(batchNumber, documentKind));
       } catch (NumberFormatException _) {
         return ResponseEntity.notFound().build();
       }

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapService.java
@@ -1,5 +1,6 @@
 package de.bund.digitalservice.ris.search.service;
 
+import de.bund.digitalservice.ris.search.config.ApiConfig;
 import de.bund.digitalservice.ris.search.models.DocumentKind;
 import de.bund.digitalservice.ris.search.models.sitemap.SitemapFile;
 import de.bund.digitalservice.ris.search.models.sitemap.SitemapIndex;
@@ -15,18 +16,51 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /** Service for generating sitemaps. */
 @Service
-@RequiredArgsConstructor
 public class SitemapService {
-  @Value("${server.front-end-url}")
-  private String baseUrl;
+  private final String baseUrl;
+
+  public SitemapService(PortalBucket portalBucket, @Value("${server.front-end-url}") String baseUrl) {
+    this.portalBucket = portalBucket;
+    //remove trailing / to cleanly concatenate with api paths
+    this.baseUrl = Strings.CS.removeEnd(baseUrl, "/");
+  }
 
   private static final String SITEMAP_PREFIX = "sitemaps/";
   public final PortalBucket portalBucket;
+
+  private String getControllerPath(DocumentKind type) {
+    return switch (type) {
+      case LEGISLATION -> ApiConfig.Paths.LEGISLATION_SITEMAPS;
+      case ADMINISTRATIVE_DIRECTIVE -> ApiConfig.Paths.ADMINISTRATIVE_DIRECTIVE_SITEMAPS;
+      case LITERATURE -> ApiConfig.Paths.LITERATURE_SITEMAPS;
+      case CASE_LAW -> ApiConfig.Paths.CASELAW_SITEMAPS;
+    };
+  }
+
+  private String getFrontendUrl(DocumentKind type) {
+    return switch (type) {
+      case LEGISLATION -> "/gesetze";
+      case ADMINISTRATIVE_DIRECTIVE -> "/verwaltungsregelungen";
+      case LITERATURE -> "/literaturnachweise";
+      case CASE_LAW -> "/gerichtsentscheidungen";
+    };
+  }
+
+  private String getS3StorageLocation(DocumentKind type) {
+    return switch (type) {
+      case LEGISLATION -> "norms";
+      case ADMINISTRATIVE_DIRECTIVE -> "administrative-directive";
+      case LITERATURE -> "literature";
+      case CASE_LAW -> "case-law";
+    };
+  }
 
   /**
    * Returns the path of a sitemap file for a given batch number
@@ -35,8 +69,8 @@ public class SitemapService {
    * @param type the type of sitemap currently being generated
    * @return sitemap file path
    */
-  public String getBatchSitemapPath(int batchNumber, DocumentKind type) {
-    return SITEMAP_PREFIX + String.format("%s/%d.xml", type.getSiteMapPath(), batchNumber);
+  public String getBatchSitemapS3Path(int batchNumber, DocumentKind type) {
+    return SITEMAP_PREFIX + String.format("%s/%d.xml", getS3StorageLocation(type), batchNumber);
   }
 
   /**
@@ -49,8 +83,8 @@ public class SitemapService {
    */
   public void createBatchSitemap(
       int batchNumber, List<String> ids, DocumentKind docKind, String prefix) {
-    String path = getBatchSitemapPath(batchNumber, docKind);
-    portalBucket.save(path, generateSitemap(ids, prefix));
+    String path = getBatchSitemapS3Path(batchNumber, docKind);
+    portalBucket.save(path, generateSitemap(ids, docKind));
   }
 
   /**
@@ -60,7 +94,7 @@ public class SitemapService {
    * @return sitemap index file path
    */
   public String getIndexSitemapPath(DocumentKind type) {
-    return SITEMAP_PREFIX + String.format("%s/index.xml", type.getSiteMapPath());
+    return SITEMAP_PREFIX + String.format("%s/index.xml", getS3StorageLocation(type));
   }
 
   /**
@@ -89,13 +123,14 @@ public class SitemapService {
    * Deletes sitemap files older than the given date
    *
    * @param documentationUnitIds the list of ids to put in the sitemap file
-   * @param prefix the sitemap file prefix
+   * @param documentKind the DocumentKind the sitemap is generated for
    * @return sitemap xml content
    */
-  public String generateSitemap(List<String> documentationUnitIds, String prefix) {
+  public String generateSitemap(List<String> documentationUnitIds, DocumentKind documentKind) {
     List<Url> urls =
         documentationUnitIds.stream()
-            .map(e -> new Url(String.format("%s%s/%s", baseUrl, prefix, e)))
+            .map(
+                e -> new Url(String.format("%s%s/%s", baseUrl, getFrontendUrl(documentKind), e)))
             .toList();
     return marshal(new SitemapFile(urls));
   }
@@ -111,9 +146,9 @@ public class SitemapService {
     List<Url> urls =
         IntStream.rangeClosed(1, size)
             .mapToObj(
-                e ->
+                batch ->
                     new Url(
-                        String.format("%sv1/%s", baseUrl, getBatchSitemapPath(e, type)),
+                        String.format("%s%s/%s.xml", baseUrl, getControllerPath(type), batch),
                         LocalDate.now(ZoneOffset.UTC)))
             .toList();
     return marshal(new SitemapIndex(urls));

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/SitemapService.java
@@ -15,8 +15,6 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.IntStream;
-import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -26,13 +24,20 @@ import org.springframework.stereotype.Service;
 public class SitemapService {
   private final String baseUrl;
 
-  public SitemapService(PortalBucket portalBucket, @Value("${server.front-end-url}") String baseUrl) {
+  /**
+   * Service for generating sitemaps.
+   *
+   * @param portalBucket PortalBucket
+   * @param baseUrl baseUrl of frontend application to reference changed sites
+   */
+  public SitemapService(
+      PortalBucket portalBucket, @Value("${server.front-end-url}") String baseUrl) {
     this.portalBucket = portalBucket;
-    //remove trailing / to cleanly concatenate with api paths
+    // remove trailing / to cleanly concatenate with api paths
     this.baseUrl = Strings.CS.removeEnd(baseUrl, "/");
   }
 
-  private static final String SITEMAP_PREFIX = "sitemaps/";
+  private static final String PORTAL_BUCKET_SITEMAP_PREFIX = "sitemaps/";
   public final PortalBucket portalBucket;
 
   private String getControllerPath(DocumentKind type) {
@@ -44,16 +49,16 @@ public class SitemapService {
     };
   }
 
-  private String getFrontendUrl(DocumentKind type) {
+  private String getFrontendPath(DocumentKind type) {
     return switch (type) {
-      case LEGISLATION -> "/gesetze";
-      case ADMINISTRATIVE_DIRECTIVE -> "/verwaltungsregelungen";
-      case LITERATURE -> "/literaturnachweise";
-      case CASE_LAW -> "/gerichtsentscheidungen";
+      case LEGISLATION -> "gesetze";
+      case ADMINISTRATIVE_DIRECTIVE -> "verwaltungsregelungen";
+      case LITERATURE -> "literaturnachweise";
+      case CASE_LAW -> "gerichtsentscheidungen";
     };
   }
 
-  private String getS3StorageLocation(DocumentKind type) {
+  private String getS3Path(DocumentKind type) {
     return switch (type) {
       case LEGISLATION -> "norms";
       case ADMINISTRATIVE_DIRECTIVE -> "administrative-directive";
@@ -70,7 +75,7 @@ public class SitemapService {
    * @return sitemap file path
    */
   public String getBatchSitemapS3Path(int batchNumber, DocumentKind type) {
-    return SITEMAP_PREFIX + String.format("%s/%d.xml", getS3StorageLocation(type), batchNumber);
+    return PORTAL_BUCKET_SITEMAP_PREFIX + String.format("%s/%d.xml", getS3Path(type), batchNumber);
   }
 
   /**
@@ -94,7 +99,7 @@ public class SitemapService {
    * @return sitemap index file path
    */
   public String getIndexSitemapPath(DocumentKind type) {
-    return SITEMAP_PREFIX + String.format("%s/index.xml", getS3StorageLocation(type));
+    return PORTAL_BUCKET_SITEMAP_PREFIX + String.format("%s/index.xml", getS3Path(type));
   }
 
   /**
@@ -114,7 +119,7 @@ public class SitemapService {
    * @param beforeDateTime date before which sitemap files should be deleted
    */
   public void deleteSitemapFiles(Instant beforeDateTime) {
-    portalBucket.getAllKeyInfosByPrefix(SITEMAP_PREFIX).stream()
+    portalBucket.getAllKeyInfosByPrefix(PORTAL_BUCKET_SITEMAP_PREFIX).stream()
         .filter(info -> info.lastModified().isBefore(beforeDateTime))
         .forEach(info -> portalBucket.delete(info.key()));
   }
@@ -129,8 +134,7 @@ public class SitemapService {
   public String generateSitemap(List<String> documentationUnitIds, DocumentKind documentKind) {
     List<Url> urls =
         documentationUnitIds.stream()
-            .map(
-                e -> new Url(String.format("%s%s/%s", baseUrl, getFrontendUrl(documentKind), e)))
+            .map(e -> new Url(String.format("%s/%s/%s", baseUrl, getFrontendPath(documentKind), e)))
             .toList();
     return marshal(new SitemapFile(urls));
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/SitemapServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/SitemapServiceTest.java
@@ -20,10 +20,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class SitemapServiceTest {
@@ -34,7 +32,7 @@ class SitemapServiceTest {
 
   @BeforeEach
   void setUp() {
-      sitemapService = new SitemapService(portalBucket, "https://test.local/");
+    sitemapService = new SitemapService(portalBucket, "https://test.local/");
   }
 
   @Test
@@ -50,7 +48,8 @@ class SitemapServiceTest {
   @Test
   void testGenerateCaseLawSitemap() {
     String caseLawSitemap = sitemapService.generateSitemap(List.of("KORE1"), DocumentKind.CASE_LAW);
-    assertTrue(caseLawSitemap.contains("<loc>https://test.local/gerichtsentscheidungen/KORE1</loc>"));
+    assertTrue(
+        caseLawSitemap.contains("<loc>https://test.local/gerichtsentscheidungen/KORE1</loc>"));
   }
 
   @Test
@@ -68,8 +67,10 @@ class SitemapServiceTest {
 
   @Test
   void testGenerateLiteratureSitemap() {
-    String caseLawSitemap = sitemapService.generateSitemap(List.of("XXLU000001"), DocumentKind.LITERATURE);
-    assertTrue(caseLawSitemap.contains("<loc>https://test.local/literaturnachweise/XXLU000001</loc>"));
+    String caseLawSitemap =
+        sitemapService.generateSitemap(List.of("XXLU000001"), DocumentKind.LITERATURE);
+    assertTrue(
+        caseLawSitemap.contains("<loc>https://test.local/literaturnachweise/XXLU000001</loc>"));
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/SitemapServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/service/SitemapServiceTest.java
@@ -29,12 +29,12 @@ import org.springframework.test.util.ReflectionTestUtils;
 class SitemapServiceTest {
   private static final String TEST_ELI_FILE =
       "eli/bund/bgbl-1/1991/s101/1991-01-01/1/deu/1991-01-20/regelungstext-1.xml";
-  @InjectMocks private SitemapService sitemapService;
   @Mock private PortalBucket portalBucket;
+  SitemapService sitemapService;
 
   @BeforeEach
   void setUp() {
-    ReflectionTestUtils.setField(sitemapService, "baseUrl", "https://test.local/");
+      sitemapService = new SitemapService(portalBucket, "https://test.local/");
   }
 
   @Test
@@ -49,8 +49,8 @@ class SitemapServiceTest {
 
   @Test
   void testGenerateCaseLawSitemap() {
-    String caseLawSitemap = sitemapService.generateSitemap(List.of("KORE1"), "case-law");
-    assertTrue(caseLawSitemap.contains("<loc>https://test.local/case-law/KORE1</loc>"));
+    String caseLawSitemap = sitemapService.generateSitemap(List.of("KORE1"), DocumentKind.CASE_LAW);
+    assertTrue(caseLawSitemap.contains("<loc>https://test.local/gerichtsentscheidungen/KORE1</loc>"));
   }
 
   @Test
@@ -68,8 +68,8 @@ class SitemapServiceTest {
 
   @Test
   void testGenerateLiteratureSitemap() {
-    String caseLawSitemap = sitemapService.generateSitemap(List.of("XXLU000001"), "literature");
-    assertTrue(caseLawSitemap.contains("<loc>https://test.local/literature/XXLU000001</loc>"));
+    String caseLawSitemap = sitemapService.generateSitemap(List.of("XXLU000001"), DocumentKind.LITERATURE);
+    assertTrue(caseLawSitemap.contains("<loc>https://test.local/literaturnachweise/XXLU000001</loc>"));
   }
 
   @Test
@@ -88,7 +88,7 @@ class SitemapServiceTest {
   @Test
   void testGetNormsBatchSitemapPath() {
     assertEquals(
-        "sitemaps/norms/1.xml", sitemapService.getBatchSitemapPath(1, DocumentKind.LEGISLATION));
+        "sitemaps/norms/1.xml", sitemapService.getBatchSitemapS3Path(1, DocumentKind.LEGISLATION));
   }
 
   @Test
@@ -102,8 +102,8 @@ class SitemapServiceTest {
     Optional<EliFile> file = EliFile.fromString(TEST_ELI_FILE);
     assertTrue(file.isPresent());
     String id = file.get().getExpressionEli().toString();
-    String normSitemap = sitemapService.generateSitemap(List.of(id), "norms");
-    assertTrue(normSitemap.contains("<loc>https://test.local/norms/" + id + "</loc>"));
+    String normSitemap = sitemapService.generateSitemap(List.of(id), DocumentKind.LEGISLATION);
+    assertTrue(normSitemap.contains("<loc>https://test.local/gesetze/" + id + "</loc>"));
   }
 
   @Test


### PR DESCRIPTION
Currently the backend url, frontend url and s3 storage location share the same configuration, leading to issues when any of those deviates from the others. 
This PR decouples those configurations and changes the frontend path in the sitemaps to the the new german ones.
Backend url and s3 locations are unchanged.
