### PR TITLE
RISDEV-12577 Improve tests

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/ArticlesRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/repository/opensearch/ArticlesRepository.java
@@ -21,6 +21,13 @@ public interface ArticlesRepository extends ElasticsearchRepository<Article, Str
    */
   void deleteByWorkEliAndIndexedAtBefore(String workEli, String indexedAt);
 
+  /**
+   * Delete articles that were indexed before the provided timestamp.
+   *
+   * @param indexedAt ISO-8601 timestamp string cutoff
+   */
+  void deleteByIndexedAtBefore(String indexedAt);
+
   /** Delete all articles that do not have an indexedAt value set. */
   void deleteByIndexedAtIsNull();
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/service/IndexNormsService.java
@@ -308,6 +308,7 @@ public class IndexNormsService implements IndexService {
   private void clearOldNorms(String timestamp) {
     normsRepository.deleteByIndexedAtBefore(timestamp);
     normsRepository.deleteByIndexedAtIsNull();
+    articlesRepository.deleteByIndexedAtBefore(timestamp);
     articlesRepository.deleteByIndexedAtIsNull();
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/data/CaseLawApiSearchDataTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/data/CaseLawApiSearchDataTest.java
@@ -11,14 +11,12 @@ import java.util.Objects;
 import java.util.Optional;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @Tag("data")
-@Disabled
 class CaseLawApiSearchDataTest extends BaseApiSearchDataTest {
 
   private final int maxEntries = 500;

--- a/backend/src/test/java/de/bund/digitalservice/ris/search/data/NormsApiSearchDataTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/search/data/NormsApiSearchDataTest.java
@@ -20,14 +20,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @Tag("data")
-@Disabled
 class NormsApiSearchDataTest extends BaseApiSearchDataTest {
 
   private static final Logger logger = LogManager.getLogger(NormsApiSearchDataTest.class);
@@ -123,13 +121,10 @@ class NormsApiSearchDataTest extends BaseApiSearchDataTest {
             member -> {
               String abbreviation =
                   (String) ((Map<String, Object>) member.get("item")).get("abbreviation");
-              String detailUrl =
-                  ((Map<String, Object>)
-                          ((Map<String, Object>) member.get("item")).get("workExample"))
-                      .get("@id")
-                      .toString();
+              String detailUrl = ((Map<String, Object>) member.get("item")).get("@id").toString();
+
               Response detailResponse = NormsApiSearchDataTest.this.fetchPageResponse(detailUrl);
-              var articleNames = (List<String>) detailResponse.path("workExample.hasPart.name");
+              var articleNames = (List<String>) detailResponse.path("hasPart.name");
               Pattern pattern = Pattern.compile("§ \\d+");
               return articleNames.stream()
                   .map(
@@ -188,7 +183,7 @@ class NormsApiSearchDataTest extends BaseApiSearchDataTest {
           "No text matches in result {}, looking for article number {}", match, articleNumber);
       return false;
     }
-    String name = textMatches.getFirst().get("name");
+    String name = textMatches.getFirst().get("name").replace("<mark>", "").replace("</mark>", "");
     final boolean nameHasExpectedPrefix = name.startsWith(articleNumber);
     if (!nameHasExpectedPrefix) {
       logger.warn("Unexpected article name {}, expected {}", name, articleNumber);


### PR DESCRIPTION
*Update the data tests to use the port the test expects (WebEnvironment.DEFINED_PORT)
*Update the data tests to the new norms schema (without workExample)
*Adjust test logic to ignore the `<mark>` tags that were not previously present
*Fix a bug where not all of the old articles get deleted on a full reindex.