### PR TITLE
RISDEV-12559 add administrative context

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/AdministrativeDirectiveController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/AdministrativeDirectiveController.java
@@ -3,6 +3,7 @@ package de.bund.digitalservice.ris.search.controller.api;
 import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 
 import de.bund.digitalservice.ris.search.config.ApiConfig;
+import de.bund.digitalservice.ris.search.config.ServerConfig;
 import de.bund.digitalservice.ris.search.exception.CustomValidationException;
 import de.bund.digitalservice.ris.search.mapper.AdministrativeDirectiveSchemaMapper;
 import de.bund.digitalservice.ris.search.mapper.AdministrativeDirectiveSearchSchemaMapper;
@@ -60,6 +61,7 @@ public class AdministrativeDirectiveController {
   private final AdministrativeDirectiveService service;
   private final AdministrativeDirectiveXsltTransformerService transformerService;
   private final ChangelogService<AdministrativeDirectiveBucket> changelogService;
+  private final ServerConfig serverConfig;
 
   /**
    * Constructor for the AdministrativeDirectiveController, used to initialize the controller with
@@ -68,15 +70,18 @@ public class AdministrativeDirectiveController {
    * @param service the service responsible for handling administrative directive operations
    * @param transformerService the service responsible for transforming administrative directives
    *     using XSLT
+   * @param serverConfig serverconfig of the application
    */
   @Autowired
   public AdministrativeDirectiveController(
       AdministrativeDirectiveService service,
       AdministrativeDirectiveXsltTransformerService transformerService,
-      ChangelogService<AdministrativeDirectiveBucket> changelogService) {
+      ChangelogService<AdministrativeDirectiveBucket> changelogService,
+      ServerConfig serverConfig) {
     this.service = service;
     this.transformerService = transformerService;
     this.changelogService = changelogService;
+    this.serverConfig = serverConfig;
   }
 
   /**
@@ -106,7 +111,9 @@ public class AdministrativeDirectiveController {
     AdministrativeDirective unit = result.getFirst();
     return ResponseEntity.ok()
         .contentType(MediaType.APPLICATION_JSON)
-        .body(AdministrativeDirectiveSchemaMapper.fromDomain(unit));
+        .body(
+            AdministrativeDirectiveSchemaMapper.fromDomain(
+                unit, serverConfig.getBackEndUrl() + ApiConfig.Paths.JSONLD_CONTEXT));
   }
 
   /**
@@ -146,7 +153,9 @@ public class AdministrativeDirectiveController {
           service.simpleSearch(universalSearchParams, searchParams, sortedPageRequest);
       return ResponseEntity.ok()
           .contentType(MediaType.APPLICATION_JSON)
-          .body(AdministrativeDirectiveSearchSchemaMapper.fromSearchPage(page));
+          .body(
+              AdministrativeDirectiveSearchSchemaMapper.fromSearchPage(
+                  page, serverConfig.getBackEndUrl() + ApiConfig.Paths.JSONLD_CONTEXT));
     } catch (UncategorizedElasticsearchException e) {
       LuceneQueryTools.checkForInvalidQuery(e);
       throw e;

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/AdvancedSearchController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/controller/api/AdvancedSearchController.java
@@ -267,7 +267,7 @@ public class AdvancedSearchController {
           advancedSearchService.searchAdministrativeDirective(query, sortedPageable);
       return ResponseEntity.ok()
           .contentType(MediaType.APPLICATION_JSON)
-          .body(AdministrativeDirectiveSearchSchemaMapper.fromSearchPage(page));
+          .body(AdministrativeDirectiveSearchSchemaMapper.fromSearchPage(page, jsonldContextPath));
     } catch (UncategorizedElasticsearchException e) {
       LuceneQueryTools.checkForInvalidQuery(e);
       throw e;

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/AdministrativeDirectiveSchemaMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/AdministrativeDirectiveSchemaMapper.java
@@ -24,15 +24,18 @@ public class AdministrativeDirectiveSchemaMapper {
    *
    * @param entity the {@code AdministrativeDirective} entity containing metadata about an
    *     administrative directive
+   * @param remoteJsonContext remoteJsonContext url to retrieve jsonld context
    * @return an {@code AdministrativeDirectiveSchema} object representing the input entity in a
    *     JSON-LD compatible format
    */
-  public static AdministrativeDirectiveSchema fromDomain(AdministrativeDirective entity) {
+  public static AdministrativeDirectiveSchema fromDomain(
+      AdministrativeDirective entity, String remoteJsonContext) {
     var entityURI = ApiConfig.Paths.ADMINISTRATIVE_DIRECTIVE + "/" + entity.documentNumber();
     var encodings = EncodingSchemaFactory.documentEncodingSchemas(entityURI);
 
     return AdministrativeDirectiveSchema.builder()
         .id(entityURI)
+        .context(remoteJsonContext)
         .documentNumber(entity.documentNumber())
         .documentType(entity.documentType())
         .headline(entity.headline())

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/AdministrativeDirectiveSearchSchemaMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/mapper/AdministrativeDirectiveSearchSchemaMapper.java
@@ -116,12 +116,13 @@ public class AdministrativeDirectiveSearchSchemaMapper {
    * @param <T> The type parameter of the paginated search result.
    * @param page The paginated search result containing the data to be transformed. This includes
    *     the page information and the content.
+   * @param remoteJsonContext remoteJsonContext url to retrieve jsonld context
    * @return A collection schema representing the administrative directive search results, including
    *     metadata such as total items, a unique identifier, and a list of member schemas.
    */
   public static <T>
       CollectionSchema<SearchMemberSchema<AdministrativeDirectiveSearchSchema>> fromSearchPage(
-          final SearchPage<T> page) {
+          final SearchPage<T> page, String remoteJsonContext) {
     String collectionBasePath = ApiConfig.Paths.ADMINISTRATIVE_DIRECTIVE;
     PartialCollectionViewSchema view =
         PartialCollectionViewMapper.fromPage(collectionBasePath, page);
@@ -132,6 +133,7 @@ public class AdministrativeDirectiveSearchSchemaMapper {
 
     return CollectionSchema.<SearchMemberSchema<AdministrativeDirectiveSearchSchema>>builder()
         .id(id)
+        .context(remoteJsonContext)
         .totalItems(page.getTotalElements())
         .member(
             page.stream().map(AdministrativeDirectiveSearchSchemaMapper::fromSearchHit).toList())

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/schema/AdministrativeDirectiveSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/schema/AdministrativeDirectiveSchema.java
@@ -20,6 +20,7 @@ import org.jspecify.annotations.Nullable;
  */
 @Builder
 public record AdministrativeDirectiveSchema(
+    @JsonProperty("@context") @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String context,
     @Schema(example = "KALU000000000", requiredMode = Schema.RequiredMode.REQUIRED)
         @JsonProperty("@id")
         String id,

--- a/backend/src/main/resources/jsonld/1_1/v1.jsonld
+++ b/backend/src/main/resources/jsonld/1_1/v1.jsonld
@@ -113,6 +113,23 @@
           "literatureType": "ris:literatureType"
         }
       },
+      "AdministrativeDirective": {
+        "@id": "ris:AdministrativeDirective",
+        "@context": {
+          "headline": "schema:headline",
+          "shortReport": "schema:abstract",
+          "documentType": "ris:documentType",
+          "documentTypeDetail": "ris:documentTypeDetail",
+          "referenceNumbers": "ris:fileNumber",
+          "entryIntoForceDate": "schema:validFrom",
+          "expiryDate": "schema:validThrough",
+          "legislationAuthority": "schema:legislationPassedBy",
+          "references": "ris:reference",
+          "citationDates": "ris:citationDate",
+          "normReferences": "ris:normReference",
+          "outline": "ris:outline"
+        }
+      },
       "SearchResult": {
         "@id": "ris:SearchResult",
         "@context": {

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/AdministrativeDirectiveControllerApiTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/integration/controller/api/AdministrativeDirectiveControllerApiTest.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.search.integration.controller.api;
 
 import static de.bund.digitalservice.ris.ZipTestUtils.readZipStream;
+import static de.bund.digitalservice.ris.utils.JsonldResultMatchers.isJsonLdCompliant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.startsWithIgnoringCase;
@@ -98,6 +99,7 @@ class AdministrativeDirectiveControllerApiTest extends ContainersIntegrationBase
             get(ApiConfig.Paths.ADMINISTRATIVE_DIRECTIVE + "/" + documentNumber)
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
+        .andExpect(isJsonLdCompliant())
         .andExpect(jsonPath("$.documentNumber", Matchers.is(documentNumber)));
   }
 
@@ -111,6 +113,7 @@ class AdministrativeDirectiveControllerApiTest extends ContainersIntegrationBase
             get(ApiConfig.Paths.ADMINISTRATIVE_DIRECTIVE + "?documentNumber=" + documentNumber)
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
+        .andExpect(isJsonLdCompliant())
         .andExpect(jsonPath("$.member", hasSize(1)))
         .andExpect(jsonPath("$.member[0].item.documentNumber", Matchers.is(documentNumber)));
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/AdministrativeDirectiveSchemaMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/unit/mapper/AdministrativeDirectiveSchemaMapperTest.java
@@ -35,6 +35,7 @@ class AdministrativeDirectiveSchemaMapperTest {
 
     AdministrativeDirectiveSchema expected =
         AdministrativeDirectiveSchema.builder()
+            .context("jsonLdContext")
             .id("/v1/administrative-directive/KN0000")
             .documentNumber("KN0000")
             .documentType("VV")
@@ -53,6 +54,7 @@ class AdministrativeDirectiveSchemaMapperTest {
                     "/v1/administrative-directive/KN0000"))
             .build();
 
-    assertThat(expected).isEqualTo(AdministrativeDirectiveSchemaMapper.fromDomain(entity));
+    assertThat(expected)
+        .isEqualTo(AdministrativeDirectiveSchemaMapper.fromDomain(entity, "jsonLdContext"));
   }
 }

--- a/frontend/src/components/search/AdministrativeDirectiveSearchResult.spec.ts
+++ b/frontend/src/components/search/AdministrativeDirectiveSearchResult.spec.ts
@@ -2,7 +2,10 @@ import { mockNuxtImport, renderSuspended } from "@nuxt/test-utils/runtime";
 import { screen } from "@testing-library/vue";
 import { describe } from "vitest";
 import AdministrativeDirectiveSearchResult from "~/components/search/AdministrativeDirectiveSearchResult.vue";
-import type { AdministrativeDirective, SearchResult } from "~/types/api";
+import type {
+  AdministrativeDirectiveSearchSchema,
+  SearchResult,
+} from "~/types/api";
 import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
 
 const { useRouteMock } = vi.hoisted(() => ({
@@ -13,7 +16,7 @@ const { useRouteMock } = vi.hoisted(() => ({
 
 mockNuxtImport("useRoute", () => useRouteMock);
 
-const searchResult: SearchResult<AdministrativeDirective> = {
+const searchResult: SearchResult<AdministrativeDirectiveSearchSchema> = {
   item: {
     "@type": "AdministrativeDirective",
     "@id": "/v1/administrative-directive/KSNR000000001",
@@ -24,7 +27,7 @@ const searchResult: SearchResult<AdministrativeDirective> = {
     documentType: "VR",
     referenceNumbers: ["Foo - 123", "Bar - 123"],
     entryIntoForceDate: "2025-07-01",
-  } as AdministrativeDirective,
+  } as AdministrativeDirectiveSearchSchema,
   textMatches: [],
 };
 
@@ -32,10 +35,10 @@ async function renderComponent({
   item = searchResult.item,
   textMatches = searchResult.textMatches,
   headingLevel,
-}: Partial<SearchResult<AdministrativeDirective>> & {
+}: Partial<SearchResult<AdministrativeDirectiveSearchSchema>> & {
   headingLevel?: SearchResultHeadingLevel;
 } = {}) {
-  const result: SearchResult<AdministrativeDirective> = {
+  const result: SearchResult<AdministrativeDirectiveSearchSchema> = {
     item,
     textMatches,
   };

--- a/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
+++ b/frontend/src/components/search/AdministrativeDirectiveSearchResult.vue
@@ -3,7 +3,10 @@ import type {
   SearchResultHeaderItem,
   TextHeaderItem,
 } from "~/components/search/SearchResultHeader.vue";
-import type { AdministrativeDirective, SearchResult } from "~/types/api";
+import type {
+  AdministrativeDirectiveSearchSchema,
+  SearchResult,
+} from "~/types/api";
 import type { SearchResultHeadingLevel } from "~/utils/search/searchResults";
 import {
   getMatch,
@@ -16,7 +19,7 @@ const {
   order,
   headingLevel = "2",
 } = defineProps<{
-  searchResult: SearchResult<AdministrativeDirective>;
+  searchResult: SearchResult<AdministrativeDirectiveSearchSchema>;
   order: number;
 
   /** Heading level of the result title. */

--- a/frontend/src/components/search/SearchResult.vue
+++ b/frontend/src/components/search/SearchResult.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type {
-  AdministrativeDirective,
+  AdministrativeDirectiveSearchSchema,
   AnyDocument,
   CaseLawSearchSchema,
   LegislationExpression,
@@ -40,7 +40,9 @@ const { headingLevel = "2" } = defineProps<{
 
   <SearchAdministrativeDirectiveSearchResult
     v-else-if="isAdministrativeDirective(searchResult.item)"
-    :search-result="searchResult as SearchResult<AdministrativeDirective>"
+    :search-result="
+      searchResult as SearchResult<AdministrativeDirectiveSearchSchema>
+    "
     :order="order"
     :heading-level="headingLevel"
   />

--- a/frontend/src/public/openapi.json
+++ b/frontend/src/public/openapi.json
@@ -4145,6 +4145,9 @@
             "type" : "string",
             "example" : "AdministrativeDirective"
           },
+          "@context" : {
+            "type" : "string"
+          },
           "@id" : {
             "type" : "string",
             "example" : "KALU000000000"
@@ -4233,7 +4236,7 @@
             }
           }
         },
-        "required" : [ "@id", "citationDates", "documentNumber", "documentType", "encoding", "normReferences", "outline", "referenceNumbers", "references" ]
+        "required" : [ "@context", "@id", "citationDates", "documentNumber", "documentType", "encoding", "normReferences", "outline", "referenceNumbers", "references" ]
       }
     }
   }

--- a/frontend/src/types/api-generated.d.ts
+++ b/frontend/src/types/api-generated.d.ts
@@ -1699,6 +1699,7 @@ export interface components {
         AdministrativeDirectiveSchema: {
             /** @example AdministrativeDirective */
             "@type"?: string;
+            "@context": string;
             /** @example KALU000000000 */
             "@id": string;
             /**

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -51,6 +51,8 @@ export type LiteratureSearchSchema =
 // Administrative directives
 export type AdministrativeDirective =
   components["schemas"]["AdministrativeDirectiveSchema"];
+export type AdministrativeDirectiveSearchSchema =
+  components["schemas"]["AdministrativeDirectiveSearchSchema"];
 
 export type DocumentEncodingSchema =
   components["schemas"]["DocumentEncodingSchema"];


### PR DESCRIPTION
Add AdministrativeDirective context in jsonld. 
Use AdministrativeDirectiveSearchSchema in search Pages.