### PR TITLE
RISDEV-12432 recent updates section on the landing page

### DIFF
--- a/frontend/e2e/startseiteV2.spec.ts
+++ b/frontend/e2e/startseiteV2.spec.ts
@@ -1,9 +1,5 @@
 import { expect, navigate, test } from "./utils/fixtures";
 
-test.beforeAll(({ privateFeaturesEnabled }) => {
-  test.skip(!privateFeaturesEnabled, "the new start page is not public yet");
-});
-
 test.describe(
   "search section on the new start page",
   { tag: ["@RISDEV-12431"] },

--- a/frontend/src/assets/typography.css
+++ b/frontend/src/assets/typography.css
@@ -69,3 +69,11 @@
     @apply link-hover text-blue-800 underline-offset-2 outline-offset-4 outline-blue-800 focus-visible:outline-4;
   }
 }
+
+@utility typo-headline-searchresult-compact {
+  @apply ris-subhead-bold 2xl:ris-heading3-bold block;
+
+  &:is(a) {
+    @apply link-hover text-blue-800 underline-offset-2 outline-offset-4 outline-blue-800 focus-visible:outline-4;
+  }
+}

--- a/frontend/src/components/RecentUpdates.spec.ts
+++ b/frontend/src/components/RecentUpdates.spec.ts
@@ -1,0 +1,210 @@
+import { mockNuxtImport, renderSuspended } from "@nuxt/test-utils/runtime";
+import userEvent from "@testing-library/user-event";
+import { screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { computed, ref } from "vue";
+import type { AnyDocument, SearchResult } from "~/types/api";
+import { DocumentKind } from "~/types/api";
+import RecentUpdates from "./RecentUpdates.vue";
+
+// The section renders whatever the search returns through SearchResult, so a
+// single realistic legislation document is enough to cover every tab.
+function result(name: string): SearchResult<AnyDocument> {
+  return {
+    item: {
+      "@type": "Legislation",
+      "@id": `eli/bund/bgbl-1/2026/${name}/regelungstext-1`,
+      name,
+      abbreviation: "TG",
+      risAbbreviation: "",
+      legislationIdentifier: `eli/bund/bgbl-1/2026/${name}/regelungstext-1`,
+      exampleOfWork: {
+        "@type": "Legislation",
+        "@id": `/v1/legislation/eli/bund/bgbl-1/2026/${name}`,
+        legislationIdentifier: `eli/bund/bgbl-1/2026/${name}`,
+        legislationDate: "2026-08-12",
+        datePublished: "2026-08-12",
+      },
+      hasPart: [],
+      encoding: [],
+      legislationLegalForce: "InForce",
+      temporalCoverage: "2026-08-12/..",
+    },
+    textMatches: [],
+  } as unknown as SearchResult<AnyDocument>;
+}
+
+type Search = {
+  documentKind: DocumentKind;
+  results?: SearchResult<AnyDocument>[];
+  error?: Error;
+};
+
+function mockSearches(searches: Search[]) {
+  useRecentSectionSearchResultsMock.mockResolvedValue(
+    searches.map(({ documentKind, results = [], error }) => ({
+      documentKind,
+      searchResults: computed(() => results),
+      searchError: ref(error ?? null),
+    })),
+  );
+}
+
+const defaultSearches: Search[] = [
+  { documentKind: DocumentKind.Norm, results: [result("Luftverkehrsgesetz")] },
+  { documentKind: DocumentKind.CaseLaw, results: [result("Ein Urteil")] },
+  {
+    documentKind: DocumentKind.AdministrativeDirective,
+    results: [result("Eine Vorschrift")],
+  },
+  {
+    documentKind: DocumentKind.Literature,
+    results: [result("Ein Aufsatz")],
+  },
+];
+
+const { useRecentSectionSearchResultsMock } = vi.hoisted(() => ({
+  useRecentSectionSearchResultsMock: vi.fn(),
+}));
+
+mockNuxtImport(
+  "useRecentSectionSearchResults",
+  () => useRecentSectionSearchResultsMock,
+);
+
+mockNuxtImport("useRoute", () => () => ({ fullPath: "/startseite-v2" }));
+
+const renderComponent = () =>
+  renderSuspended(RecentUpdates, {
+    global: {
+      stubs: {
+        NuxtLink: {
+          props: ["to"],
+          template:
+            '<a :href="to.path ?? to.name" :data-document-kind="to.query?.documentKind"><slot /></a>',
+        },
+      },
+    },
+  });
+
+describe("RecentUpdates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearches(defaultSearches);
+  });
+
+  it("renders the section heading", async () => {
+    await renderComponent();
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Aktuelles" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one tab per document kind", async () => {
+    await renderComponent();
+
+    expect(
+      screen.getAllByRole("tab").map((tab) => tab.textContent?.trim()),
+    ).toEqual([
+      "Gesetze und Verordnungen",
+      "Gerichtsentscheidungen",
+      "Verwaltungsvorschriften",
+      "Literaturnachweise",
+    ]);
+  });
+
+  it("selects the first tab by default", async () => {
+    await renderComponent();
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+    for (const tab of tabs.slice(1)) {
+      expect(tab).toHaveAttribute("aria-selected", "false");
+    }
+  });
+
+  it("labels the tab panel with the selected tab", async () => {
+    await renderComponent();
+
+    const selectedTab = screen.getAllByRole("tab")[0]!;
+    expect(screen.getByRole("tabpanel")).toHaveAttribute(
+      "aria-labelledby",
+      selectedTab.id,
+    );
+  });
+
+  it("shows the results of the selected document kind", async () => {
+    await renderComponent();
+
+    expect(screen.getByText("Luftverkehrsgesetz")).toBeInTheDocument();
+    expect(screen.queryByText("Ein Urteil")).not.toBeInTheDocument();
+  });
+
+  it("renders result titles as level 3 headings", async () => {
+    await renderComponent();
+
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Luftverkehrsgesetz" }),
+    ).toBeInTheDocument();
+  });
+
+  it("links to the simple search for the selected document kind", async () => {
+    await renderComponent();
+
+    expect(
+      screen.getByRole("link", { name: "Zu den Gesetzen und Verordnungen" }),
+    ).toHaveAttribute("data-document-kind", DocumentKind.Norm);
+  });
+
+  it("swaps results and button label when another tab is selected", async () => {
+    await renderComponent();
+
+    await userEvent.click(
+      screen.getByRole("tab", { name: "Literaturnachweise" }),
+    );
+
+    expect(screen.getByText("Ein Aufsatz")).toBeInTheDocument();
+    expect(screen.queryByText("Luftverkehrsgesetz")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Zu den Literaturnachweisen" }),
+    ).toHaveAttribute("data-document-kind", DocumentKind.Literature);
+    expect(
+      screen.getByRole("tab", { name: "Literaturnachweise" }),
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("shows an error on the failing tab only", async () => {
+    mockSearches([
+      { documentKind: DocumentKind.Norm, error: new Error("Boom") },
+      ...defaultSearches.slice(1),
+    ]);
+
+    await renderComponent();
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Die Ergebnisse konnten nicht geladen werden.",
+    );
+
+    await userEvent.click(
+      screen.getByRole("tab", { name: "Gerichtsentscheidungen" }),
+    );
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByText("Ein Urteil")).toBeInTheDocument();
+  });
+
+  it("shows a notice when a tab has no results", async () => {
+    mockSearches([
+      { documentKind: DocumentKind.Norm, results: [] },
+      ...defaultSearches.slice(1),
+    ]);
+
+    await renderComponent();
+
+    expect(
+      screen.getByText("Derzeit keine Einträge verfügbar."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/RecentUpdates.vue
+++ b/frontend/src/components/RecentUpdates.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { NuxtLink } from "#components";
+import type { RecentSectionDocumentKind } from "~/composables/useRecentSectionSearchResults";
+import { DocumentKind } from "~/types/api";
+
+const labels: Record<
+  RecentSectionDocumentKind,
+  { tab: string; button: string }
+> = {
+  [DocumentKind.Norm]: {
+    tab: "Gesetze und Verordnungen",
+    button: "Zu den Gesetzen und Verordnungen",
+  },
+  [DocumentKind.CaseLaw]: {
+    tab: "Gerichtsentscheidungen",
+    button: "Zu den Gerichtsentscheidungen",
+  },
+  [DocumentKind.AdministrativeDirective]: {
+    tab: "Verwaltungsvorschriften",
+    button: "Zu den Verwaltungsvorschriften",
+  },
+  [DocumentKind.Literature]: {
+    tab: "Literaturnachweise",
+    button: "Zu den Literaturnachweisen",
+  },
+};
+
+const idBase = useId();
+
+const tabId = (documentKind: RecentSectionDocumentKind) =>
+  `${idBase}-${documentKind}`;
+
+const searches = await useRecentSectionSearchResults();
+
+const selected = ref<RecentSectionDocumentKind>(
+  RECENT_SECTION_DOCUMENT_KINDS[0],
+);
+
+const tabs = searches.map(({ documentKind }) => ({
+  documentKind,
+  id: tabId(documentKind),
+  label: labels[documentKind].tab,
+}));
+
+const activeTab = computed(() => {
+  const documentKind = selected.value;
+  const search = searches.find((s) => s.documentKind === documentKind);
+
+  return {
+    documentKind,
+    id: tabId(documentKind),
+    buttonLabel: labels[documentKind].button,
+    results: search?.searchResults.value ?? [],
+    error: search?.searchError.value,
+  };
+});
+</script>
+
+<template>
+  <h2 class="typo-headline2-bold mb-4 wrap-break-word hyphens-auto md:mb-12">
+    Aktuelles
+  </h2>
+
+  <UiTabs aria-label="Aktuelles nach Dokumentart">
+    <UiTab
+      v-for="tab in tabs"
+      :id="tab.id"
+      :key="tab.documentKind"
+      :active="tab.documentKind === selected"
+      @click="selected = tab.documentKind"
+    >
+      {{ tab.label }}
+    </UiTab>
+  </UiTabs>
+
+  <div role="tabpanel" :aria-labelledby="activeTab.id" class="mt-16 md:mt-24">
+    <UiMessage v-if="activeTab.error" severity="error" role="alert">
+      Die Ergebnisse konnten nicht geladen werden.
+    </UiMessage>
+
+    <p v-else-if="!activeTab.results.length" class="typo-body-regular">
+      Derzeit keine Einträge verfügbar.
+    </p>
+
+    <ul v-else class="flex flex-col gap-4 md:gap-8">
+      <li
+        v-for="(searchResult, order) in activeTab.results"
+        :key="getIdentifier(searchResult.item)"
+        class="border border-gray-400 bg-white p-16"
+      >
+        <SearchResult :search-result :order heading-level="3" />
+      </li>
+    </ul>
+
+    <UiButton
+      class="mt-16 w-full md:mt-24 md:w-auto"
+      :as="NuxtLink"
+      :to="{
+        name: 'suche',
+        query: { documentKind: activeTab.documentKind },
+      }"
+    >
+      {{ activeTab.buttonLabel }}
+    </UiButton>
+  </div>
+</template>

--- a/frontend/src/components/RecentUpdates.vue
+++ b/frontend/src/components/RecentUpdates.vue
@@ -61,7 +61,7 @@ const activeTab = computed(() => {
     Aktuelles
   </h2>
 
-  <UiTabs aria-label="Aktuelles nach Dokumentart">
+  <UiTabs aria-label="Aktuelles nach Dokumentart" scroller-class="px-16 -mx-16">
     <UiTab
       v-for="tab in tabs"
       :id="tab.id"

--- a/frontend/src/components/documents/TabsLayout.spec.ts
+++ b/frontend/src/components/documents/TabsLayout.spec.ts
@@ -10,12 +10,9 @@ const { useRouteMock } = vi.hoisted(() => ({
 
 mockNuxtImport("useRoute", () => useRouteMock);
 
-const IconA = { template: `<svg aria-label="icon-a" />` };
-const IconB = { template: `<svg aria-label="icon-b" />` };
-
 const views: OneOrMore<TabView> = [
-  { label: "Tab A", path: "view-a", icon: IconA },
-  { label: "Tab B", path: "view-b", icon: IconB, analyticsId: "tab-b" },
+  { label: "Tab A", path: "view-a" },
+  { label: "Tab B", path: "view-b", analyticsId: "tab-b" },
 ];
 
 describe("TabsLayout", () => {
@@ -26,15 +23,6 @@ describe("TabsLayout", () => {
 
     expect(screen.getByRole("tab", { name: /Tab A/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Tab B/i })).toBeInTheDocument();
-  });
-
-  it("renders tab icons", async () => {
-    useRouteMock.mockReturnValue({ query: {} });
-
-    await renderSuspended(TabsLayout, { props: { views } });
-
-    expect(screen.getByLabelText("icon-a")).toBeInTheDocument();
-    expect(screen.getByLabelText("icon-b")).toBeInTheDocument();
   });
 
   it("marks only the first tab as active when no query param is set", async () => {

--- a/frontend/src/components/documents/TabsLayout.vue
+++ b/frontend/src/components/documents/TabsLayout.vue
@@ -4,7 +4,6 @@ import { NuxtLink } from "#components";
 export type TabView = {
   label: string;
   path: string;
-  icon: Component;
   analyticsId?: string;
 };
 
@@ -32,7 +31,6 @@ const currentView = computed(
             :to="{ query: { ...route.query, view: view.path } }"
             :data-attr="view.analyticsId"
           >
-            <component :is="view.icon" />
             {{ view.label }}
           </UiTab>
         </UiTabs>

--- a/frontend/src/components/documents/TabsLayout.vue
+++ b/frontend/src/components/documents/TabsLayout.vue
@@ -22,7 +22,7 @@ const currentView = computed(
   <div>
     <div class="border-b border-gray-400">
       <nav class="-mb-px" aria-label="Tab">
-        <UiTabs class="content-gutters">
+        <UiTabs scroller-class="content-gutters">
           <UiTab
             v-for="view in views"
             :key="view.path"

--- a/frontend/src/components/search/AdministrativeDirectiveSearchResult.spec.ts
+++ b/frontend/src/components/search/AdministrativeDirectiveSearchResult.spec.ts
@@ -3,6 +3,7 @@ import { screen } from "@testing-library/vue";
 import { describe } from "vitest";
 import AdministrativeDirectiveSearchResult from "~/components/search/AdministrativeDirectiveSearchResult.vue";
 import type { AdministrativeDirective, SearchResult } from "~/types/api";
+import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
 
 const { useRouteMock } = vi.hoisted(() => ({
   useRouteMock: vi.fn(() => ({
@@ -30,14 +31,17 @@ const searchResult: SearchResult<AdministrativeDirective> = {
 async function renderComponent({
   item = searchResult.item,
   textMatches = searchResult.textMatches,
-}: Partial<SearchResult<AdministrativeDirective>> = {}) {
+  headingLevel,
+}: Partial<SearchResult<AdministrativeDirective>> & {
+  headingLevel?: SearchResultHeadingLevel;
+} = {}) {
   const result: SearchResult<AdministrativeDirective> = {
     item,
     textMatches,
   };
 
   return await renderSuspended(AdministrativeDirectiveSearchResult, {
-    props: { searchResult: result, order: 0 },
+    props: { searchResult: result, order: 0, headingLevel },
     global: {
       stubs: {
         NuxtLink: {
@@ -249,5 +253,28 @@ describe("AdministrativeDirectiveSearchResult", () => {
       "data-from",
       "/suche?query=Vorschrift&documentKind=VS&pageIndex=0",
     );
+  });
+
+  describe("heading level", () => {
+    it("renders the title as an h2 with the responsive style by default", async () => {
+      await renderComponent();
+
+      const heading = screen.getByRole("heading", { level: 2 });
+      expect(heading).toBeInTheDocument();
+      expect(heading.closest("a")).toHaveClass("typo-headline-searchresult");
+    });
+
+    it("renders the title as an h3 with the compact style at level 3", async () => {
+      await renderComponent({ headingLevel: "3" });
+
+      const heading = screen.getByRole("heading", { level: 3 });
+      expect(heading).toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { level: 2 }),
+      ).not.toBeInTheDocument();
+      expect(heading.closest("a")).toHaveClass(
+        "typo-headline-searchresult-compact",
+      );
+    });
   });
 });

--- a/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
+++ b/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
@@ -4,12 +4,26 @@ import type {
   TextHeaderItem,
 } from "~/components/search/SearchResultHeader.vue";
 import type { AdministrativeDirective, SearchResult } from "~/types/api";
-import { getMatch, getTitleWithFallback } from "~/utils/search/searchResults";
+import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
+import {
+  getMatch,
+  getSearchResultHeadline,
+  getTitleWithFallback,
+} from "~/utils/search/searchResults";
 
-const { searchResult, order } = defineProps<{
+const {
+  searchResult,
+  order,
+  headingLevel = "2",
+} = defineProps<{
   searchResult: SearchResult<AdministrativeDirective>;
   order: number;
+
+  /** Heading level of the result title. */
+  headingLevel?: SearchResultHeadingLevel;
 }>();
+
+const headlineStyle = computed(() => getSearchResultHeadline(headingLevel));
 
 const { searchResultClicked } = usePostHog();
 
@@ -94,12 +108,12 @@ function trackResultClick() {
     <NuxtLink
       :to="detailPageRoute"
       :aria-describedby="resultTypeId"
-      class="typo-headline-searchresult"
+      :class="headlineStyle.class"
       @click="trackResultClick()"
     >
-      <h2>
+      <component :is="headlineStyle.tag">
         <span v-html="headline" />
-      </h2>
+      </component>
     </NuxtLink>
 
     <div v-if="previewSections.length" class="flex w-full flex-col gap-6">

--- a/frontend/src/components/search/CaseLawSearchResult.spec.ts
+++ b/frontend/src/components/search/CaseLawSearchResult.spec.ts
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/vue";
 import { describe, expect, it } from "vitest";
 import CaselawRecord from "~/components/search/CaselawSearchResult.vue";
 import type { CaseLaw, SearchResult, TextMatch } from "~/types/api";
+import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
 
 const { useRouteMock } = vi.hoisted(() => ({
   useRouteMock: vi.fn(() => ({
@@ -44,11 +45,14 @@ const searchResult: SearchResult<CaseLaw> = {
 function renderComponent({
   item = searchResult.item,
   textMatches = [],
-}: Partial<SearchResult<CaseLaw>>) {
+  headingLevel,
+}: Partial<SearchResult<CaseLaw>> & {
+  headingLevel?: SearchResultHeadingLevel;
+}) {
   const result: SearchResult<CaseLaw> = { item, textMatches };
 
   return render(CaselawRecord, {
-    props: { searchResult: result, order: 0 },
+    props: { searchResult: result, order: 0, headingLevel },
     global: {
       stubs: {
         NuxtLink: {
@@ -478,5 +482,28 @@ describe("CaselawSearchResult", () => {
       "data-from",
       "/suche?query=BGB&documentKind=R&pageIndex=2",
     );
+  });
+
+  describe("heading level", () => {
+    it("renders the title as an h2 with the responsive style by default", () => {
+      renderComponent({});
+
+      const heading = screen.getByRole("heading", { level: 2 });
+      expect(heading).toBeInTheDocument();
+      expect(heading.closest("a")).toHaveClass("typo-headline-searchresult");
+    });
+
+    it("renders the title as an h3 with the compact style at level 3", () => {
+      renderComponent({ headingLevel: "3" });
+
+      const heading = screen.getByRole("heading", { level: 3 });
+      expect(heading).toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { level: 2 }),
+      ).not.toBeInTheDocument();
+      expect(heading.closest("a")).toHaveClass(
+        "typo-headline-searchresult-compact",
+      );
+    });
   });
 });

--- a/frontend/src/components/search/CaselawSearchResult.vue
+++ b/frontend/src/components/search/CaselawSearchResult.vue
@@ -4,16 +4,27 @@ import type {
   TextHeaderItem,
 } from "~/components/search/SearchResultHeader.vue";
 import type { CaseLaw, SearchResult } from "~/types/api";
+import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
 import {
   getMatch,
   getMatches,
   getTitleWithFallback,
+  getSearchResultHeadline,
 } from "~/utils/search/searchResults";
 
-const { searchResult, order } = defineProps<{
+const {
+  searchResult,
+  order,
+  headingLevel = "2",
+} = defineProps<{
   searchResult: SearchResult<CaseLaw>;
   order: number;
+
+  /** Heading level of the result title. */
+  headingLevel?: SearchResultHeadingLevel;
 }>();
+
+const headlineStyle = computed(() => getSearchResultHeadline(headingLevel));
 
 const { searchResultClicked } = usePostHog();
 
@@ -134,10 +145,10 @@ function trackResultClick() {
     <NuxtLink
       :to="detailPageRoute"
       :aria-describedby="resultTypeId"
-      class="typo-headline-searchresult"
+      :class="headlineStyle.class"
       @click="trackResultClick()"
     >
-      <h2><span v-html="headline" /></h2>
+      <component :is="headlineStyle.tag"><span v-html="headline" /></component>
     </NuxtLink>
 
     <div v-if="previewSections.length" class="flex w-full flex-col gap-6">

--- a/frontend/src/components/search/LiteratureSearchResult.spec.ts
+++ b/frontend/src/components/search/LiteratureSearchResult.spec.ts
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/vue";
 import { describe } from "vitest";
 import LiteratureSearchResult from "~/components/search/LiteratureSearchResult.vue";
 import type { Literature, SearchResult, TextMatch } from "~/types/api";
+import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
 
 const { useRouteMock } = vi.hoisted(() => ({
   useRouteMock: vi.fn(() => ({
@@ -55,14 +56,17 @@ Abschließend gibt das Werk Empfehlungen für die praktische Anwendung juristisc
 function renderComponent({
   item = searchResult.item,
   textMatches = [],
-}: Partial<SearchResult<Literature>> = {}) {
+  headingLevel,
+}: Partial<SearchResult<Literature>> & {
+  headingLevel?: SearchResultHeadingLevel;
+} = {}) {
   const result: SearchResult<Literature> = {
     item,
     textMatches,
   };
 
   return render(LiteratureSearchResult, {
-    props: { searchResult: result, order: 0 },
+    props: { searchResult: result, order: 0, headingLevel },
     global: {
       stubs: {
         NuxtLink: {
@@ -299,5 +303,28 @@ describe("LiteratureSearchResult", () => {
       "data-from",
       "/suche?query=Recht&documentKind=L&pageIndex=3",
     );
+  });
+
+  describe("heading level", () => {
+    it("renders the title as an h2 with the responsive style by default", () => {
+      renderComponent();
+
+      const heading = screen.getByRole("heading", { level: 2 });
+      expect(heading).toBeInTheDocument();
+      expect(heading.closest("a")).toHaveClass("typo-headline-searchresult");
+    });
+
+    it("renders the title as an h3 with the compact style at level 3", () => {
+      renderComponent({ headingLevel: "3" });
+
+      const heading = screen.getByRole("heading", { level: 3 });
+      expect(heading).toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { level: 2 }),
+      ).not.toBeInTheDocument();
+      expect(heading.closest("a")).toHaveClass(
+        "typo-headline-searchresult-compact",
+      );
+    });
   });
 });

--- a/frontend/src/components/search/LiteratureSearchResult.vue
+++ b/frontend/src/components/search/LiteratureSearchResult.vue
@@ -4,12 +4,26 @@ import type {
   TextHeaderItem,
 } from "~/components/search/SearchResultHeader.vue";
 import type { Literature, SearchResult } from "~/types/api";
-import { getMatch, getTitleWithFallback } from "~/utils/search/searchResults";
+import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
+import {
+  getMatch,
+  getSearchResultHeadline,
+  getTitleWithFallback,
+} from "~/utils/search/searchResults";
 
-const { searchResult, order } = defineProps<{
+const {
+  searchResult,
+  order,
+  headingLevel = "2",
+} = defineProps<{
   searchResult: SearchResult<Literature>;
   order: number;
+
+  /** Heading level of the result title. */
+  headingLevel?: SearchResultHeadingLevel;
 }>();
+
+const headlineStyle = computed(() => getSearchResultHeadline(headingLevel));
 
 const { searchResultClicked } = usePostHog();
 
@@ -85,12 +99,12 @@ function trackResultClick() {
     <NuxtLink
       :to="detailPageRoute"
       :aria-describedby="resultTypeId"
-      class="typo-headline-searchresult"
+      :class="headlineStyle.class"
       @click="trackResultClick()"
     >
-      <h2>
+      <component :is="headlineStyle.tag">
         <span v-html="headline" />
-      </h2>
+      </component>
     </NuxtLink>
 
     <div v-if="previewSections.length" class="flex w-full flex-col gap-6">

--- a/frontend/src/components/search/NormSearchResult.spec.ts
+++ b/frontend/src/components/search/NormSearchResult.spec.ts
@@ -6,6 +6,7 @@ import type {
   SearchResult,
   TextMatch,
 } from "~/types/api";
+import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
 import NormSearchResult from "./NormSearchResult.vue";
 
 const { useRouteMock } = vi.hoisted(() => ({
@@ -78,9 +79,10 @@ const mockSearchResult: SearchResult<LegislationExpression> = {
 function renderComponent(
   searchResult: SearchResult<LegislationExpression> = mockSearchResult,
   order: number = 0,
+  headingLevel?: SearchResultHeadingLevel,
 ) {
   return render(NormSearchResult, {
-    props: { searchResult, order },
+    props: { searchResult, order, headingLevel },
     global: {
       stubs: {
         NuxtLink: {
@@ -410,5 +412,28 @@ describe("NormSearchResult", () => {
       "data-from",
       "/suche?query=BGB&documentKind=N&pageIndex=1",
     );
+  });
+
+  describe("heading level", () => {
+    it("renders the title as an h2 with the responsive style by default", () => {
+      renderComponent();
+
+      expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /Test Title/i })).toHaveClass(
+        "typo-headline-searchresult",
+      );
+    });
+
+    it("renders the title as an h3 with the compact style at level 3", () => {
+      renderComponent(mockSearchResult, 0, "3");
+
+      expect(screen.getByRole("heading", { level: 3 })).toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { level: 2 }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /Test Title/i })).toHaveClass(
+        "typo-headline-searchresult-compact",
+      );
+    });
   });
 });

--- a/frontend/src/components/search/NormSearchResult.vue
+++ b/frontend/src/components/search/NormSearchResult.vue
@@ -5,12 +5,26 @@ import type {
   TextHeaderItem,
 } from "~/components/search/SearchResultHeader.vue";
 import type { LegislationExpression, SearchResult } from "~/types/api";
-import { getMatch, getTitleWithFallback } from "~/utils/search/searchResults";
+import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
+import {
+  getMatch,
+  getSearchResultHeadline,
+  getTitleWithFallback,
+} from "~/utils/search/searchResults";
 
-const { searchResult, order } = defineProps<{
+const {
+  searchResult,
+  order,
+  headingLevel = "2",
+} = defineProps<{
   searchResult: SearchResult<LegislationExpression>;
   order: number;
+
+  /** Heading level of the result title. */
+  headingLevel?: SearchResultHeadingLevel;
 }>();
+
+const headlineStyle = computed(() => getSearchResultHeadline(headingLevel));
 
 const { searchResultClicked } = usePostHog();
 const privateFeaturesEnabled = usePrivateFeaturesFlag();
@@ -123,10 +137,10 @@ const relevantHighlights = computed(() =>
       v-if="detailPageRoute"
       :to="detailPageRoute"
       :aria-describedby="resultTypeId"
-      class="typo-headline-searchresult"
+      :class="headlineStyle.class"
       @click="searchResultClicked(detailPageRoute.path, order)"
     >
-      <h2 v-html="headline" />
+      <component :is="headlineStyle.tag" v-html="headline" />
     </NuxtLink>
 
     <div

--- a/frontend/src/components/search/SearchResult.spec.ts
+++ b/frontend/src/components/search/SearchResult.spec.ts
@@ -105,4 +105,45 @@ describe("SearchResult", () => {
 
     expect(container).toBeEmptyDOMElement();
   });
+
+  it("forwards the heading level to the result component", () => {
+    const { container } = render(SearchResultComponent, {
+      props: {
+        searchResult: {
+          item: { "@type": "Decision" },
+        } as SearchResult<CaseLaw>,
+        order: 0,
+        headingLevel: "3" as const,
+      },
+      global: {
+        stubs: {
+          SearchCaselawSearchResult: true,
+        },
+      },
+    });
+
+    expect(
+      container.querySelector("search-caselaw-search-result-stub"),
+    ).toHaveAttribute("headinglevel", "3");
+  });
+
+  it("defaults the heading level to 2", () => {
+    const { container } = render(SearchResultComponent, {
+      props: {
+        searchResult: {
+          item: { "@type": "Decision" },
+        } as SearchResult<CaseLaw>,
+        order: 0,
+      },
+      global: {
+        stubs: {
+          SearchCaselawSearchResult: true,
+        },
+      },
+    });
+
+    expect(
+      container.querySelector("search-caselaw-search-result-stub"),
+    ).toHaveAttribute("headinglevel", "2");
+  });
 });

--- a/frontend/src/components/search/SearchResult.vue
+++ b/frontend/src/components/search/SearchResult.vue
@@ -7,10 +7,12 @@ import type {
   Literature,
   SearchResult,
 } from "~/types/api";
+import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
 
-defineProps<{
+const { headingLevel = "2" } = defineProps<{
   searchResult: SearchResult<AnyDocument>;
   order: number;
+  headingLevel?: SearchResultHeadingLevel;
 }>();
 </script>
 
@@ -19,23 +21,27 @@ defineProps<{
     v-if="isCaselaw(searchResult.item)"
     :search-result="searchResult as SearchResult<CaseLaw>"
     :order="order"
+    :heading-level="headingLevel"
   />
 
   <SearchNormSearchResult
     v-else-if="isLegislation(searchResult.item)"
     :search-result="searchResult as SearchResult<LegislationExpression>"
     :order="order"
+    :heading-level="headingLevel"
   />
 
   <SearchLiteratureSearchResult
     v-else-if="isLiterature(searchResult.item)"
     :search-result="searchResult as SearchResult<Literature>"
     :order="order"
+    :heading-level="headingLevel"
   />
 
   <SearchAdministrativeDirectiveSearchResult
     v-else-if="isAdministrativeDirective(searchResult.item)"
     :search-result="searchResult as SearchResult<AdministrativeDirective>"
     :order="order"
+    :heading-level="headingLevel"
   />
 </template>

--- a/frontend/src/components/ui/Tab.vue
+++ b/frontend/src/components/ui/Tab.vue
@@ -16,14 +16,19 @@ const isNativeButton = computed(() => as === "button");
 
 // Classes ------------------------------------------------
 
-const base = tw`typo-label2-bold relative -mb-px flex h-64 shrink-0 items-center gap-8 border-x border-t border-transparent px-24 pb-4 whitespace-nowrap outline-0 -outline-offset-4 outline-blue-800 focus-visible:outline-4 has-[svg]:pl-20`;
+const base = tw`typo-label1-regular relative -mb-px flex h-48 shrink-0 items-center whitespace-nowrap outline-0 after:absolute after:inset-x-0 after:bottom-0 after:h-4 after:content-[""]`;
 
-const activeTab = tw`border-x-gray-400 border-t-gray-400 bg-white text-black`;
+// Pseudo element so we can give it some horizontal distance from the text while
+// keeping the vertical inset
+const focusRing = tw`before:pointer-events-none before:absolute before:-inset-x-12 before:inset-y-0 before:z-10 before:hidden before:border-4 before:border-blue-800 before:content-[""] focus-visible:before:block`;
 
-const inactiveTab = tw`cursor-pointer text-blue-800 after:absolute after:-inset-x-1 after:bottom-0 after:h-4 after:content-[""] hover:after:bg-blue-800`;
+const activeTab = tw`text-gray-1000 after:bg-gray-1000`;
+
+const inactiveTab = tw`cursor-pointer text-blue-800 hover:after:bg-blue-800`;
 
 const rootClass = computed(() => ({
   [base]: true,
+  [focusRing]: true,
   [activeTab]: active,
   [inactiveTab]: !active,
 }));

--- a/frontend/src/components/ui/Tabs.spec.ts
+++ b/frontend/src/components/ui/Tabs.spec.ts
@@ -4,8 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Tab from "./Tab.vue";
 import Tabs from "./Tabs.vue";
 
-const renderTabs = () =>
+const renderTabs = (props?: { scrollerClass?: string }) =>
   render(Tabs, {
+    props,
     attrs: { "aria-label": "Ansichten" },
     slots: {
       default: [
@@ -43,6 +44,15 @@ describe("Tabs", () => {
     renderTabs();
 
     expect(screen.getByRole("tablist", { name: "Ansichten" })).toBeVisible();
+  });
+
+  it("adds the scroller class to the scrolling container", () => {
+    renderTabs({ scrollerClass: "px-24" });
+
+    const scroller = screen.getByRole("tablist").parentElement;
+
+    expect(scroller).toHaveClass("px-24");
+    expect(scroller).toHaveClass("overflow-x-auto");
   });
 
   it("moves focus to the next tab on ArrowRight, wrapping around", async () => {

--- a/frontend/src/components/ui/Tabs.stories.ts
+++ b/frontend/src/components/ui/Tabs.stories.ts
@@ -1,7 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
 import { ref } from "vue";
-import IcBaselineSubject from "~icons/ic/baseline-subject";
-import IcOutlineInfo from "~icons/ic/outline-info";
 import { html } from "../../utils/tags";
 import UiTab from "./Tab.vue";
 import UiTabs from "./Tabs.vue";
@@ -36,29 +34,6 @@ export const Default: StoryObj<typeof meta> = {
           @click="selected = tab"
         >
           {{ tab }}
-        </UiTab>
-      </UiTabs>
-      <div :class="panel">Inhalt von „{{ selected }}“</div>
-    </div>`,
-  }),
-};
-
-export const WithIcons: StoryObj<typeof meta> = {
-  render: () => ({
-    components: { UiTabs, UiTab, IcBaselineSubject, IcOutlineInfo },
-    setup() {
-      const selected = ref("Text");
-      return { selected, wrapper, panel };
-    },
-    template: html`<div :class="wrapper">
-      <UiTabs aria-label="Beispiel">
-        <UiTab :active="selected === 'Text'" @click="selected = 'Text'">
-          <IcBaselineSubject />
-          Text
-        </UiTab>
-        <UiTab :active="selected === 'Details'" @click="selected = 'Details'">
-          <IcOutlineInfo />
-          Details
         </UiTab>
       </UiTabs>
       <div :class="panel">Inhalt von „{{ selected }}“</div>

--- a/frontend/src/components/ui/Tabs.vue
+++ b/frontend/src/components/ui/Tabs.vue
@@ -43,9 +43,9 @@ const onKeydown = (event: KeyboardEvent) => {
 
 // Classes ------------------------------------------------
 
-const scroller = tw`overflow-x-auto`;
+const scroller = tw`overflow-x-auto overflow-y-hidden`;
 
-const tabList = tw`flex w-max min-w-full gap-24 border-b border-gray-400`;
+const tabList = tw`flex w-max min-w-full scroll-px-12 gap-24 border-b border-gray-400 px-12`;
 </script>
 
 <template>

--- a/frontend/src/components/ui/Tabs.vue
+++ b/frontend/src/components/ui/Tabs.vue
@@ -45,7 +45,7 @@ const onKeydown = (event: KeyboardEvent) => {
 
 const scroller = tw`overflow-x-auto`;
 
-const tabList = tw`flex w-max min-w-full border-b border-gray-400`;
+const tabList = tw`flex w-max min-w-full gap-24 border-b border-gray-400`;
 </script>
 
 <template>

--- a/frontend/src/components/ui/Tabs.vue
+++ b/frontend/src/components/ui/Tabs.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { useTemplateRef } from "vue";
+import { useTemplateRef, type ClassValue } from "vue";
 import { tw } from "../../utils/tags";
 
 defineOptions({ inheritAttrs: false });
+
+defineProps<{ scrollerClass?: ClassValue }>();
 
 const list = useTemplateRef<HTMLElement>("list");
 
@@ -43,13 +45,13 @@ const onKeydown = (event: KeyboardEvent) => {
 
 // Classes ------------------------------------------------
 
-const scroller = tw`overflow-x-auto overflow-y-hidden`;
+const scroller = tw`overflow-x-auto`;
 
-const tabList = tw`flex w-max min-w-full scroll-px-12 gap-24 border-b border-gray-400 px-12`;
+const tabList = tw`flex w-max min-w-full scroll-px-12 gap-24 border-b border-gray-400`;
 </script>
 
 <template>
-  <div :class="scroller">
+  <div :class="[scroller, scrollerClass]">
     <div
       ref="list"
       v-bind="$attrs"

--- a/frontend/src/composables/useAdvancedSearch.ts
+++ b/frontend/src/composables/useAdvancedSearch.ts
@@ -1,11 +1,12 @@
 import { toValue } from "vue";
 import type { Page } from "~/components/Pagination.vue";
-import { DocumentKind, type LuceneSearchParams } from "~/types/api";
-import {
-  dateFilterToQuery,
-  type StrictDateFilterValue,
-} from "~/utils/search/dateFilterType";
+import type { DocumentKind, LuceneSearchParams } from "~/types/api";
+import type { StrictDateFilterValue } from "~/utils/search/dateFilterType";
 import { itemsPerPageDefault } from "~/utils/search/itemsPerPageOptions";
+import {
+  buildLuceneQuery,
+  getLuceneSearchPath,
+} from "~/utils/search/luceneSearch";
 
 /** Additional configuration for search API calls */
 type AdvancedSearchOptions = {
@@ -41,42 +42,20 @@ export async function useAdvancedSearch(
     sort = "default",
   }: Partial<AdvancedSearchOptions>,
 ) {
-  const searchEndpointUrl = computed(() => {
-    const documentKindVal = toValue(documentKind);
-    const baseUrl = "/v1/document/lucene-search";
+  const searchEndpointUrl = computed(() =>
+    getLuceneSearchPath(toValue(documentKind)),
+  );
 
-    if (documentKindVal === DocumentKind.CaseLaw) {
-      return baseUrl + "/case-law";
-    } else if (documentKindVal === DocumentKind.Norm) {
-      return baseUrl + "/legislation";
-    } else if (documentKindVal === DocumentKind.Literature) {
-      return baseUrl + "/literature";
-    } else if (documentKindVal === DocumentKind.AdministrativeDirective) {
-      return baseUrl + "/administrative-directive";
-    } else return baseUrl;
-  });
-
-  const combinedQuery = computed<AdvancedSearchEndpointParams>(() => {
-    const result = [toValue(query)];
-
-    const filterVal = toValue(dateFilter);
-    if (filterVal) {
-      const dateQuery = dateFilterToQuery(filterVal, toValue(documentKind));
-      if (dateQuery) result.push(dateQuery);
-    }
-
-    const resultStr = result
-      .filter((i) => !!i.trim())
-      .map((i) => `(${i.trim()})`)
-      .join(" AND ");
-
-    return {
-      query: resultStr,
-      size: toValue(itemsPerPage),
-      sort: toValue(sort),
-      pageIndex: toValue(pageIndex),
-    };
-  });
+  const combinedQuery = computed<AdvancedSearchEndpointParams>(() => ({
+    query: buildLuceneQuery(
+      toValue(query),
+      toValue(dateFilter),
+      toValue(documentKind),
+    ),
+    size: toValue(itemsPerPage),
+    sort: toValue(sort),
+    pageIndex: toValue(pageIndex),
+  }));
 
   const { data, error, status, execute } = await useRisBackend<Page>(
     searchEndpointUrl,

--- a/frontend/src/composables/useRecentSectionSearchResults.spec.ts
+++ b/frontend/src/composables/useRecentSectionSearchResults.spec.ts
@@ -1,0 +1,161 @@
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Ref } from "vue";
+import { ref } from "vue";
+import type { AnyDocument, SearchResult } from "~/types/api";
+import { DocumentKind } from "~/types/api";
+import {
+  RECENT_SECTION_DOCUMENT_KINDS,
+  useRecentSectionSearchResults,
+} from "./useRecentSectionSearchResults";
+
+type MockedOptions = {
+  key: string;
+  query: { query: string; size: number; sort: string; pageIndex: number };
+};
+
+type MockedRequest = {
+  data: Ref<{ member: SearchResult<AnyDocument>[] } | null>;
+  error: Ref<Error | null>;
+  status: Ref<string>;
+  execute: () => void;
+  refresh: () => void;
+  clear: () => void;
+};
+
+function result(name: string) {
+  return {
+    item: { name },
+    textMatches: [],
+  } as unknown as SearchResult<AnyDocument>;
+}
+
+function mockRequest(
+  member: SearchResult<AnyDocument>[] | null,
+  error: Error | null = null,
+): MockedRequest {
+  return {
+    data: ref(member === null ? null : { member }),
+    error: ref(error),
+    status: ref("success"),
+    execute: vi.fn(),
+    refresh: vi.fn(),
+    clear: vi.fn(),
+  };
+}
+
+const { useRisBackendMock } = vi.hoisted(() => ({
+  useRisBackendMock: vi.fn(
+    (url: string, _options: MockedOptions): MockedRequest =>
+      mockRequest([result(url)]),
+  ),
+}));
+
+mockNuxtImport("useRisBackend", () => useRisBackendMock);
+
+describe("useRecentSectionSearchResults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useRisBackendMock.mockImplementation((url) => mockRequest([result(url)]));
+  });
+
+  it("issues one search per document kind", async () => {
+    const searches = await useRecentSectionSearchResults();
+
+    expect(useRisBackendMock).toHaveBeenCalledTimes(4);
+    expect(RECENT_SECTION_DOCUMENT_KINDS).toHaveLength(4);
+    expect(searches.map((s) => s.documentKind)).toEqual([
+      DocumentKind.Norm,
+      DocumentKind.CaseLaw,
+      DocumentKind.AdministrativeDirective,
+      DocumentKind.Literature,
+    ]);
+  });
+
+  it("calls the lucene endpoint matching each document kind", async () => {
+    await useRecentSectionSearchResults();
+
+    expect(useRisBackendMock.mock.calls.map((call) => call[0])).toEqual([
+      "/v1/document/lucene-search/legislation",
+      "/v1/document/lucene-search/case-law",
+      "/v1/document/lucene-search/administrative-directive",
+      "/v1/document/lucene-search/literature",
+    ]);
+  });
+
+  it("requests five results per document kind with the default sort", async () => {
+    await useRecentSectionSearchResults();
+
+    for (const call of useRisBackendMock.mock.calls) {
+      expect(call[1].query).toMatchObject({
+        size: 5,
+        sort: "default",
+        pageIndex: 0,
+      });
+    }
+  });
+
+  it("filters legislation down to the currently valid versions", async () => {
+    await useRecentSectionSearchResults();
+
+    expect(useRisBackendMock.mock.calls[0]![1].query.query).toMatch(
+      /^\(entry_into_force_date:<\d{4}-\d{2}-\d{2} AND \(\(expiry_date:>\d{4}-\d{2}-\d{2}\) OR \(NOT _exists_:expiry_date\)\)\)$/,
+    );
+  });
+
+  it("submits an empty query for the other document kinds", async () => {
+    await useRecentSectionSearchResults();
+
+    for (const call of useRisBackendMock.mock.calls.slice(1)) {
+      expect(call[1].query.query).toBe("");
+    }
+  });
+
+  it("uses a unique payload key per document kind", async () => {
+    await useRecentSectionSearchResults();
+
+    const keys = useRisBackendMock.mock.calls.map((call) => call[1].key);
+    expect(new Set(keys).size).toBe(4);
+  });
+
+  it("exposes the results of each search", async () => {
+    const searches = await useRecentSectionSearchResults();
+
+    expect(searches[0]!.searchResults.value).toEqual([
+      result("/v1/document/lucene-search/legislation"),
+    ]);
+  });
+
+  it("falls back to an empty list when a search returns no data", async () => {
+    useRisBackendMock.mockImplementation(() => mockRequest(null));
+
+    const searches = await useRecentSectionSearchResults();
+
+    expect(searches[0]!.searchResults.value).toEqual([]);
+  });
+
+  it("reports an error on the failing document kind only", async () => {
+    const failure = new Error("Search failed");
+
+    useRisBackendMock.mockImplementation((url) =>
+      url.endsWith("/case-law")
+        ? mockRequest(null, failure)
+        : mockRequest([result("Some document")]),
+    );
+
+    const searches = await useRecentSectionSearchResults();
+
+    const caseLaw = searches.find(
+      (s) => s.documentKind === DocumentKind.CaseLaw,
+    );
+    expect(caseLaw!.searchError.value).toBe(failure);
+    expect(caseLaw!.searchResults.value).toEqual([]);
+
+    for (const other of searches.filter(
+      (s) => s.documentKind !== DocumentKind.CaseLaw,
+    )) {
+      expect(other.searchError.value).toBeNull();
+      expect(other.searchResults.value).toEqual([result("Some document")]);
+    }
+  });
+});

--- a/frontend/src/composables/useRecentSectionSearchResults.ts
+++ b/frontend/src/composables/useRecentSectionSearchResults.ts
@@ -1,0 +1,59 @@
+import type { Page } from "~/components/Pagination.vue";
+import { DocumentKind } from "~/types/api";
+import {
+  buildLuceneQuery,
+  getLuceneSearchPath,
+} from "~/utils/search/luceneSearch";
+
+/** Document kinds shown in the "Aktuelles" section. */
+export const RECENT_SECTION_DOCUMENT_KINDS = [
+  DocumentKind.Norm,
+  DocumentKind.CaseLaw,
+  DocumentKind.AdministrativeDirective,
+  DocumentKind.Literature,
+] as const;
+
+/** A document kind shown in the "Aktuelles" section. */
+export type RecentSectionDocumentKind =
+  (typeof RECENT_SECTION_DOCUMENT_KINDS)[number];
+
+/** Number of results shown per document kind. */
+const RESULTS_PER_KIND = 5;
+
+/**
+ * Loads the results shown in the "Aktuelles" section of the landing page.
+ *
+ * @returns Search results
+ */
+export async function useRecentSectionSearchResults() {
+  const searches = RECENT_SECTION_DOCUMENT_KINDS.map((documentKind) => {
+    const url = getLuceneSearchPath(documentKind);
+
+    const query = buildLuceneQuery(
+      "",
+      { type: getDefaultDateFilterType(documentKind) },
+      documentKind,
+    );
+
+    const request = useRisBackend<Page>(url, {
+      key: `recent-section-${documentKind}`,
+      query: {
+        query,
+        size: RESULTS_PER_KIND,
+        sort: ADVANCED_SEARCH_DEFAULTS.sort,
+        pageIndex: ADVANCED_SEARCH_DEFAULTS.pageIndex,
+      },
+    });
+
+    return {
+      documentKind,
+      searchResults: computed(() => request.data.value?.member ?? []),
+      searchError: request.error,
+      request,
+    };
+  });
+
+  await Promise.all(searches.map(({ request }) => request));
+
+  return searches.map(({ request: _request, ...rest }) => rest);
+}

--- a/frontend/src/layouts/document.spec.ts
+++ b/frontend/src/layouts/document.spec.ts
@@ -1,8 +1,6 @@
 import { mockNuxtImport, renderSuspended } from "@nuxt/test-utils/runtime";
 import { screen } from "@testing-library/vue";
 import { describe, expect, it, vi } from "vitest";
-import IcBaselineSubject from "~icons/ic/baseline-subject";
-import IcOutlineInfo from "~icons/ic/outline-info";
 import type { TabView } from "~/components/documents/TabsLayout.vue";
 import DocumentLayout from "./document.vue";
 
@@ -13,8 +11,8 @@ const { useRouteMock } = vi.hoisted(() => ({
 mockNuxtImport("useRoute", () => useRouteMock);
 
 const defaultViews: OneOrMore<TabView> = [
-  { label: "Text", path: "text", icon: IcBaselineSubject },
-  { label: "Details", path: "details", icon: IcOutlineInfo },
+  { label: "Text", path: "text" },
+  { label: "Details", path: "details" },
 ];
 
 describe("document", () => {

--- a/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
+++ b/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import IcBaselineSubject from "~icons/ic/baseline-subject";
 import IcOutlineInfo from "~icons/ic/outline-info";
 import type { DetailsListItem } from "~/components/documents/DetailsList.vue";
 import type { MetadataItem } from "~/components/documents/Metadata.vue";
@@ -48,11 +47,10 @@ useCaselawSeo({ caseLaw: caseLaw.value, document: document.value });
 // Page contents ------------------------------------------
 
 const views: TabView[] = [
-  { path: "text", label: "Text", icon: IcBaselineSubject },
+  { path: "text", label: "Text" },
   {
     path: "details",
     label: "Details",
-    icon: IcOutlineInfo,
     analyticsId: "caselaw-metadata-tab",
   },
 ];

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -1,7 +1,4 @@
 <script setup lang="ts">
-import IcBaselineSubject from "~icons/ic/baseline-subject";
-import IcOutlineInfo from "~icons/ic/outline-info";
-import IcOutlineRestore from "~icons/ic/outline-settings-backup-restore";
 import { NuxtLink } from "#components";
 import type { BreadcrumbItem } from "~/components/Breadcrumbs.vue";
 import type { DetailsListItem } from "~/components/documents/DetailsList.vue";
@@ -211,13 +208,11 @@ const views = computed<OneOrMore<TabView>>(() => {
     {
       path: "details",
       label: "Details",
-      icon: IcOutlineInfo,
       analyticsId: "norm-metadata-tab",
     },
     {
       path: "versions",
       label: "Fassungen",
-      icon: IcOutlineRestore,
       analyticsId: "norm-versions-tab",
     },
   ] as const;
@@ -225,7 +220,6 @@ const views = computed<OneOrMore<TabView>>(() => {
   const textTab = {
     path: "text",
     label: "Text",
-    icon: IcBaselineSubject,
     analyticsId: "norm-text-tab",
   } as const;
 

--- a/frontend/src/pages/literaturnachweise/[documentNumber].vue
+++ b/frontend/src/pages/literaturnachweise/[documentNumber].vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import IcBaselineSubject from "~icons/ic/baseline-subject";
-import IcOutlineInfo from "~icons/ic/outline-info";
 import type { TabView } from "~/components/documents/TabsLayout.vue";
 import type { TreeItem } from "~/components/TreeView.vue";
 import { useSearchBackLink } from "~/composables/useSearchBackLink";
@@ -45,11 +43,10 @@ useLiteratureSeo({
 // Page contents ------------------------------------------
 
 const views: TabView[] = [
-  { path: "text", label: "Text", icon: IcBaselineSubject },
+  { path: "text", label: "Text" },
   {
     path: "details",
     label: "Details",
-    icon: IcOutlineInfo,
     analyticsId: "literature-metadata-tab",
   },
 ];

--- a/frontend/src/pages/startseite-v2/index.vue
+++ b/frontend/src/pages/startseite-v2/index.vue
@@ -106,62 +106,72 @@ useSeo({
     </nav>
   </section>
 
-  <section
-    class="content-wrapper content-grid bg-white py-24 md:py-40 lg:py-48 2xl:py-56"
-  >
-    <div class="content-grid-textblock xl:col-start-2">
-      <h2 class="typo-headline2-bold mb-8 wrap-break-word hyphens-auto">
-        Rechtsinformationen finden
-      </h2>
-      <p class="typo-body-regular mb-16 md:mb-24">
-        Nutzen Sie Stichwörter, Themen oder direkte Angaben wie Paragrafen,
-        Normen oder Aktenzeichen.
-      </p>
+  <section class="bg-white">
+    <div class="content-wrapper content-grid py-24 md:py-40 lg:py-48 2xl:py-56">
+      <div class="content-grid-textblock xl:col-start-2">
+        <h2 class="typo-headline2-bold mb-8 wrap-break-word hyphens-auto">
+          Rechtsinformationen finden
+        </h2>
+        <p class="typo-body-regular mb-16 md:mb-24">
+          Nutzen Sie Stichwörter, Themen oder direkte Angaben wie Paragrafen,
+          Normen oder Aktenzeichen.
+        </p>
 
-      <SearchSimpleSearchInput
-        full-width
-        input-placeholder="z.B. Mietrecht, § 535 BGB, 1 BvR 123/20 …"
-        model-value=""
-        @update:model-value="(query) => redirectToSearch(query)"
-        @empty-search="() => redirectToSearch()"
-      />
+        <SearchSimpleSearchInput
+          full-width
+          input-placeholder="z.B. Mietrecht, § 535 BGB, 1 BvR 123/20 …"
+          model-value=""
+          @update:model-value="(query) => redirectToSearch(query)"
+          @empty-search="() => redirectToSearch()"
+        />
+      </div>
     </div>
   </section>
 
-  <section
-    class="content-wrapper content-grid gap-y-16 border-t border-gray-400 bg-white py-24 md:gap-y-24 md:py-40 lg:py-48 2xl:py-56"
-  >
-    <div
-      class="col-span-12 md:col-span-6 lg:col-span-6 xl:col-span-5 xl:col-start-2"
-    >
-      <h2 class="typo-headline2-bold mb-8 wrap-break-word hyphens-auto">
-        Offene Rechtsdaten für neue Anwendungen
-      </h2>
-      <p class="typo-body-regular mb-8">
-        Unsere Rechtsinformationen stehen als Open Data zur Verfügung. Über
-        unsere Programmierschnittstelle (API) lassen sich die Daten einfach
-        abrufen, weiterverarbeiten und für eigene Anwendungen und Services
-        nutzen.
-      </p>
-      <p class="typo-body-regular">
-        Analysieren Sie Trends oder integrieren Sie Rechtstexte in Ihre
-        Anwendungen. Die API-Dokumentation steht in englischer Sprache zur
-        Verfügung.
-      </p>
+  <section class="border-t border-gray-400">
+    <div class="content-wrapper content-grid py-24 md:py-40 lg:py-48 2xl:py-56">
+      <div class="col-span-12 xl:col-span-10 xl:col-start-2">
+        <RecentUpdates />
+      </div>
     </div>
+  </section>
 
-    <AppCodeExample
-      class="col-span-12 self-start md:col-span-6 md:row-span-2 lg:col-span-5 lg:col-start-8 xl:col-span-4 xl:col-start-8"
-    />
-
-    <div class="col-span-12 md:col-span-6 md:row-start-2 xl:col-start-2">
-      <UiButton
-        class="w-full md:w-auto"
-        :as="ExternalLink"
-        url="https://docs.rechtsinformationen.bund.de"
+  <section class="border-t border-gray-400 bg-white">
+    <div
+      class="content-wrapper content-grid gap-y-16 py-24 md:gap-y-24 md:py-40 lg:py-48 2xl:py-56"
+    >
+      <div
+        class="col-span-12 md:col-span-6 lg:col-span-6 xl:col-span-5 xl:col-start-2"
       >
-        Zur API-Dokumentation
-      </UiButton>
+        <h2 class="typo-headline2-bold mb-8 wrap-break-word hyphens-auto">
+          Offene Rechtsdaten für neue Anwendungen
+        </h2>
+        <p class="typo-body-regular mb-8">
+          Unsere Rechtsinformationen stehen als Open Data zur Verfügung. Über
+          unsere Programmierschnittstelle (API) lassen sich die Daten einfach
+          abrufen, weiterverarbeiten und für eigene Anwendungen und Services
+          nutzen.
+        </p>
+        <p class="typo-body-regular">
+          Analysieren Sie Trends oder integrieren Sie Rechtstexte in Ihre
+          Anwendungen. Die API-Dokumentation steht in englischer Sprache zur
+          Verfügung.
+        </p>
+      </div>
+
+      <AppCodeExample
+        class="col-span-12 self-start md:col-span-6 md:row-span-2 lg:col-span-5 lg:col-start-8 xl:col-span-4 xl:col-start-8"
+      />
+
+      <div class="col-span-12 md:col-span-6 md:row-start-2 xl:col-start-2">
+        <UiButton
+          class="w-full md:w-auto"
+          :as="ExternalLink"
+          url="https://docs.rechtsinformationen.bund.de"
+        >
+          Zur API-Dokumentation
+        </UiButton>
+      </div>
     </div>
   </section>
 

--- a/frontend/src/pages/startseite-v2/index.vue
+++ b/frontend/src/pages/startseite-v2/index.vue
@@ -12,13 +12,6 @@ definePageMeta({
     { label: "Zum Inhalt", to: "#main" },
     { label: "Zum Fußbereich", to: "#footer" },
   ],
-  middleware: () => {
-    // For some reason our private feature flag composable doesn't work in this
-    // context, falling back to the runtime config directly instead
-    const config = useRuntimeConfig();
-    if (!config.public.privateFeaturesEnabled)
-      return navigateTo({ name: "index" });
-  },
 });
 
 useSeo({

--- a/frontend/src/pages/translations/[id].vue
+++ b/frontend/src/pages/translations/[id].vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import IcBaselineSubject from "~icons/ic/baseline-subject";
-import IcOutlineInfo from "~icons/ic/outline-info";
 import { NuxtLink } from "#components";
 import NormTranslationActionMenu from "~/components/documents/actionMenu/NormTranslationActionMenu.vue";
 import type { DetailsListItem } from "~/components/documents/DetailsList.vue";
@@ -64,13 +62,11 @@ const views: OneOrMore<TabView> = [
   {
     path: "text",
     label: "Text",
-    icon: IcBaselineSubject,
     analyticsId: "translation-text-tab",
   },
   {
     path: "details",
     label: "Details",
-    icon: IcOutlineInfo,
     analyticsId: "translation-metadata-tab",
   },
 ] as const;

--- a/frontend/src/pages/verwaltungsregelungen/[documentNumber].vue
+++ b/frontend/src/pages/verwaltungsregelungen/[documentNumber].vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import IcBaselineSubject from "~icons/ic/baseline-subject";
-import IcOutlineInfo from "~icons/ic/outline-info";
 import type { TabView } from "~/components/documents/TabsLayout.vue";
 import type { TreeItem } from "~/components/TreeView.vue";
 import { useSearchBackLink } from "~/composables/useSearchBackLink";
@@ -42,8 +40,8 @@ useAdministrativeDirectiveSeo({
 // Page contents ------------------------------------------
 
 const views: TabView[] = [
-  { path: "text", label: "Text", icon: IcBaselineSubject },
-  { path: "details", label: "Details", icon: IcOutlineInfo },
+  { path: "text", label: "Text" },
+  { path: "details", label: "Details" },
 ];
 
 const textSectionId = useId();

--- a/frontend/src/utils/search/luceneSearch.spec.ts
+++ b/frontend/src/utils/search/luceneSearch.spec.ts
@@ -1,0 +1,73 @@
+import { DocumentKind } from "~/types/api";
+import { buildLuceneQuery, getLuceneSearchPath } from "./luceneSearch";
+
+const allTime = { type: "allTime" } as const;
+const currentlyInForce = { type: "currentlyInForce" } as const;
+
+describe("luceneSearch", () => {
+  describe("getLuceneSearchPath", () => {
+    it.each([
+      [DocumentKind.Norm, "/v1/document/lucene-search/legislation"],
+      [DocumentKind.CaseLaw, "/v1/document/lucene-search/case-law"],
+      [DocumentKind.Literature, "/v1/document/lucene-search/literature"],
+      [
+        DocumentKind.AdministrativeDirective,
+        "/v1/document/lucene-search/administrative-directive",
+      ],
+      [DocumentKind.All, "/v1/document/lucene-search"],
+    ])("returns the endpoint for %s", (documentKind, expected) => {
+      expect(getLuceneSearchPath(documentKind)).toBe(expected);
+    });
+  });
+
+  describe("buildLuceneQuery", () => {
+    it("returns an empty string when there is nothing to filter by", () => {
+      expect(buildLuceneQuery("", undefined, DocumentKind.Norm)).toBe("");
+      expect(buildLuceneQuery("   ", allTime, DocumentKind.Norm)).toBe("");
+    });
+
+    it("wraps a user query in parentheses", () => {
+      expect(
+        buildLuceneQuery("test query", allTime, DocumentKind.CaseLaw),
+      ).toBe("(test query)");
+    });
+
+    it("trims the user query", () => {
+      expect(
+        buildLuceneQuery("  test  ", undefined, DocumentKind.CaseLaw),
+      ).toBe("(test)");
+    });
+
+    it("returns only the date filter when the user query is blank", () => {
+      expect(buildLuceneQuery("", currentlyInForce, DocumentKind.Norm)).toMatch(
+        /^\(entry_into_force_date:<\d{4}-\d{2}-\d{2} AND \(\(expiry_date:>\d{4}-\d{2}-\d{2}\) OR \(NOT _exists_:expiry_date\)\)\)$/,
+      );
+    });
+
+    it("combines the user query and the date filter with AND", () => {
+      expect(
+        buildLuceneQuery(
+          "test",
+          { type: "specificDate", from: "2024-01-01" },
+          DocumentKind.CaseLaw,
+        ),
+      ).toBe("(test) AND (DATUM:2024-01-01)");
+    });
+
+    it("drops a date filter that doesn't apply to the document kind", () => {
+      expect(
+        buildLuceneQuery("test", currentlyInForce, DocumentKind.CaseLaw),
+      ).toBe("(test)");
+    });
+
+    it("throws for unsupported filter types", () => {
+      expect(() =>
+        buildLuceneQuery(
+          "",
+          { type: "before", to: "2024-01-01" },
+          DocumentKind.Norm,
+        ),
+      ).toThrow("Attempted to convert unsupported filter type before to query");
+    });
+  });
+});

--- a/frontend/src/utils/search/luceneSearch.ts
+++ b/frontend/src/utils/search/luceneSearch.ts
@@ -1,0 +1,52 @@
+import { DocumentKind } from "~/types/api";
+import {
+  dateFilterToQuery,
+  type DateFilterValue,
+} from "~/utils/search/dateFilterType";
+
+/**
+ * Returns the Lucene search endpoint for a document kind.
+ *
+ * @param documentKind Kind of documents to search for
+ * @returns Path of the matching endpoint
+ */
+export function getLuceneSearchPath(documentKind: DocumentKind): string {
+  const baseUrl = "/v1/document/lucene-search";
+
+  if (documentKind === DocumentKind.CaseLaw) {
+    return baseUrl + "/case-law";
+  } else if (documentKind === DocumentKind.Norm) {
+    return baseUrl + "/legislation";
+  } else if (documentKind === DocumentKind.Literature) {
+    return baseUrl + "/literature";
+  } else if (documentKind === DocumentKind.AdministrativeDirective) {
+    return baseUrl + "/administrative-directive";
+  } else return baseUrl;
+}
+
+/**
+ * Combines a user query and a date filter into a single Lucene query.
+ *
+ * @param query Lucene query as entered by the user
+ * @param dateFilter Date filter to apply, if any
+ * @param documentKind Kind of documents to search for
+ * @returns Combined Lucene query, or an empty string if there is nothing to
+ *   filter by
+ */
+export function buildLuceneQuery(
+  query: string,
+  dateFilter: DateFilterValue | undefined,
+  documentKind: DocumentKind,
+): string {
+  const parts = [query];
+
+  if (dateFilter) {
+    const dateQuery = dateFilterToQuery(dateFilter, documentKind);
+    if (dateQuery) parts.push(dateQuery);
+  }
+
+  return parts
+    .filter((i) => !!i.trim())
+    .map((i) => `(${i.trim()})`)
+    .join(" AND ");
+}

--- a/frontend/src/utils/search/searchResults.ts
+++ b/frontend/src/utils/search/searchResults.ts
@@ -32,3 +32,22 @@ export function getTitleWithFallback(
   const value = candidates.find((c) => !!c) ?? TITLE_FALLBACK;
   return sanitizeSearchResult(value);
 }
+
+/** Heading levels a search result title can be rendered at. */
+export type SearchResultHeadingLevel = "2" | "3";
+
+/**
+ * Returns the tag name and typography class for a search result title.
+ *
+ * @param level Heading level to render the title at
+ * @returns Tag name and typography class to apply
+ */
+export function getSearchResultHeadline(level: SearchResultHeadingLevel) {
+  return {
+    tag: `h${level}`,
+    class:
+      level === "2"
+        ? "typo-headline-searchresult"
+        : "typo-headline-searchresult-compact",
+  };
+}


### PR DESCRIPTION
This PR:

- implements redesigned tabs for the new landing page, also updating document pages
- adds a new `h3` variant to the search teasers to be used on the landing page
- adds the "recent updates" section to the landing page
- fixes the overall landing page layout on `2xl` screens
- enables the new landing page on testphase

To be done in a follow-up PR:

- current search queries for the content are just placeholders, will be updated to the actual queries
- E2E tests with the correct queries