### PR TITLE
RISDEV-0000 define type discriminator on AbstractDocumentSchema

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/AbstractDocumentSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/AbstractDocumentSchema.java
@@ -2,6 +2,8 @@ package de.bund.digitalservice.ris.search.schema;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Represents a base interface for document search schemas used in various legal or informational
@@ -38,6 +40,18 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
       value = AdministrativeDirectiveSearchSchema.class,
       name = "AdministrativeDirective")
 })
+@Schema(
+    discriminatorProperty = "@type",
+    discriminatorMapping = {
+      @DiscriminatorMapping(schema = CaseLawSearchSchema.class, value = "Decision"),
+      @DiscriminatorMapping(schema = LiteratureSearchSchema.class, value = "Literature"),
+      @DiscriminatorMapping(
+          schema = LegislationExpressionSearchSchema.class,
+          value = "Legislation"),
+      @DiscriminatorMapping(
+          schema = AdministrativeDirectiveSearchSchema.class,
+          value = "AdministrativeDirective")
+    })
 public sealed interface AbstractDocumentSchema
     permits AdministrativeDirectiveSearchSchema,
         CaseLawSearchSchema,

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/CaseLawSearchSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/CaseLawSearchSchema.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.search.schema;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
@@ -8,6 +9,7 @@ import lombok.Builder;
 
 /** A DTO for court decisions in a specific encoding, following schema.org naming guidelines. */
 @Builder
+@JsonTypeName("Decision")
 public record CaseLawSearchSchema(
     @Schema(example = "KARE000000000", requiredMode = Schema.RequiredMode.REQUIRED)
         String documentNumber,

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/SwaggerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/SwaggerIntegrationTest.java
@@ -62,6 +62,10 @@ class SwaggerIntegrationTest extends ContainersIntegrationBase {
                 Matchers.is("Legislation")))
         .andExpect(
             jsonPath(
+                "$.components.schemas.LegislationExpressionSchema.properties['@type'].example",
+                Matchers.is("Legislation")))
+        .andExpect(
+            jsonPath(
                 "$.tags[*].name",
                 Matchers.containsInAnyOrder(
                     "All documents",

--- a/frontend/src/public/openapi.json
+++ b/frontend/src/public/openapi.json
@@ -3541,7 +3541,13 @@
       },
       "AbstractDocumentSchema" : {
         "discriminator" : {
-          "propertyName" : "@type"
+          "propertyName" : "@type",
+          "mapping" : {
+            "Decision" : "#/components/schemas/CaseLawSearchSchema",
+            "Literature" : "#/components/schemas/LiteratureSearchSchema",
+            "Legislation" : "#/components/schemas/LegislationExpressionSearchSchema",
+            "AdministrativeDirective" : "#/components/schemas/AdministrativeDirectiveSearchSchema"
+          }
         },
         "properties" : {
           "@type" : {

--- a/frontend/src/types/api-generated.d.ts
+++ b/frontend/src/types/api-generated.d.ts
@@ -1022,9 +1022,7 @@ export interface components {
             member: components["schemas"]["SearchMemberSchemaLiteratureSearchSchema"][];
             view: components["schemas"]["PartialCollectionViewSchema"];
         };
-        LiteratureSearchSchema: {
-            "@type": "LiteratureSearchSchema";
-        } & (Omit<components["schemas"]["AbstractDocumentSchema"], "@type"> & {
+        LiteratureSearchSchema: Omit<components["schemas"]["AbstractDocumentSchema"], "@type"> & {
             /** @example Literature */
             "@type"?: string;
             /** @example KALU000000000 */
@@ -1086,7 +1084,13 @@ export interface components {
              */
             literatureType: string;
             encoding: components["schemas"]["DocumentEncodingSchema"][];
-        });
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            "@type": "Literature";
+        };
         PartialCollectionViewSchema: {
             /** @example hydra:PartialCollectionView */
             "@type"?: string;
@@ -1245,9 +1249,7 @@ export interface components {
             view: components["schemas"]["PartialCollectionViewSchema"];
         };
         /** @description A legislation expression and references to its manifestations. */
-        LegislationExpressionSearchSchema: {
-            "@type": "LegislationExpressionSearchSchema";
-        } & (Omit<components["schemas"]["AbstractDocumentSchema"], "@type"> & {
+        LegislationExpressionSearchSchema: Omit<components["schemas"]["AbstractDocumentSchema"], "@type"> & {
             /** @example Legislation */
             "@type"?: string;
             /** @example /v1/legislation/eli/bund/bgbl-1/1975/s1760/1998-01-29/10/deu */
@@ -1282,7 +1284,13 @@ export interface components {
              */
             legislationLegalForce: "InForce" | "NotInForce" | "PartiallyInForce";
             encoding: components["schemas"]["LegislationObjectSchema"][];
-        });
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            "@type": "Legislation";
+        };
         LegislationObjectSchema: {
             /** @example LegislationObject */
             "@type"?: string;
@@ -1406,9 +1414,7 @@ export interface components {
         AbstractDocumentSchema: {
             "@type": string;
         };
-        AdministrativeDirectiveSearchSchema: {
-            "@type": "AdministrativeDirectiveSearchSchema";
-        } & (Omit<components["schemas"]["AbstractDocumentSchema"], "@type"> & {
+        AdministrativeDirectiveSearchSchema: Omit<components["schemas"]["AbstractDocumentSchema"], "@type"> & {
             /** @example AdministrativeDirective */
             "@type"?: string;
             /** @example KALU000000000 */
@@ -1443,10 +1449,14 @@ export interface components {
              */
             entryIntoForceDate?: string;
             encoding: components["schemas"]["DocumentEncodingSchema"][];
-        });
-        CaseLawSearchSchema: {
-            "@type": "CaseLawSearchSchema";
-        } & (Omit<components["schemas"]["AbstractDocumentSchema"], "@type"> & {
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            "@type": "AdministrativeDirective";
+        };
+        CaseLawSearchSchema: Omit<components["schemas"]["AbstractDocumentSchema"], "@type"> & {
             /** @example Decision */
             "@type"?: string;
             /** @example KARE000000000 */
@@ -1484,7 +1494,13 @@ export interface components {
             "@id": string;
             /** @example de */
             inLanguage: string;
-        });
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            "@type": "Decision";
+        };
         CollectionSchemaSearchMemberSchemaAbstractDocumentSchema: {
             /** @example hydra:Collection */
             "@type"?: string;


### PR DESCRIPTION
Define discriminator of SearchSchemas on AbstractDocumentSchema parent. 
This stops the openapi.json from polluting the Schemas with class name type definitions and using the actual type name.

This enables us to use the actual SearchSchemas in the nuxt application