### PR TITLE
Add missing cl meta data to details tab

### DIFF
--- a/backend/e2e-data/caselaw/BDRE000800001/BDRE000800001.xml
+++ b/backend/e2e-data/caselaw/BDRE000800001/BDRE000800001.xml
@@ -75,7 +75,7 @@
                      </ris:nachgehendeEntscheidung>
                  </akn:implicitReference>
                  <akn:implicitReference ris:domainTerm="Rechtszug">
-                     <ris:nachgehendeEntscheidung domainTerm="Nachgehende Entscheidung">
+                     <ris:nachgehendeEntscheidung domainTerm="Nachgehende Entscheidung" art="nachgehend">
                          <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
                          <ris:entscheidungsdatum domainTerm="Entscheidungsdatum">2025-09-15</ris:entscheidungsdatum>
                          <ris:dokumentnummer domainTerm="Dokumentnummer">BDRE001000000</ris:dokumentnummer>
@@ -87,7 +87,7 @@
                      </ris:nachgehendeEntscheidung>
                  </akn:implicitReference>
                  <akn:implicitReference ris:domainTerm="Rechtszug">
-                     <ris:nachgehendeEntscheidung domainTerm="Nachgehende Entscheidung">
+                     <ris:nachgehendeEntscheidung domainTerm="Nachgehende Entscheidung" art="nachgehend">
                          <ris:dokumenttyp domainTerm="Dokumenttyp">Beschluss</ris:dokumenttyp>
                          <ris:entscheidungsdatum domainTerm="Entscheidungsdatum">2025-11-03</ris:entscheidungsdatum>
                          <ris:dokumentnummer domainTerm="Dokumentnummer">BDRE001100000</ris:dokumentnummer>

--- a/backend/e2e-data/caselaw/BDRE000800001/BDRE000800001.xml
+++ b/backend/e2e-data/caselaw/BDRE000800001/BDRE000800001.xml
@@ -51,6 +51,18 @@
                      </ris:vorgehendeEntscheidung>
                  </akn:implicitReference>
                  <akn:implicitReference ris:domainTerm="Rechtszug">
+                     <ris:vorgehendeEntscheidung domainTerm="Vorgehende Entscheidung">
+                         <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
+                         <ris:entscheidungsdatum domainTerm="Entscheidungsdatum">2023-05-20</ris:entscheidungsdatum>
+                         <ris:dokumentnummer domainTerm="Dokumentnummer">BDRE000600000</ris:dokumentnummer>
+                         <ris:aktenzeichen domainTerm="Aktenzeichen">XVI VL 12/97</ris:aktenzeichen>
+                         <ris:gericht domainTerm="Gericht">
+                             <ris:gerichtstyp domainTerm="Gerichtstyp">AG</ris:gerichtstyp>
+                             <ris:gerichtsort domainTerm="Gerichtsort">Wiesbaden</ris:gerichtsort>
+                         </ris:gericht>
+                     </ris:vorgehendeEntscheidung>
+                 </akn:implicitReference>
+                 <akn:implicitReference ris:domainTerm="Rechtszug">
                      <ris:nachgehendeEntscheidung domainTerm="Nachgehende Entscheidung" art="anhängig">
                          <ris:dokumenttyp domainTerm="Dokumenttyp">Beschluss</ris:dokumenttyp>
                          <ris:entscheidungsdatum domainTerm="Entscheidungsdatum">2025-06-01</ris:entscheidungsdatum>
@@ -61,6 +73,54 @@
                              <ris:gerichtsort domainTerm="Gerichtsort">Münster</ris:gerichtsort>
                          </ris:gericht>
                      </ris:nachgehendeEntscheidung>
