### PR TITLE
 RISDEV-11959 rename abbreviation field for norms

### DIFF
--- a/backend/src/main/resources/openSearch/norms_index_template.json
+++ b/backend/src/main/resources/openSearch/norms_index_template.json
@@ -103,6 +103,16 @@
             }
           }
         },
+        "abbreviation": {
+          "type": "text",
+          "analyzer": "custom_german_analyzer",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "normalized_keyword"
+            }
+          }
+        },
         "ris_abbreviation": {
           "type": "text",
           "analyzer": "custom_german_analyzer",


### PR DESCRIPTION
- this will replace the existing `official_abbreviation` with `abbreviation` field, (as it contains the fallback logic and is not always the "official" abbreviation anymore)
- to prevent issues the fields will exist in parallel for a short period of time and then the `official_abbreviation` field is removed

RISDEV-11959