### PR TITLE
RISDEV-11697 lucene query unexpected error

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/search/utils/LuceneQueryTools.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/search/utils/LuceneQueryTools.java
@@ -40,17 +40,17 @@ public class LuceneQueryTools {
     try {
       QueryParser queryParser = new QueryParser("", analyzer);
       queryParser.parse(query);
-    } catch (ParseException e) {
-      throw buildLuceneErrorMessage(e);
+    } catch (ParseException | IllegalArgumentException e) {
+      throw buildLuceneErrorMessage(e.getMessage());
     }
   }
 
-  private static CustomValidationException buildLuceneErrorMessage(ParseException e) {
+  private static CustomValidationException buildLuceneErrorMessage(String errorMessage) {
     return new CustomValidationException(
         CustomError.builder()
             .code("invalid_lucene_query")
             .parameter("query")
-            .message(e.getMessage())
+            .message(errorMessage)
             .build());
   }
 
@@ -75,7 +75,7 @@ public class LuceneQueryTools {
           .map(t -> t.field().isBlank() ? t.text() : t.field() + ":" + t.text())
           .collect(Collectors.joining(" OR "));
     } catch (ParseException e) {
-      throw buildLuceneErrorMessage(e);
+      throw buildLuceneErrorMessage(e.getMessage());
     }
   }
 


### PR DESCRIPTION
* Added IllegalArgumentException to the list of client errors to cause the API to return a client error and log at the WARN level (instead of ERROR level)