### PR TITLE
Risdev-11398 literature context

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/AdvancedSearchController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/AdvancedSearchController.java
@@ -224,7 +224,7 @@ public class AdvancedSearchController {
       SearchPage<Literature> page = advancedSearchService.searchLiterature(query, sortedPageable);
       return ResponseEntity.ok()
           .contentType(MediaType.APPLICATION_JSON)
-          .body(LiteratureSearchSchemaMapper.fromSearchPage(page));
+          .body(LiteratureSearchSchemaMapper.fromSearchPage(page, jsonldContextPath));
     } catch (UncategorizedElasticsearchException e) {
       LuceneQueryTools.checkForInvalidQuery(e);
       throw e;

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/LiteratureController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/LiteratureController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import de.bund.digitalservice.ris.html.service.xslt.LiteratureXsltTransformer;
 import de.bund.digitalservice.ris.html.service.xslt.SliLiteratureXsltTransformer;
 import de.bund.digitalservice.ris.search.config.ApiConfig;
+import de.bund.digitalservice.ris.search.config.ServerConfig;
 import de.bund.digitalservice.ris.search.exception.CustomValidationException;
 import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
 import de.bund.digitalservice.ris.search.mapper.ChangelogResponseMapper;
@@ -61,6 +62,7 @@ public class LiteratureController {
   private final LiteratureXsltTransformer xsltTransformer;
   private final SliLiteratureXsltTransformer sliXsltTransformer;
   private final ChangelogService<LiteratureBucket> changelogService;
+  private final String jsonldContextPath;
 
   /**
    * Constructor for LiteratureController.
@@ -74,11 +76,13 @@ public class LiteratureController {
       LiteratureService literatureService,
       LiteratureXsltTransformer literatureXsltTransformer,
       SliLiteratureXsltTransformer sliLiteratureXsltTransformer,
-      ChangelogService<LiteratureBucket> changelogService) {
+      ChangelogService<LiteratureBucket> changelogService,
+      ServerConfig serverConfig) {
     this.literatureService = literatureService;
     this.xsltTransformer = literatureXsltTransformer;
     this.sliXsltTransformer = sliLiteratureXsltTransformer;
     this.changelogService = changelogService;
+    this.jsonldContextPath = serverConfig.getBackEndUrl() + ApiConfig.Paths.JSONLD_CONTEXT;
   }
 
   /**
@@ -105,7 +109,7 @@ public class LiteratureController {
     Literature unit = result.getFirst();
     return ResponseEntity.ok()
         .contentType(MediaType.APPLICATION_JSON)
-        .body(LiteratureSchemaMapper.fromDomain(unit));
+        .body(LiteratureSchemaMapper.fromDomain(unit, jsonldContextPath));
   }
 
   /**
@@ -212,7 +216,7 @@ public class LiteratureController {
               universalSearchParams, literatureSearchParams, sortedPageRequest);
       return ResponseEntity.ok()
           .contentType(MediaType.APPLICATION_JSON)
-          .body(LiteratureSearchSchemaMapper.fromSearchPage(page));
+          .body(LiteratureSearchSchemaMapper.fromSearchPage(page, jsonldContextPath));
     } catch (UncategorizedElasticsearchException e) {
       LuceneQueryTools.checkForInvalidQuery(e);
       throw e;

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureSchemaMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureSchemaMapper.java
@@ -20,14 +20,16 @@ public class LiteratureSchemaMapper {
    *
    * @param entity the {@link Literature} domain entity representing the literature details to be
    *     mapped
+   * @param remoteJsonContext the URL of the JSON-LD context document
    * @return a {@link LiteratureSchema} object containing the mapped literature data
    */
-  public static LiteratureSchema fromDomain(Literature entity) {
+  public static LiteratureSchema fromDomain(Literature entity, String remoteJsonContext) {
     var entityURI = ApiConfig.Paths.LITERATURE + "/" + entity.documentNumber();
     var encodings = EncodingSchemaFactory.documentEncodingSchemas(entityURI);
 
     return LiteratureSchema.builder()
         .id(entityURI)
+        .context(remoteJsonContext)
         .inLanguage("de")
         .documentNumber(entity.documentNumber())
         .yearsOfPublication(entity.yearsOfPublication())

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureSearchSchemaMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureSearchSchemaMapper.java
@@ -104,7 +104,6 @@ public class LiteratureSearchSchemaMapper {
         .inLanguage("de")
         .documentNumber(doc.documentNumber())
         .yearsOfPublication(doc.yearsOfPublication())
-        .firstPublicationDate(doc.firstPublicationDate())
         .documentTypes(doc.documentTypes())
         .dependentReferences(doc.dependentReferences())
         .independentReferences(doc.independentReferences())

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureSearchSchemaMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/LiteratureSearchSchemaMapper.java
@@ -128,11 +128,12 @@ public class LiteratureSearchSchemaMapper {
    * @param <T> The type of content contained in the given {@link SearchPage}.
    * @param page The {@link SearchPage} object containing the search results and pagination data
    *     that will be transformed into a collection schema.
+   * @param remoteJsonContext the URL of the JSON-LD context document
    * @return A {@link CollectionSchema} containing a collection of {@link SearchMemberSchema}
    *     objects with transformed search results and metadata.
    */
   public static <T> CollectionSchema<SearchMemberSchema<LiteratureSearchSchema>> fromSearchPage(
-      final SearchPage<T> page) {
+      final SearchPage<T> page, String remoteJsonContext) {
     String collectionBasePath = ApiConfig.Paths.LITERATURE;
     PartialCollectionViewSchema view =
         PartialCollectionViewMapper.fromPage(collectionBasePath, page);
@@ -143,6 +144,7 @@ public class LiteratureSearchSchemaMapper {
 
     return CollectionSchema.<SearchMemberSchema<LiteratureSearchSchema>>builder()
         .id(id)
+        .context(remoteJsonContext)
         .totalItems(page.getTotalElements())
         .member(page.stream().map(LiteratureSearchSchemaMapper::fromSearchHit).toList())
         .view(view)

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/LiteratureSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/LiteratureSchema.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
  */
 @Builder
 public record LiteratureSchema(
+    @JsonProperty("@context") @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String context,
     @Schema(example = "KALU000000000", requiredMode = Schema.RequiredMode.REQUIRED)
         @JsonProperty("@id")
         String id,

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/LiteratureSearchSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/LiteratureSearchSchema.java
@@ -2,7 +2,6 @@ package de.bund.digitalservice.ris.search.schema;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 
@@ -37,11 +36,6 @@ public record LiteratureSearchSchema(
             example = "[2014, 2024-09]",
             requiredMode = Schema.RequiredMode.REQUIRED)
         List<String> yearsOfPublication,
-    @Schema(
-            description = "Erstes Veröffentlichungsdatum",
-            example = "2014-01-01",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-        LocalDate firstPublicationDate,
     @Schema(
             description = "Dokumenttypen",
             example = "['Auf']",

--- a/backend/src/main/resources/jsonld/1_1/v1.jsonld
+++ b/backend/src/main/resources/jsonld/1_1/v1.jsonld
@@ -31,6 +31,7 @@
       "LegislationObject": "schema:LegislationObject",
       "PublicationIssue": "schema:PublicationIssue",
       "MediaObject": "schema:MediaObject",
+      "documentNumber": "schema:identifier",
       "Legislation": {
         "@id": "schema:Legislation",
         "@context": {
@@ -52,7 +53,6 @@
       "Decision": {
         "@id": "ris:Decision",
         "@context": {
-          "documentNumber": "schema:identifier",
           "ecli": "ris:ecli",
           "caseFacts": "ris:caseFacts",
           "decisionGrounds": "ris:decisionGrounds",
@@ -81,6 +81,36 @@
           "gesetzeskraft": "ris:gesetzeskraft",
           "streitjahre": "ris:streitjahre",
           "vorabdokument": "ris:vorabdokument"
+        }
+      },
+      "Literature": {
+        "@id": "ris:Literature",
+        "@context": {
+          "yearsOfPublication": "ris:yearsOfPublication",
+          "documentTypes": "ris:documentTypes",
+          "dependentReferences": "ris:dependentReferences",
+          "independentReferences": "ris:independentReferences",
+          "normReferences": "ris:normReferences",
+          "headline": "schema:headline",
+          "headlineAdditions": "ris:headlineAdditions",
+          "alternativeHeadline": "schema:alternativeHeadline",
+          "edition": "ris:edition",
+          "internationalIdentifiers": "ris:internationalIdentifiers",
+          "authors": "schema:author",
+          "collaborators": "schema:contributor",
+          "editors": "schema:editor",
+          "founder": "ris:founder",
+          "publishers": "schema:publisher",
+          "publisherOrganizations": "ris:publisherOrganizations",
+          "publishingHouses": "ris:publishingHouses",
+          "languages": "ris:languages",
+          "originators": "schema:creator",
+          "conferenceNotes": "ris:conferenceNotes",
+          "shortReport": "schema:abstract",
+          "outline": "ris:outline",
+          "universityNotes": "ris:universityNotes",
+          "volumes": "ris:volumes",
+          "literatureType": "ris:literatureType"
         }
       },
       "SearchResult": {

--- a/backend/src/test/java/de/bund/digitalservice/ris/TestJsonUtils.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/TestJsonUtils.java
@@ -53,7 +53,7 @@ public class TestJsonUtils {
   private static String getDate(AbstractDocumentSchema entity) {
     return switch (entity) {
       case CaseLawSearchSchema c -> c.decisionDate().toString();
-      case LiteratureSearchSchema l -> l.firstPublicationDate().toString();
+      case LiteratureSearchSchema l -> l.yearsOfPublication().getFirst();
       case LegislationExpressionSearchSchema n ->
           Objects.requireNonNull(n.temporalCoverage().substring(0, 10));
       case AdministrativeDirectiveSearchSchema n ->

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/config/ContainersIntegrationBase.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/config/ContainersIntegrationBase.java
@@ -177,7 +177,7 @@ public class ContainersIntegrationBase {
 
     List<String> result = new ArrayList<>();
     result.addAll(allCaseLaw.stream().map(e -> e.decisionDate().toString()).toList());
-    result.addAll(allLiterature.stream().map(e -> e.firstPublicationDate().toString()).toList());
+    result.addAll(allLiterature.stream().map(e -> e.yearsOfPublication().getFirst()).toList());
     result.addAll(allNorms.stream().map(e -> e.getEntryIntoForceDate().toString()).toList());
     result.addAll(
         directives.stream()

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/LiteratureControllerApiTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/LiteratureControllerApiTest.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.search.integration.controller.api;
 
 import static de.bund.digitalservice.ris.ZipTestUtils.readZipStream;
+import static de.bund.digitalservice.ris.utils.JsonldResultMatchers.isJsonLdCompliant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
@@ -57,6 +58,7 @@ class LiteratureControllerApiTest extends ContainersIntegrationBase {
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpectAll(
             status().isOk(),
+            isJsonLdCompliant(),
             jsonPath("$.documentNumber", Matchers.is(documentNumberPersistedInTest)),
             jsonPath("$.yearsOfPublication", Matchers.containsInAnyOrder("1999", "2000", "2001")),
             jsonPath("$.documentTypes", Matchers.containsInAnyOrder("Kommentar", "Aufsatz")),
@@ -171,6 +173,7 @@ class LiteratureControllerApiTest extends ContainersIntegrationBase {
             get(ApiConfig.Paths.LITERATURE + String.format("?searchTerm=%s", searchTerm))
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
+        .andExpect(isJsonLdCompliant())
         .andExpect(jsonPath("$.member", hasSize(1)))
         .andExpect(jsonPath("$.member[0]['item'].documentNumber", Matchers.is("KALU000000001")))
         .andExpect(

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/values/SortingTestArguments.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/values/SortingTestArguments.java
@@ -76,7 +76,7 @@ public class SortingTestArguments {
     List<String> literatureDates =
         new ArrayList<>(
             LiteratureTestData.allDocuments.stream()
-                .map(d -> d.firstPublicationDate().toString())
+                .map(d -> d.yearsOfPublication().getFirst())
                 .sorted()
                 .toList());
     List<String> administrativeDirectivesDates =
@@ -96,7 +96,7 @@ public class SortingTestArguments {
             "date",
             combinedSize,
             jsonPath("$.member[*].item.decisionDate", Matchers.is(caseLawDates)),
-            jsonPath("$.member[*].item.firstPublicationDate", Matchers.is(literatureDates)),
+            jsonPath("$.member[*].item.yearsOfPublication[0]", Matchers.is(literatureDates)),
             jsonPath("$.member[*].item.citationDates", Matchers.is(administrativeDirectivesDates)),
             jsonPath("$.member[*].item.legislationDate", Matchers.is(normsDates))));
 
@@ -113,7 +113,8 @@ public class SortingTestArguments {
             "-date",
             combinedSize,
             jsonPath("$.member[*].item.decisionDate", Matchers.is(invertedCaseLawDates)),
-            jsonPath("$.member[*].item.firstPublicationDate", Matchers.is(invertedLiteratureDates)),
+            jsonPath(
+                "$.member[*].item.yearsOfPublication[0]", Matchers.is(invertedLiteratureDates)),
             jsonPath("$.member[*].item.citationDates", Matchers.is(invertedAdminsitrativeDates)),
             jsonPath("$.member[*].item.legislationDate", Matchers.is(invertedNormsDates))));
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/controller/api/LiteratureControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/controller/api/LiteratureControllerTest.java
@@ -8,26 +8,39 @@ import static org.mockito.Mockito.when;
 
 import de.bund.digitalservice.ris.html.service.xslt.LiteratureXsltTransformer;
 import de.bund.digitalservice.ris.html.service.xslt.SliLiteratureXsltTransformer;
+import de.bund.digitalservice.ris.search.config.ServerConfig;
 import de.bund.digitalservice.ris.search.controller.api.LiteratureController;
 import de.bund.digitalservice.ris.search.exception.ObjectStoreServiceException;
+import de.bund.digitalservice.ris.search.service.ChangelogService;
 import de.bund.digitalservice.ris.search.service.LiteratureService;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class LiteratureControllerTest {
 
-  @InjectMocks LiteratureController controller;
+  LiteratureController controller;
 
   @Mock LiteratureService literatureService;
 
   @Mock LiteratureXsltTransformer uliTransformer;
 
   @Mock SliLiteratureXsltTransformer sliTransformer;
+
+  @Mock ChangelogService changelogService;
+
+  @BeforeEach
+  void setup() {
+    ServerConfig config = new ServerConfig();
+    config.setBackEndUrl("http://backendUrl");
+    controller =
+        new LiteratureController(
+            literatureService, uliTransformer, sliTransformer, changelogService, config);
+  }
 
   @Test
   void itCallsTheUliTransformer() throws ObjectStoreServiceException {

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/LiteratureSchemaMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/LiteratureSchemaMapperTest.java
@@ -47,6 +47,7 @@ class LiteratureSchemaMapperTest {
 
     LiteratureSchema expected =
         LiteratureSchema.builder()
+            .context("jsonLdContext")
             .id("/v1/literature/XXLU000000001")
             .languages(List.of("de"))
             .documentNumber("XXLU000000001")
@@ -79,7 +80,8 @@ class LiteratureSchemaMapperTest {
             .encoding(EncodingSchemaFactory.documentEncodingSchemas("/v1/literature/XXLU000000001"))
             .build();
 
-    LiteratureSchema literatureSchema = LiteratureSchemaMapper.fromDomain(literature);
+    LiteratureSchema literatureSchema =
+        LiteratureSchemaMapper.fromDomain(literature, "jsonLdContext");
     assertThat(literatureSchema).isEqualTo(expected);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/LiteratureSearchSchemaMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/LiteratureSearchSchemaMapperTest.java
@@ -55,12 +55,13 @@ class LiteratureSearchSchemaMapperTest {
         SearchHitSupport.searchPageFor(searchHits, PageRequest.of(0, 1));
 
     CollectionSchema<SearchMemberSchema<LiteratureSearchSchema>> destination =
-        LiteratureSearchSchemaMapper.fromSearchPage(source);
-    LiteratureSearchSchema expectedItem = destination.member().get(0).item();
+        LiteratureSearchSchemaMapper.fromSearchPage(source, "jsonLdContext");
+    LiteratureSearchSchema expectedItem = destination.member().getFirst().item();
     assertEquals(literature.documentNumber(), expectedItem.documentNumber());
     assertEquals(1, destination.totalItems());
     assertEquals(destination.member().size(), destination.totalItems());
     assertTrue(destination.id().startsWith(ApiConfig.Paths.LITERATURE));
+    assertThat(destination.context()).isEqualTo("jsonLdContext");
   }
 
   @Test
@@ -94,15 +95,15 @@ class LiteratureSearchSchemaMapperTest {
 
     var firstPageImpl = createSearchPage(firstPageContents, 0, pageSize, total);
     CollectionSchema<SearchMemberSchema<LiteratureSearchSchema>> firstPage =
-        LiteratureSearchSchemaMapper.fromSearchPage(firstPageImpl);
+        LiteratureSearchSchemaMapper.fromSearchPage(firstPageImpl, "jsonLdContext");
 
     var middlePageImpl = createSearchPage(middlePageContents, 1, pageSize, total);
     CollectionSchema<SearchMemberSchema<LiteratureSearchSchema>> middlePage =
-        LiteratureSearchSchemaMapper.fromSearchPage(middlePageImpl);
+        LiteratureSearchSchemaMapper.fromSearchPage(middlePageImpl, "jsonLdContext");
 
     var lastPageImpl = createSearchPage(lastPageContents, 2, pageSize, total);
     CollectionSchema<SearchMemberSchema<LiteratureSearchSchema>> lastPage =
-        LiteratureSearchSchemaMapper.fromSearchPage(lastPageImpl);
+        LiteratureSearchSchemaMapper.fromSearchPage(lastPageImpl, "jsonLdContext");
 
     String prefix = ApiConfig.Paths.LITERATURE + "/XXLU-";
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/LiteratureTypeMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/LiteratureTypeMapperTest.java
@@ -16,7 +16,8 @@ class LiteratureTypeMapperTest {
   @CsvSource({"XXLU00001,uli", "XXLS000001,sli"})
   void itDeterminesTheDocumentTypeBasedOnDocumentNumber(String docNumber, String expected) {
     Literature literature = Literature.builder().id(docNumber).documentNumber(docNumber).build();
-    assertThat(LiteratureSchemaMapper.fromDomain(literature).literatureType()).isEqualTo(expected);
+    assertThat(LiteratureSchemaMapper.fromDomain(literature, "jsonLdContext").literatureType())
+        .isEqualTo(expected);
     assertThat(LiteratureSearchSchemaMapper.fromDomain(literature).literatureType())
         .isEqualTo(expected);
   }
@@ -27,7 +28,7 @@ class LiteratureTypeMapperTest {
     assertThrows(
         IllegalStateException.class,
         () -> {
-          LiteratureSchemaMapper.fromDomain(literature);
+          LiteratureSchemaMapper.fromDomain(literature, "jsonLdContext");
         });
   }
 }

--- a/frontend/src/components/search/LiteratureSearchResult.spec.ts
+++ b/frontend/src/components/search/LiteratureSearchResult.spec.ts
@@ -2,7 +2,11 @@ import { mockNuxtImport } from "@nuxt/test-utils/runtime";
 import { render, screen } from "@testing-library/vue";
 import { describe } from "vitest";
 import LiteratureSearchResult from "~/components/search/LiteratureSearchResult.vue";
-import type { Literature, SearchResult, TextMatch } from "~/types/api";
+import type {
+  LiteratureSearchSchema,
+  SearchResult,
+  TextMatch,
+} from "~/types/api";
 import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
 
 const { useRouteMock } = vi.hoisted(() => ({
@@ -13,7 +17,7 @@ const { useRouteMock } = vi.hoisted(() => ({
 
 mockNuxtImport("useRoute", () => useRouteMock);
 
-const searchResult: SearchResult<Literature> = {
+const searchResult: SearchResult<LiteratureSearchSchema> = {
   item: {
     "@id": "",
     "@type": "Literature",
@@ -23,15 +27,10 @@ const searchResult: SearchResult<Literature> = {
     documentTypes: ["Book", "Article"],
     dependentReferences: ["DEP-122", "DEP-121"],
     independentReferences: ["INDEP-124", "INDEP-125"],
-    normReferences: ["GG, Art 6 Abs 2 S 1, 1949-05-23"],
     headline: "Eine Untersuchung der juristischen Methoden im 21. Jahrhundert",
     alternativeHeadline: "Study of Legal Methodologies in the 21st Century",
-    headlineAdditions: "Zusatz zur Hauptüberschrift",
     authors: ["Mustermann, Max", "Musterfrau, Erika"],
     collaborators: ["Doe, John", "Doe, Jane"],
-    originators: ["FOO"],
-    conferenceNotes: ["Internationaler Kongress 2025, Berlin, GER"],
-    languages: ["deu", "eng"],
     shortReport: `Dieses Werk analysiert die Entwicklung der juristischen Methoden seit Beginn des 21. Jahrhunderts mit besonderem Fokus auf europäische Rechtssysteme.
 Es werden die Unterschiede zwischen nationalen Rechtstraditionen dargestellt und ihre Auswirkungen auf internationale Verträge erläutert.
 Darüber hinaus untersucht die Studie die Rolle von Präzedenzfällen in modernen Gerichtsbarkeiten und diskutiert aktuelle Trends in der Gesetzesauslegung.
@@ -39,16 +38,7 @@ Abschließend gibt das Werk Empfehlungen für die praktische Anwendung juristisc
     outline:
       "1. Einführung\n2. Historischer Überblick\n3. Aktuelle Entwicklungen\n4. Schlussfolgerungen",
     encoding: [],
-    universityNotes: [],
     literatureType: "uli",
-    editors: [],
-    founder: [],
-    publishers: [],
-    publisherOrganizations: [],
-    publishingHouses: [],
-    edition: undefined,
-    volumes: [],
-    internationalIdentifiers: [],
   },
   textMatches: [],
 };
@@ -57,10 +47,10 @@ function renderComponent({
   item = searchResult.item,
   textMatches = [],
   headingLevel,
-}: Partial<SearchResult<Literature>> & {
+}: Partial<SearchResult<LiteratureSearchSchema>> & {
   headingLevel?: SearchResultHeadingLevel;
 } = {}) {
-  const result: SearchResult<Literature> = {
+  const result: SearchResult<LiteratureSearchSchema> = {
     item,
     textMatches,
   };

--- a/frontend/src/components/search/LiteratureSearchResult.vue
+++ b/frontend/src/components/search/LiteratureSearchResult.vue
@@ -3,7 +3,7 @@ import type {
   SearchResultHeaderItem,
   TextHeaderItem,
 } from "~/components/search/SearchResultHeader.vue";
-import type { Literature, SearchResult } from "~/types/api";
+import type { LiteratureSearchSchema, SearchResult } from "~/types/api";
 import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
 import {
   getMatch,
@@ -16,7 +16,7 @@ const {
   order,
   headingLevel = "2",
 } = defineProps<{
-  searchResult: SearchResult<Literature>;
+  searchResult: SearchResult<LiteratureSearchSchema>;
   order: number;
 
   /** Heading level of the result title. */

--- a/frontend/src/components/search/SearchResult.vue
+++ b/frontend/src/components/search/SearchResult.vue
@@ -4,7 +4,7 @@ import type {
   AnyDocument,
   CaseLawSearchSchema,
   LegislationExpression,
-  Literature,
+  LiteratureSearchSchema,
   SearchResult,
 } from "~/types/api";
 import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
@@ -33,7 +33,7 @@ const { headingLevel = "2" } = defineProps<{
 
   <SearchLiteratureSearchResult
     v-else-if="isLiterature(searchResult.item)"
-    :search-result="searchResult as SearchResult<Literature>"
+    :search-result="searchResult as SearchResult<LiteratureSearchSchema>"
     :order="order"
     :heading-level="headingLevel"
   />

--- a/frontend/src/public/openapi.json
+++ b/frontend/src/public/openapi.json
@@ -2849,12 +2849,6 @@
                 "type" : "string"
               }
             },
-            "firstPublicationDate" : {
-              "type" : "string",
-              "format" : "date",
-              "description" : "Erstes Veröffentlichungsdatum",
-              "example" : "2014-01-01"
-            },
             "documentTypes" : {
               "type" : "array",
               "description" : "Dokumenttypen",
@@ -2924,7 +2918,7 @@
             }
           }
         } ],
-        "required" : [ "@id", "authors", "collaborators", "dependentReferences", "documentNumber", "documentTypes", "encoding", "firstPublicationDate", "inLanguage", "independentReferences", "literatureType", "yearsOfPublication" ]
+        "required" : [ "@id", "authors", "collaborators", "dependentReferences", "documentNumber", "documentTypes", "encoding", "inLanguage", "independentReferences", "literatureType", "yearsOfPublication" ]
       },
       "PartialCollectionViewSchema" : {
         "type" : "object",
@@ -2991,6 +2985,9 @@
           "@type" : {
             "type" : "string",
             "example" : "Literature"
+          },
+          "@context" : {
+            "type" : "string"
           },
           "@id" : {
             "type" : "string",
@@ -3177,7 +3174,7 @@
             }
           }
         },
-        "required" : [ "@id", "authors", "collaborators", "conferenceNotes", "dependentReferences", "documentNumber", "documentTypes", "editors", "encoding", "founder", "inLanguage", "independentReferences", "internationalIdentifiers", "languages", "literatureType", "normReferences", "originators", "publisherOrganizations", "publishers", "publishingHouses", "universityNotes", "volumes", "yearsOfPublication" ]
+        "required" : [ "@context", "@id", "authors", "collaborators", "conferenceNotes", "dependentReferences", "documentNumber", "documentTypes", "editors", "encoding", "founder", "inLanguage", "independentReferences", "internationalIdentifiers", "languages", "literatureType", "normReferences", "originators", "publisherOrganizations", "publishers", "publishingHouses", "universityNotes", "volumes", "yearsOfPublication" ]
       },
       "StreamingResponseBody" : { },
       "ChangelogChangedDocument" : {

--- a/frontend/src/types/api-generated.d.ts
+++ b/frontend/src/types/api-generated.d.ts
@@ -1040,12 +1040,6 @@ export interface components {
              */
             yearsOfPublication: string[];
             /**
-             * Format: date
-             * @description Erstes Veröffentlichungsdatum
-             * @example 2014-01-01
-             */
-            firstPublicationDate: string;
-            /**
              * @description Dokumenttypen
              * @example ['Auf']
              */
@@ -1115,6 +1109,7 @@ export interface components {
         LiteratureSchema: {
             /** @example Literature */
             "@type"?: string;
+            "@context": string;
             /** @example KALU000000000 */
             "@id": string;
             /** @example de */

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -45,6 +45,8 @@ export type Article = components["schemas"]["LegislationExpressionPartSchema"];
 
 // Literature
 export type Literature = components["schemas"]["LiteratureSchema"];
+export type LiteratureSearchSchema =
+  components["schemas"]["LiteratureSearchSchema"];
 
 // Administrative directives
 export type AdministrativeDirective =

--- a/frontend/src/utils/anyDocument.spec.ts
+++ b/frontend/src/utils/anyDocument.spec.ts
@@ -111,6 +111,7 @@ describe("anyDocument", () => {
   describe("isLiterature", () => {
     it("returns true if the document is a literature document", () => {
       const doc: Literature = {
+        "@context": "http://localhost:8080/v1/context.jsonld",
         "@id": "4711",
         "@type": "Literature",
         inLanguage: "",
@@ -278,6 +279,7 @@ describe("anyDocument", () => {
 
     it("identifies a literature document", () => {
       const doc: Literature = {
+        "@context": "http://backend/v1/context.jsonld",
         "@id": "",
         "@type": "Literature",
         inLanguage: "",
@@ -315,6 +317,7 @@ describe("anyDocument", () => {
 
     it("throws if the identifier is falsy", () => {
       const doc: Literature = {
+        "@context": "http://localhost:8080/v1/context.jsonld",
         "@id": "",
         "@type": "Literature",
         inLanguage: "",


### PR DESCRIPTION
* create Literature context definitions in jsonld file
* remove obsolete firstPublicationDate from api. It is still used for ordering in opensearch but no longer exposed in the api
* use LiteratureSearchSchema in frontend search results