### PR TITLE
RISDEV-11959 remove handling for undefined norm abberviation

### DIFF
--- a/frontend/src/components/search/NormSearchResult.vue
+++ b/frontend/src/components/search/NormSearchResult.vue
@@ -51,9 +51,7 @@ const resultTypeId = useId();
 const headerItems = computed(() => {
   const items: SearchResultHeaderItem[] = [];
 
-  if (searchResult.item.abbreviation) {
-    items.push({ type: "text", value: searchResult.item.abbreviation });
-  }
+  items.push({ type: "text", value: searchResult.item.abbreviation });
 
   const validityStatus = formatNormValidity(searchResult.item.temporalCoverage);
 

--- a/frontend/src/composables/useNormSeo.spec.ts
+++ b/frontend/src/composables/useNormSeo.spec.ts
@@ -43,14 +43,6 @@ describe("useNormSeo", () => {
       );
     });
 
-    it("uses 'Gesetz' as fallback if abbreviation is missing", () => {
-      useNormSeo({ norm: {} as LegislationExpression });
-
-      expect(useSeo).toHaveBeenCalledWith(
-        expect.objectContaining({ title: "Gesetz" }),
-      );
-    });
-
     it.each([
       [undefined, undefined, ""],
       [dayjs("01-01-2025"), undefined, ", vom 01.01.2025"],
@@ -98,7 +90,9 @@ describe("useNormSeo", () => {
 
   describe("norm description", () => {
     it("returns empty string if norm has no alternateName or name", () => {
-      useNormSeo({ norm: {} as LegislationExpression });
+      useNormSeo({
+        norm: { abbreviation: "FooBar" } as LegislationExpression,
+      });
 
       expect(useSeo).toHaveBeenCalledWith(
         expect.objectContaining({ description: "" }),
@@ -108,6 +102,7 @@ describe("useNormSeo", () => {
     it("uses alternateName as description", () => {
       useNormSeo({
         norm: {
+          abbreviation: "FooBar",
           name: "Gesetz über Foo und Bar",
           alternateName: "Foo Bar Gesetz",
         } as LegislationExpression,
@@ -120,7 +115,10 @@ describe("useNormSeo", () => {
 
     it("falls back to name if alternateName is absent", () => {
       useNormSeo({
-        norm: { name: "Gesetz über Foo und Bar" } as LegislationExpression,
+        norm: {
+          abbreviation: "FooBar",
+          name: "Gesetz über Foo und Bar",
+        } as LegislationExpression,
       });
 
       expect(useSeo).toHaveBeenCalledWith(
@@ -131,7 +129,10 @@ describe("useNormSeo", () => {
     it("truncates description at 150 characters", () => {
       const longTitle = "Ein sehr langes Gesetz ".repeat(7).trim(); // 154 chars
       useNormSeo({
-        norm: { alternateName: longTitle } as LegislationExpression,
+        norm: {
+          abbreviation: "FooBar",
+          alternateName: longTitle,
+        } as LegislationExpression,
       });
 
       expect(useSeo).toHaveBeenCalledWith(
@@ -144,16 +145,6 @@ describe("useNormSeo", () => {
   });
 
   describe("norm og:title", () => {
-    it("empty if norm has no abbreviation or alternateName", () => {
-      useNormSeo({
-        norm: {} as LegislationExpression,
-      });
-
-      expect(useSeo).toHaveBeenCalledWith(
-        expect.objectContaining({ ogTitle: undefined }),
-      );
-    });
-
     it("uses abbreviation as base title", () => {
       useNormSeo({
         norm: {
@@ -164,16 +155,6 @@ describe("useNormSeo", () => {
 
       expect(useSeo).toHaveBeenCalledWith(
         expect.objectContaining({ ogTitle: "FooBar" }),
-      );
-    });
-
-    it("falls back to alternateName if abbreviation is absent", () => {
-      useNormSeo({
-        norm: { alternateName: "Foo Bar Gesetz" } as LegislationExpression,
-      });
-
-      expect(useSeo).toHaveBeenCalledWith(
-        expect.objectContaining({ ogTitle: "Foo Bar Gesetz" }),
       );
     });
 

--- a/frontend/src/composables/useNormSeo.ts
+++ b/frontend/src/composables/useNormSeo.ts
@@ -30,7 +30,7 @@ function buildTitle(
     ? `, ${getValidityStatusLabel(validityStatus)}`
     : "";
 
-  return `${norm.abbreviation || "Gesetz"}${validityIntervalPart}${validityStatusPart}`;
+  return `${norm.abbreviation}${validityIntervalPart}${validityStatusPart}`;
 }
 
 /**
@@ -67,10 +67,7 @@ function buildOgTitle(
   validFrom?: Dayjs,
   normValidityStatus?: ValidityStatus,
 ) {
-  const shortTitle = norm.alternateName?.trim();
-  const baseTitle = norm.abbreviation?.trim() || shortTitle;
-
-  if (!baseTitle) return undefined;
+  const baseTitle = norm.abbreviation.trim();
 
   const parts: string[] = [];
 

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/[eId].vue
@@ -50,7 +50,7 @@ if (error.value || !data.value) {
 
 const norm = computed(() => data.value.legislation);
 
-const normTitle = computed(() => getNormBreadcrumbTitle(norm.value));
+const normAbbreviation = computed(() => norm.value.abbreviation);
 
 const articleHtml = computed(() => data.value.htmlBody);
 
@@ -93,7 +93,7 @@ const article: Ref<Article | undefined> = computed(() =>
 );
 
 useArticleSeo({
-  abbreviation: norm.value?.abbreviation,
+  abbreviation: normAbbreviation.value,
   article: article.value,
   articleHeadlineHtml: data.value.articleHeading,
   articleHtml: data.value.htmlBody,
@@ -155,7 +155,11 @@ const breadcrumbItems: Ref<BreadcrumbItem[]> = computed(() => {
     ? (findNodePath(tableOfContents.value, eId.value) ?? [])
     : [];
 
-  const title = truncateAtWord(normTitle.value, NORM_INFO_MAX_LENGTH, true);
+  const title = truncateAtWord(
+    normAbbreviation.value,
+    NORM_INFO_MAX_LENGTH,
+    true,
+  );
 
   const fromQuery = route.query.from
     ? { from: route.query.from as string }
@@ -169,7 +173,7 @@ const breadcrumbItems: Ref<BreadcrumbItem[]> = computed(() => {
     {
       label: title,
       route: { path: normExpressionPath, query: fromQuery },
-      extendedLabel: normTitle.value,
+      extendedLabel: normAbbreviation.value,
     },
   ];
 
@@ -245,7 +249,7 @@ const metadataItems = computed<MetadataItem[]>(() => {
       class="content-wrapper mb-24 space-y-24 sm:mb-32 sm:space-y-32 md:mb-40 md:space-y-40"
     >
       <p class="typo-headline3-regular mb-8">
-        {{ normTitle }}
+        {{ normAbbreviation }}
       </p>
       <h1
         class="typo-headline1-bold wrap-break-word hyphens-auto"
@@ -301,7 +305,7 @@ const metadataItems = computed<MetadataItem[]>(() => {
         <template #sidebar>
           <DocumentsTableOfContents
             v-if="tableOfContents.length"
-            :subheading="normTitle"
+            :subheading="normAbbreviation"
             :subheading-to="normExpressionRoute"
             :table-of-contents="tableOfContents"
             :selected-key="eId"

--- a/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
+++ b/frontend/src/pages/gesetze/eli/[jurisdiction]/[agent]/[year]/[naturalIdentifier]/[pointInTime]/[version]/[language]/index.vue
@@ -66,7 +66,6 @@ const abbreviation = data.value.legislation.abbreviation;
  * longer change once the page has loaded.
  */
 async function fetchTranslationUrl() {
-  if (!abbreviation) return "";
   const { translations } = await fetchTranslationListWithIdFilter(abbreviation);
   return translations.value?.length ? `/translations/${abbreviation}` : "";
 }
@@ -125,7 +124,7 @@ const detailItems = computed<DetailsListItem[]>(() => [
     type: "link",
     label: "Download:",
     url: zipUrl.value,
-    text: `${metadata.value.abbreviation ?? "Inhalte"} als ZIP herunterladen`,
+    text: `${metadata.value.abbreviation} als ZIP herunterladen`,
     dataAttr: "xml-zip-view",
   },
 ]);
@@ -167,9 +166,7 @@ useNormSeo({
   validityStatus: validityStatus.value,
 });
 
-const normBreadcrumbTitle = computed(() =>
-  getNormBreadcrumbTitle(metadata.value),
-);
+const normBreadcrumbTitle = computed(() => metadata.value.abbreviation);
 
 const searchBackLink = useSearchBackLink(DocumentKind.Norm);
 
@@ -194,7 +191,7 @@ const metadataItems = computed<MetadataItem[]>(() => {
     {
       type: "text",
       label: "Abkürzung",
-      value: abbreviation ?? "",
+      value: abbreviation,
     },
     {
       type: "text",

--- a/frontend/src/utils/norm.spec.ts
+++ b/frontend/src/utils/norm.spec.ts
@@ -6,7 +6,9 @@ import { describe, expect, vi } from "vitest";
 import type { LegislationExpression } from "~/types/api";
 import {
   getEinzelnormEIdFromHref,
+  getManifestationUrl,
   getMostRelevantExpression,
+  getNormTitle,
   getValidityStatus,
   isNormBodyEmpty,
   temporalCoverageToValidityInterval,
@@ -107,6 +109,54 @@ describe("getValidityStatus", () => {
   });
 });
 
+describe("getManifestationUrl", () => {
+  type EncodingExpression = Pick<LegislationExpression, "encoding">;
+
+  it("returns undefined if metadata is undefined", () => {
+    expect(getManifestationUrl(undefined, "application/xml")).toBeUndefined();
+  });
+
+  it("returns undefined if no encoding matches the format", () => {
+    const metadata: EncodingExpression = {
+      encoding: [
+        {
+          "@id": "",
+          contentUrl: "html-url",
+          encodingFormat: "text/html",
+          inLanguage: "de",
+        },
+      ],
+    };
+
+    expect(
+      getManifestationUrl(metadata as LegislationExpression, "application/xml"),
+    ).toBeUndefined();
+  });
+
+  it("returns the contentUrl of the matching encoding", () => {
+    const metadata: EncodingExpression = {
+      encoding: [
+        {
+          "@id": "",
+          contentUrl: "html-url",
+          encodingFormat: "text/html",
+          inLanguage: "de",
+        },
+        {
+          "@id": "",
+          contentUrl: "xml-url",
+          encodingFormat: "application/xml",
+          inLanguage: "de",
+        },
+      ],
+    };
+
+    expect(
+      getManifestationUrl(metadata as LegislationExpression, "application/xml"),
+    ).toBe("xml-url");
+  });
+});
+
 type PartialExpression = Pick<
   LegislationExpression,
   "legislationLegalForce" | "temporalCoverage" | "legislationIdentifier"
@@ -116,6 +166,12 @@ const currentExpression: PartialExpression = {
   legislationLegalForce: "InForce",
   temporalCoverage: "1999-01-01/..",
   legislationIdentifier: "currentExpression",
+};
+
+const secondCurrentExpression: PartialExpression = {
+  legislationLegalForce: "InForce",
+  temporalCoverage: "1999-06-01/..",
+  legislationIdentifier: "secondCurrentExpression",
 };
 
 const veryOldExpression: PartialExpression = {
@@ -150,6 +206,45 @@ function transform(
   );
 }
 
+describe("getNormTitle", () => {
+  type TitleExpression = Pick<
+    LegislationExpression,
+    "name" | "alternateName" | "abbreviation"
+  >;
+
+  it("uses name if present", () => {
+    const norm: TitleExpression = {
+      name: "Gesetz über Foo und Bar",
+      alternateName: "Foo Bar Gesetz",
+      abbreviation: "FooBar",
+    };
+
+    expect(getNormTitle(norm as LegislationExpression)).toBe(
+      "Gesetz über Foo und Bar",
+    );
+  });
+
+  it("falls back to alternateName if name is empty", () => {
+    const norm: TitleExpression = {
+      name: "",
+      alternateName: "Foo Bar Gesetz",
+      abbreviation: "FooBar",
+    };
+
+    expect(getNormTitle(norm as LegislationExpression)).toBe("Foo Bar Gesetz");
+  });
+
+  it("falls back to abbreviation if name and alternateName are absent", () => {
+    const norm: TitleExpression = {
+      name: "",
+      alternateName: undefined,
+      abbreviation: "FooBar",
+    };
+
+    expect(getNormTitle(norm as LegislationExpression)).toBe("FooBar");
+  });
+});
+
 describe("getMostRelevantExpression", () => {
   beforeAll(() => {
     vi.useFakeTimers();
@@ -179,6 +274,16 @@ describe("getMostRelevantExpression", () => {
   it("picks the most recent past expression if there is no current or future expression", () => {
     const testCase = transform([veryOldExpression, oldExpression]);
     expect(getMostRelevantExpression(testCase)).toBe("oldExpression");
+  });
+
+  it("picks the first active expression if there is more than one", () => {
+    const testCase = transform([currentExpression, secondCurrentExpression]);
+
+    expect(getMostRelevantExpression(testCase)).toBe("currentExpression");
+  });
+
+  it("returns null if there are no expressions", () => {
+    expect(getMostRelevantExpression([])).toBeNull();
   });
 });
 

--- a/frontend/src/utils/norm.spec.ts
+++ b/frontend/src/utils/norm.spec.ts
@@ -184,7 +184,10 @@ describe("getMostRelevantExpression", () => {
 
 describe("getNormMetadataItems", () => {
   it("creates correct labels", () => {
-    const result = getNormMetadataItems();
+    const result = getNormMetadataItems({
+      abbreviation: "",
+      temporalCoverage: "",
+    });
 
     expect(result.map((item) => item.label)).toEqual([
       "Abkürzung",
@@ -194,27 +197,12 @@ describe("getNormMetadataItems", () => {
     ]);
   });
 
-  it("converts empty properties to undefined values", () => {
+  it("converts invalid temporalCoverage to undefined/empty values", () => {
     const result = getNormMetadataItems({
-      abbreviation: undefined,
-      legislationIdentifier: "",
-      "@type": "Legislation",
-      "@id": "",
+      abbreviation: "",
       temporalCoverage: "",
-      legislationLegalForce: "NotInForce",
-      encoding: [
-        {
-          "@type": "LegislationObject",
-          "@id": "",
-          contentUrl: "",
-          encodingFormat: "",
-          inLanguage: "",
-        },
-      ],
-      hasPart: [],
     });
 
-    expect(result[0]).toMatchObject({ type: "text", value: undefined });
     expect(result[1]).toMatchObject({ type: "badge", values: [] });
     expect(result[2]).toMatchObject({ type: "text", value: undefined });
     expect(result[3]).toMatchObject({ type: "text", value: undefined });
@@ -223,21 +211,7 @@ describe("getNormMetadataItems", () => {
   it("converts properties to correct values", () => {
     const result = getNormMetadataItems({
       abbreviation: "ABC",
-      legislationIdentifier: "",
-      "@type": "Legislation",
-      "@id": "",
       temporalCoverage: "2025-05-06/2037-03-31",
-      legislationLegalForce: "NotInForce",
-      encoding: [
-        {
-          "@type": "LegislationObject",
-          "@id": "",
-          contentUrl: "",
-          encodingFormat: "",
-          inLanguage: "",
-        },
-      ],
-      hasPart: [],
     });
 
     expect(result[0]).toMatchObject({ type: "text", value: "ABC" });
@@ -254,21 +228,7 @@ describe("getNormMetadataItems", () => {
     (temporalCoverage, expectedLabel, expectedColor) => {
       const result = getNormMetadataItems({
         abbreviation: "ABC",
-        legislationIdentifier: "",
-        "@type": "Legislation",
-        "@id": "",
         temporalCoverage: temporalCoverage,
-        legislationLegalForce: "InForce", // not relevant for validity status calculation
-        encoding: [
-          {
-            "@type": "LegislationObject",
-            "@id": "",
-            contentUrl: "",
-            encodingFormat: "",
-            inLanguage: "",
-          },
-        ],
-        hasPart: [],
       });
 
       expect(result[1]).toMatchObject({

--- a/frontend/src/utils/norm.ts
+++ b/frontend/src/utils/norm.ts
@@ -93,12 +93,8 @@ export function getEinzelnormEIdFromHref(href: string): string | null {
   return match?.[1] ?? null;
 }
 
-export function getNormBreadcrumbTitle(norm: LegislationExpression): string {
-  return norm.abbreviation || norm.alternateName || norm.name || "";
-}
-
 export function getNormTitle(norm: LegislationExpression): string {
-  return norm.name || norm.alternateName || norm.abbreviation || "";
+  return norm.name || norm.alternateName || norm.abbreviation;
 }
 
 export function getMostRelevantExpression(
@@ -136,19 +132,21 @@ export function getMostRelevantExpression(
   throw new Error("Could not identify the most relevant expression");
 }
 
-export function getNormMetadataItems(
-  norm?: Partial<LegislationExpression>,
-): MetadataItem[] {
-  const validityInterval = temporalCoverageToValidityInterval(
-    norm?.temporalCoverage,
-  );
+export function getNormMetadataItems({
+  abbreviation,
+  temporalCoverage,
+}: {
+  abbreviation: string;
+  temporalCoverage: string;
+}): MetadataItem[] {
+  const validityInterval = temporalCoverageToValidityInterval(temporalCoverage);
 
-  const validityStatus = formatNormValidity(norm?.temporalCoverage);
+  const validityStatus = formatNormValidity(temporalCoverage);
   return [
     {
       type: "text",
       label: "Abkürzung",
-      value: norm?.abbreviation,
+      value: abbreviation,
     },
     {
       type: "badge",

--- a/frontend/src/utils/norm.ts
+++ b/frontend/src/utils/norm.ts
@@ -103,33 +103,31 @@ export function getMostRelevantExpression(
   if (expressions.length === 0) {
     return null;
   }
+
   const activeExpressions = expressions.filter(
     (expression) => expression.legislationLegalForce === "InForce",
   );
+
   if (activeExpressions.length > 0) {
-    if (activeExpressions.length > 1) {
-      console.info(
-        "found more than one matching active expressions",
-        activeExpressions,
-      );
-    }
     return activeExpressions[0]?.legislationIdentifier;
   }
+
   const referenceDate = getCurrentDateInGermanyFormatted();
   const [future, past] = partition(
     expressions,
     (item) => item.temporalCoverage >= referenceDate,
   );
+
   if (future.length > 0) {
     return sortBy(future, "legislationLegalForce")[0]?.legislationIdentifier;
   }
+
   if (past.length > 0) {
     return (
       sortBy(past, "legislationLegalForce").at(-1)?.legislationIdentifier ??
       null
     );
   }
-  throw new Error("Could not identify the most relevant expression");
 }
 
 export function getNormMetadataItems({


### PR DESCRIPTION
- as the abbreviation is now always defined, no need for undefined checks and logic

RISDEV-11959