+                 </akn:implicitReference>
+                 <akn:implicitReference ris:domainTerm="Rechtszug">
+                     <ris:nachgehendeEntscheidung domainTerm="Nachgehende Entscheidung">
+                         <ris:dokumenttyp domainTerm="Dokumenttyp">Urteil</ris:dokumenttyp>
+                         <ris:entscheidungsdatum domainTerm="Entscheidungsdatum">2025-09-15</ris:entscheidungsdatum>
+                         <ris:dokumentnummer domainTerm="Dokumentnummer">BDRE001000000</ris:dokumentnummer>
+                         <ris:aktenzeichen domainTerm="Aktenzeichen">XVI VL 34/99</ris:aktenzeichen>
+                         <ris:gericht domainTerm="Gericht">
+                             <ris:gerichtstyp domainTerm="Gerichtstyp">BVerwG</ris:gerichtstyp>
+                             <ris:gerichtsort domainTerm="Gerichtsort">Leipzig</ris:gerichtsort>
+                         </ris:gericht>
+                     </ris:nachgehendeEntscheidung>
+                 </akn:implicitReference>
+                 <akn:implicitReference ris:domainTerm="Rechtszug">
+                     <ris:nachgehendeEntscheidung domainTerm="Nachgehende Entscheidung">
+                         <ris:dokumenttyp domainTerm="Dokumenttyp">Beschluss</ris:dokumenttyp>
+                         <ris:entscheidungsdatum domainTerm="Entscheidungsdatum">2025-11-03</ris:entscheidungsdatum>
+                         <ris:dokumentnummer domainTerm="Dokumentnummer">BDRE001100000</ris:dokumentnummer>
+                         <ris:aktenzeichen domainTerm="Aktenzeichen">XVI VL 34/99</ris:aktenzeichen>
+                         <ris:gericht domainTerm="Gericht">
+                             <ris:gerichtstyp domainTerm="Gerichtstyp">OVG</ris:gerichtstyp>
+                             <ris:gerichtsort domainTerm="Gerichtsort">Berlin</ris:gerichtsort>
+                         </ris:gericht>
+                     </ris:nachgehendeEntscheidung>
+                 </akn:implicitReference>
+                 <akn:implicitReference ris:domainTerm="Rechtszug">
+                     <ris:nachgehendeEntscheidung domainTerm="Nachgehende Entscheidung" art="anhängig">
+                         <ris:dokumenttyp domainTerm="Dokumenttyp">Revision</ris:dokumenttyp>
+                         <ris:entscheidungsdatum domainTerm="Entscheidungsdatum">2026-02-18</ris:entscheidungsdatum>
+                         <ris:dokumentnummer domainTerm="Dokumentnummer">BDRE001200000</ris:dokumentnummer>
+                         <ris:aktenzeichen domainTerm="Aktenzeichen">XVI VL 34/99</ris:aktenzeichen>
+                         <ris:gericht domainTerm="Gericht">
+                             <ris:gerichtstyp domainTerm="Gerichtstyp">BVerwG</ris:gerichtstyp>
+                             <ris:gerichtsort domainTerm="Gerichtsort">Leipzig</ris:gerichtsort>
+                         </ris:gericht>
+                     </ris:nachgehendeEntscheidung>
+                 </akn:implicitReference>
+                 <akn:implicitReference ris:domainTerm="Norm">
+                     <ris:referenzNorm domainTerm="Norm">
+                         <ris:abkuerzung domainTerm="Abkürzung">BDG</ris:abkuerzung>
+                         <ris:einzelnorm domainTerm="Einzelnorm">
+                             <ris:bezeichnung domainTerm="Bezeichnung">§ 34</ris:bezeichnung>
+                             <ris:gesetzeskraft domainTerm="Gesetzeskraft">
+                                 <ris:gesetzeskraftTyp domainTerm="Typ der Gesetzeskraft">vereinbar mit höherrangigem Recht</ris:gesetzeskraftTyp>
+                                 <ris:geltungsbereich domainTerm="Geltungsbereich">Hessen</ris:geltungsbereich>
+                             </ris:gesetzeskraft>
+                         </ris:einzelnorm>
+                     </ris:referenzNorm>
                  </akn:implicitReference>
              </akn:otherReferences>
              <akn:otherAnalysis source="#ris">
@@ -100,6 +160,10 @@
                     <ris:sachgebiet domainTerm="Sachgebiet" sachgebiet-id="TT">Testbeendigung</ris:sachgebiet>
                 </ris:sachgebiete>
                 <ris:rechtskraft domainTerm="Rechtskraft">Ja</ris:rechtskraft>
+                <ris:streitjahre domainTerm="Streitjahre">
+                    <ris:streitjahr domainTerm="Streitjahr">2024</ris:streitjahr>
+                    <ris:streitjahr domainTerm="Streitjahr">2025</ris:streitjahr>
+                </ris:streitjahre>
 </ris:meta>
          </akn:proprietary>
       </akn:meta>

