### PR TITLE
RISDEV-0000 use latest cosign release

### DIFF
--- a/.github/workflows/scan-attest-sign-image.yml
+++ b/.github/workflows/scan-attest-sign-image.yml
@@ -113,8 +113,6 @@ jobs:
       - name: Install Cosign
         if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
-        with:
-         cosign-release: "v2.6.0" # We need to use v2.X.X because of major version GHA v4.X.X and broken image verification of Kyverno
 
       - name: Attest vulnerability scan
         if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}


### PR DESCRIPTION
- kyverno now supports cosign v3 signatures so we can use the latest version

RISDEV-0000