--- a/frontend/e2e/gerichtsentscheidungen.spec.ts
+++ b/frontend/e2e/gerichtsentscheidungen.spec.ts
@@ -230,6 +230,38 @@ test("can view details", { tag: ["@RISDEV-12108"] }, async ({ page }) => {
 });
 
 test(
+  "can view Gesetzeskraft, Streitjahre and linked decisions",
+  { tag: ["@RISDEV-12471"] },
+  async ({ page }) => {
+    await navigate(page, "/gerichtsentscheidungen/BDRE000800001");
+    await page.getByRole("tab", { name: "Details" }).click();
+    const detailsList = page.getByTestId("details-list");
+
+    await expect(
+      detailsList.getByRole("term").or(detailsList.getByRole("definition")),
+    ).toHaveText([
+      "Spruchkörper:",
+      "16. Kammer",
+      "Gesetzeskraft:",
+      "vereinbar mit höherrangigem Recht, Hessen",
+      "Streitjahre:",
+      "2024",
+      "2025",
+      "Vorgehende Entscheidungen:",
+      "VG Frankfurt, Beschluss vom 12. November 2024 - XVI VL 34/99",
+      "AG Wiesbaden, Urteil vom 20. Mai 2023 - XVI VL 12/97",
+      "Nachgehende Entscheidungen:",
+      "OVG Münster, Beschluss vom 1. Juni 2025 - XVI VL 34/99 (anhängig)",
+      "BVerwG Leipzig, Urteil vom 15. September 2025 - XVI VL 34/99",
+      "OVG Berlin, Beschluss vom 3. November 2025 - XVI VL 34/99",
+      "BVerwG Leipzig, Revision vom 18. Februar 2026 - XVI VL 34/99 (anhängig)",
+      "Download:",
+      "Diese Gerichtsentscheidung als ZIP herunterladen",
+    ]);
+  },
+);
+
+test(
   "hides empty detail fields and only shows populated ones",
   { tag: ["@RISDEV-12108"] },
   async ({ page }) => {

--- a/frontend/src/components/documents/DetailsList.vue
+++ b/frontend/src/components/documents/DetailsList.vue
@@ -4,6 +4,7 @@ import IcOutlineFileDownload from "~icons/ic/outline-file-download";
 export type TextEntry = {
   type: "text";
   label: string;
+  labelClass?: string;
   value?: string;
   valueClass?: string;
 };
@@ -11,18 +12,21 @@ export type TextEntry = {
 export type ListEntry = {
   type: "list";
   label: string;
+  labelClass?: string;
   values: string[];
 };
 
 export type BadgeEntry = {
   type: "badge";
   label: string;
+  labelClass?: string;
   values: string[];
 };
 
 export type HtmlEntry = {
   type: "html";
   label: string;
+  labelClass?: string;
   html?: string;
   htmlClass?: string;
 };
@@ -30,6 +34,7 @@ export type HtmlEntry = {
 export type LinkEntry = {
   type: "link";
   label: string;
+  labelClass?: string;
   url?: string;
   text: string;
   dataAttr?: string;
@@ -72,7 +77,8 @@ const visibleItems = computed(() =>
       class="col-span-12 grid grid-cols-subgrid items-baseline"
     >
       <dt
-        class="typo-label1-bold col-span-12 hyphens-auto md:col-span-3 xl:col-span-2"
+        class="typo-label1-bold col-span-12 hyphens-auto md:col-span-3 md:h-0 md:self-start md:overflow-visible xl:col-span-2"
+        :class="item.labelClass"
       >
         {{ item.label }}
       </dt>

--- a/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
+++ b/frontend/src/pages/gerichtsentscheidungen/[documentNumber].vue
@@ -118,6 +118,29 @@ const detailItems = computed<DetailsListItem[]>(() => [
     value: formatArray(caseLaw.value?.decisionName ?? []),
   },
   {
+    type: "list",
+    label: "Gesetzeskraft:",
+    values: caseLaw.value?.gesetzeskraft ?? [],
+  },
+  {
+    type: "list",
+    label: "Streitjahre:",
+    values: caseLaw.value?.streitjahre ?? [],
+  },
+  {
+    type: "list",
+    label: "Vorgehende\nEntscheidungen:",
+    labelClass: "md:whitespace-pre-line",
+    values: caseLaw.value?.previousDecisions ?? [],
+  },
+  {
+    type: "list",
+    label: "Nachgehende\nEntscheidungen:",
+    labelClass: "md:whitespace-pre-line",
+    values: caseLaw.value?.ensuingDecisions ?? [],
+  },
+
+  {
     type: "link",
     label: "Download:",
     url: getEncodingURL(caseLaw.value?.encoding, "application/zip"),


### PR DESCRIPTION
 This PR adds the case law fields that were already exposed on the caselaw API endpoint — gesetzeskraft, streitjahre, vorgehendeEntscheidungen, nachgehendeEntscheidungen — to the case law detail page's UI:

- Details tab: renders "Gesetzeskraft", "Streitjahre", "Vorgehende Entscheidungen", and "Nachgehende Entscheidungen" as new list entries.
- DetailsList.vue: fixed a layout bug where a long label wrapping to two lines left a visual gap before the next value, and added a labelClass prop so specific items (the two "…Entscheidungen" labels) can force a two-line break via whitespace-pre-line regardless of available width.
- E2E fixture (BDRE000800001.xml): extended with multiple previous/ensuing decisions and a gesetzeskraft/streitjahre example, to exercise the new fields.
- E2E test: added coverage asserting the full formatted details list for BDRE000800001, including all four new fields.